### PR TITLE
Feat/multi client track b

### DIFF
--- a/.claude/agent-memory/lp-parser-llm/MEMORY.md
+++ b/.claude/agent-memory/lp-parser-llm/MEMORY.md
@@ -1,3 +1,4 @@
 # Memória — lp-parser-llm (Lia)
 
 - [PoC-3 R4 estado](poc3-r4-estado.md) — FALTA=0/TEXTO=0 atingido 2026-07-12; SOBRA=8 + 7 XSD = Etapa B (máscara do mapeador); gotchas de diagnóstico.
+- [RAG few-shot B4](rag-fewshot-b4.md) — corpus SEM pares DSL→XSLT (exportContext criptografado); 191 XSLs reais = estilo; gotcha: interpretador parcial em regra difícil.

--- a/.claude/agent-memory/lp-parser-llm/rag-fewshot-b4.md
+++ b/.claude/agent-memory/lp-parser-llm/rag-fewshot-b4.md
@@ -1,0 +1,20 @@
+---
+name: rag-fewshot-b4
+description: "B4/P1 RAG few-shot: o que o corpus layoutparser realmente contém, decisões do FewShotIndex e gotchas (interpretador parcial em regras difíceis, Ollama instável)"
+metadata:
+  type: project
+---
+
+B4 (P1) entregue em 2026-07-15: `ai/XslSynth/Synthesis/FewShotIndex.cs` + few-shot opt-in no `DslRuleTranslator` + flags `--rag <pasta>` / `--rag-stats` no Program.cs do XslSynth.
+
+**Fatos do corpus** (`…/LayoutParserApi/.claude/tmp/servidor/layoutparser/`, somente-leitura):
+- **NÃO há pares DSL→XSLT em claro.** As regras DSL do Sysmiddle vivem no `globalfolder/exportContext.data` (119 MB, criptografado) — inutilizável sem decrypt.
+- O utilizável: `Examples/xsl/` = **191 XSLs reais de produção** por tipo×versão (NFe 2.06b/2.06c/3.10/4.00, CTe, MDFe, NFSe) — 116 com `xsl:otherwise` (else), 69 com `test` composto com `and`. Indexados como few-shot de ESTILO. `Examples/tcl/` espelha (parsers, não transform).
+- DSL real vem do mapeador descriptografado `…/.claude/tmp/export/MAP_MQSERIES_SEND_ENV_TXT_XML_NFE.decrypted.xml` (98 regras; 96 `&&` — escapado como `&amp;&amp;` no XML! — e 141 `else`).
+- "G2KA" só aparece em nomes de XSL NFSe e em logs — o "corpus G2KA" dos docs é, na prática, `Examples/xsl`+`tcl`.
+
+**Gotcha de correção (importante):** o `DslBlockInterpreter.Interpret` em regra DIFÍCIL (else/&&/aninhada) consome só os blocos que reconhece e o `DirectEmit` pega `T.x=…;` de dentro de branches → emissões INCONDICIONAIS erradas com cara de verificadas. No FewShotIndex só emparelho interpretador↔DSL para regras fáceis. **O fluxo RunRealAsync tem o mesmo risco** (interpreter primeiro, LLM nunca vê a regra se houver ≥1 emissão) — follow-up aberto.
+
+**Ollama nesta máquina:** respondeu `/api/tags` (qwen2.5-coder:7b) e minutos depois recusou conexão (nada ouvindo em 11434) — serviço instável/parado por outra sessão. Comparação com/sem few-shot ficou pendente; o código já suporta (`--rag-stats --ollama`).
+
+**How to apply:** para melhorar a tradução das regras difíceis, o caminho é estilo-XSLT real + DSL análoga no prompt (não há gold pairs); rodar a comparação Ollama quando o serviço estiver de pé.

--- a/Program.cs
+++ b/Program.cs
@@ -245,6 +245,8 @@ try
     builder.Services.AddScoped<LayoutLearningService>();
     builder.Services.AddScoped<XmlFormatterService>();
     builder.Services.AddScoped<FileStorageService>();
+    // ✅ Detector de anomalia por z-score sobre MLData/DocumentPatterns (P2 do roadmap)
+    builder.Services.AddScoped<IDocumentAnomalyDetector, DocumentAnomalyDetectorService>();
 
     // Validation Services
     builder.Services.AddScoped<LayoutValidationService>();

--- a/Services/Interfaces/IDocumentAnomalyDetector.cs
+++ b/Services/Interfaces/IDocumentAnomalyDetector.cs
@@ -1,0 +1,18 @@
+using LayoutParserApi.Services.Learning.Models;
+
+namespace LayoutParserApi.Services.Interfaces
+{
+    /// <summary>
+    /// Detector de anomalia de documentos posicionais: pontua um documento novo
+    /// contra a distribuição histórica de features (MLData/DocumentPatterns) do mesmo LayoutGuid.
+    /// </summary>
+    public interface IDocumentAnomalyDetector
+    {
+        /// <summary>
+        /// Calcula o score de anomalia do documento para o layout informado.
+        /// Com menos amostras históricas que o mínimo, retorna resultado explícito
+        /// de dados insuficientes (score null) — nunca inventa score.
+        /// </summary>
+        Task<DocumentAnomalyResult> DetectAsync(string documentContent, string layoutGuid);
+    }
+}

--- a/Services/Learning/DocumentAnomalyDetectorService.cs
+++ b/Services/Learning/DocumentAnomalyDetectorService.cs
@@ -1,0 +1,242 @@
+using LayoutParserApi.Models.Configuration;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Learning.Models;
+using LayoutParserApi.Services.Validation;
+
+using System.Globalization;
+using System.Text.Json;
+
+namespace LayoutParserApi.Services.Learning
+{
+    /// <summary>
+    /// Detector de anomalia por z-score sobre os padrões históricos de
+    /// MLData/DocumentPatterns (P2 do roadmap — meta 1.1: documentos incorretos do cliente).
+    ///
+    /// Funcionamento:
+    /// 1. Carrega os <c>DocumentPattern</c> do LayoutGuid (mesmos arquivos <c>pattern_*.json</c>
+    ///    gravados pelo <c>DocumentMLValidationService</c>).
+    /// 2. Extrai do documento novo as MESMAS features numéricas
+    ///    (via <see cref="DocumentFeatureExtractor"/> — helper compartilhado, sem duplicação).
+    /// 3. Para cada feature, calcula z = |x - média| / desvio contra a distribuição histórica.
+    /// 4. Normaliza cada z em [0..1] por saturação na regra 3-sigma (z >= 3 → 1.0) e combina:
+    ///    <c>score = 0.5 * max + 0.5 * média</c> das features pontuadas — o máximo captura
+    ///    anomalia concentrada numa feature; a média evita que uma única flutuação domine.
+    ///
+    /// Guarda de amostra mínima: com menos de <see cref="MinimumSamples"/> padrões históricos
+    /// do layout, retorna resultado explícito de dados insuficientes (score null) — nunca
+    /// inventa score. Qualquer falha interna degrada para o mesmo resultado (resiliência).
+    /// </summary>
+    public class DocumentAnomalyDetectorService : IDocumentAnomalyDetector
+    {
+        /// <summary>Mínimo de padrões históricos do layout para pontuar com honestidade.</summary>
+        private const int MinimumSamples = 5;
+
+        /// <summary>|z| a partir do qual a feature entra na lista de suspeitas.</summary>
+        private const double SuspiciousZThreshold = 2.0;
+
+        /// <summary>Saturação da normalização (regra 3-sigma): |z| >= 3 → score 1.0 na feature.</summary>
+        private const double ZSaturation = 3.0;
+
+        /// <summary>Score combinado a partir do qual o documento é marcado como anômalo.</summary>
+        private const double AnomalyScoreThreshold = 0.5;
+
+        /// <summary>Nº de amostras em que a confiança satura em 1.0.</summary>
+        private const int ConfidenceSaturationSamples = 20;
+
+        private readonly ILogger<DocumentAnomalyDetectorService> _logger;
+        private readonly string _learningDataPath;
+
+        public DocumentAnomalyDetectorService(
+            ILogger<DocumentAnomalyDetectorService> logger,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+            // Mesmo path (e mesmo default) usado pelo DocumentMLValidationService ao gravar os padrões
+            _learningDataPath = configuration["ML:LearningDataPath"]
+                ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "DocumentPatterns");
+        }
+
+        /// <inheritdoc />
+        public async Task<DocumentAnomalyResult> DetectAsync(string documentContent, string layoutGuid)
+        {
+            var result = new DocumentAnomalyResult { LayoutGuid = layoutGuid ?? "" };
+
+            try
+            {
+                var patterns = await LoadPatternsForLayoutAsync(layoutGuid);
+                result.HistoricalSampleCount = patterns.Count;
+
+                // ✅ Guarda de amostra mínima: sem histórico suficiente, NÃO inventa score
+                if (patterns.Count < MinimumSamples)
+                {
+                    result.HasSufficientData = false;
+                    result.AnomalyScore = null;
+                    result.IsAnomalous = false;
+                    result.Confidence = 0.0;
+                    result.Explanation =
+                        $"Dados insuficientes para o layout '{result.LayoutGuid}': {patterns.Count} padrão(ões) " +
+                        $"histórico(s) encontrado(s), mínimo exigido = {MinimumSamples}. Nenhum score foi calculado.";
+                    return result;
+                }
+
+                // ✅ Tamanho de linha via LineLengthResolver (nunca reintroduzir o literal 600)
+                var expectedLineLength = LineLengthResolver.Resolve(0, layoutGuid) ?? LineLengthResolver.LegacyDefaultLineLength;
+
+                // Mesmas features do histórico (helper compartilhado com o DocumentMLValidationService)
+                var currentFeatures = DocumentFeatureExtractor.Extract(documentContent ?? "", expectedLineLength);
+
+                var featureScores = new List<double>();
+
+                foreach (var (featureName, rawValue) in currentFeatures)
+                {
+                    if (!DocumentFeatureExtractor.TryToDouble(rawValue, out var value))
+                        continue;
+
+                    // Distribuição histórica da feature para este LayoutGuid
+                    var historicalValues = new List<double>();
+                    foreach (var pattern in patterns)
+                    {
+                        if (pattern.Features != null
+                            && pattern.Features.TryGetValue(featureName, out var historical)
+                            && DocumentFeatureExtractor.TryToDouble(historical, out var h))
+                        {
+                            historicalValues.Add(h);
+                        }
+                    }
+
+                    // Feature precisa da mesma guarda mínima para entrar no score
+                    if (historicalValues.Count < MinimumSamples)
+                        continue;
+
+                    var mean = historicalValues.Average();
+                    var stdDev = Math.Sqrt(historicalValues.Sum(v => (v - mean) * (v - mean)) / historicalValues.Count);
+
+                    double zScore;
+                    if (stdDev < 1e-9)
+                    {
+                        // Histórico constante: qualquer desvio real é fortemente anômalo
+                        var tolerance = Math.Max(1e-9, Math.Abs(mean) * 1e-6);
+                        zScore = Math.Abs(value - mean) <= tolerance ? 0.0 : ZSaturation;
+                    }
+                    else
+                    {
+                        zScore = Math.Abs(value - mean) / stdDev;
+                    }
+
+                    // Normalização por saturação: [0..1], com z >= 3 (3-sigma) → 1.0
+                    featureScores.Add(Math.Min(zScore / ZSaturation, 1.0));
+
+                    if (zScore >= SuspiciousZThreshold)
+                    {
+                        result.SuspiciousFeatures.Add(new SuspiciousFeature
+                        {
+                            FeatureName = featureName,
+                            Value = value,
+                            ZScore = Math.Round(zScore, 2),
+                            ExpectedMin = Math.Round(mean - 2 * stdDev, 2),
+                            ExpectedMax = Math.Round(mean + 2 * stdDev, 2)
+                        });
+                    }
+                }
+
+                if (featureScores.Count == 0)
+                {
+                    // Padrões existem mas nenhuma feature comparável — honestidade: sem score
+                    result.HasSufficientData = false;
+                    result.AnomalyScore = null;
+                    result.IsAnomalous = false;
+                    result.Confidence = 0.0;
+                    result.Explanation =
+                        "Padrões históricos encontrados, porém sem features numéricas comparáveis " +
+                        "com o documento atual. Nenhum score foi calculado.";
+                    return result;
+                }
+
+                // Score combinado: 0.5 * máximo + 0.5 * média das features pontuadas
+                var score = 0.5 * featureScores.Max() + 0.5 * featureScores.Average();
+                score = Math.Clamp(score, 0.0, 1.0);
+
+                result.HasSufficientData = true;
+                result.AnomalyScore = Math.Round(score, 4);
+                result.IsAnomalous = score >= AnomalyScoreThreshold;
+                result.Confidence = Math.Round(Math.Min(1.0, patterns.Count / (double)ConfidenceSaturationSamples), 4);
+                result.Explanation = BuildExplanation(result);
+
+                _logger.LogInformation(
+                    "Anomalia calculada para layout {LayoutGuid}: score={Score}, suspeitas={SuspiciousCount}, amostras={SampleCount}",
+                    result.LayoutGuid, result.AnomalyScore, result.SuspiciousFeatures.Count, patterns.Count);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                // Resiliência: falha interna NUNCA propaga — degrada para "não avaliado"
+                _logger.LogError(ex, "Erro ao calcular score de anomalia para layout {LayoutGuid}", layoutGuid);
+                result.HasSufficientData = false;
+                result.AnomalyScore = null;
+                result.IsAnomalous = false;
+                result.Confidence = 0.0;
+                result.Explanation = "Falha interna ao calcular o score de anomalia; documento não avaliado.";
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Carrega os padrões históricos (pattern_*.json) do LayoutGuid informado.
+        /// Arquivos corrompidos são ignorados individualmente (Warning), sem derrubar a análise.
+        /// </summary>
+        private async Task<List<DocumentPattern>> LoadPatternsForLayoutAsync(string? layoutGuid)
+        {
+            var patterns = new List<DocumentPattern>();
+
+            if (string.IsNullOrWhiteSpace(layoutGuid) || !Directory.Exists(_learningDataPath))
+                return patterns;
+
+            foreach (var file in Directory.GetFiles(_learningDataPath, "pattern_*.json"))
+            {
+                try
+                {
+                    var json = await File.ReadAllTextAsync(file);
+                    var pattern = JsonSerializer.Deserialize<DocumentPattern>(json);
+
+                    if (pattern != null && string.Equals(pattern.LayoutGuid, layoutGuid, StringComparison.OrdinalIgnoreCase))
+                        patterns.Add(pattern);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Erro ao carregar padrão do arquivo {File} (ignorado)", file);
+                }
+            }
+
+            return patterns;
+        }
+
+        /// <summary>
+        /// Monta a explicação legível (PT-BR) do resultado.
+        /// </summary>
+        private static string BuildExplanation(DocumentAnomalyResult result)
+        {
+            var score = (result.AnomalyScore ?? 0).ToString("0.00", CultureInfo.InvariantCulture);
+
+            if (!result.IsAnomalous)
+            {
+                return $"Documento dentro da faixa histórica do layout (score {score}, " +
+                       $"{result.HistoricalSampleCount} amostras históricas).";
+            }
+
+            var details = result.SuspiciousFeatures
+                .OrderByDescending(f => f.ZScore)
+                .Select(f =>
+                    $"{f.FeatureName}={f.Value.ToString("0.##", CultureInfo.InvariantCulture)} fora da faixa esperada " +
+                    $"[{f.ExpectedMin.ToString("0.##", CultureInfo.InvariantCulture)}; {f.ExpectedMax.ToString("0.##", CultureInfo.InvariantCulture)}] " +
+                    $"(z={f.ZScore.ToString("0.0", CultureInfo.InvariantCulture)})");
+
+            var detailText = result.SuspiciousFeatures.Count > 0
+                ? string.Join("; ", details)
+                : "múltiplas features com desvio moderado em relação ao histórico";
+
+            return $"Documento provavelmente incorreto (score {score}, " +
+                   $"{result.HistoricalSampleCount} amostras históricas): {detailText}.";
+        }
+    }
+}

--- a/Services/Learning/Models/DocumentAnomalyResult.cs
+++ b/Services/Learning/Models/DocumentAnomalyResult.cs
@@ -1,0 +1,51 @@
+namespace LayoutParserApi.Services.Learning.Models
+{
+    /// <summary>
+    /// Resultado da detecção de anomalia de um documento contra o histórico
+    /// de padrões (MLData/DocumentPatterns) do mesmo LayoutGuid.
+    /// </summary>
+    public class DocumentAnomalyResult
+    {
+        public string LayoutGuid { get; set; } = "";
+
+        /// <summary>Quantidade de padrões históricos usados na distribuição.</summary>
+        public int HistoricalSampleCount { get; set; }
+
+        /// <summary>
+        /// False quando há menos amostras que o mínimo exigido — nesse caso
+        /// <see cref="AnomalyScore"/> é null e nenhum score é inventado.
+        /// </summary>
+        public bool HasSufficientData { get; set; }
+
+        /// <summary>
+        /// Score de anomalia normalizado em [0..1] (0 = típico, 1 = fortemente anômalo).
+        /// Null quando não há dados suficientes para pontuar com honestidade.
+        /// </summary>
+        public double? AnomalyScore { get; set; }
+
+        /// <summary>True quando <see cref="AnomalyScore"/> ultrapassa o limiar de anomalia.</summary>
+        public bool IsAnomalous { get; set; }
+
+        /// <summary>Confiança no score em [0..1], crescente com o nº de amostras históricas.</summary>
+        public double Confidence { get; set; }
+
+        /// <summary>Features cujo z-score ultrapassou o limiar de suspeita (|z| >= 2).</summary>
+        public List<SuspiciousFeature> SuspiciousFeatures { get; set; } = new();
+
+        /// <summary>Explicação legível (PT-BR) do resultado.</summary>
+        public string Explanation { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Feature individual apontada como suspeita, com o valor observado,
+    /// o z-score e a faixa esperada (média ± 2 desvios) do histórico.
+    /// </summary>
+    public class SuspiciousFeature
+    {
+        public string FeatureName { get; set; } = "";
+        public double Value { get; set; }
+        public double ZScore { get; set; }
+        public double ExpectedMin { get; set; }
+        public double ExpectedMax { get; set; }
+    }
+}

--- a/Services/Validation/DocumentFeatureExtractor.cs
+++ b/Services/Validation/DocumentFeatureExtractor.cs
@@ -1,0 +1,100 @@
+using LayoutParserApi.Models.Configuration;
+
+using System.Text.Json;
+
+namespace LayoutParserApi.Services.Validation
+{
+    /// <summary>
+    /// Extrator ÚNICO de features numéricas de documentos posicionais.
+    /// Compartilhado entre <c>DocumentMLValidationService</c> (que grava os padrões em
+    /// MLData/DocumentPatterns) e <c>DocumentAnomalyDetectorService</c> (que pontua por z-score),
+    /// garantindo que histórico e documento novo usem EXATAMENTE as mesmas features.
+    /// </summary>
+    public static class DocumentFeatureExtractor
+    {
+        /// <summary>
+        /// Extrai as features de um documento. Mantém as MESMAS chaves e semântica
+        /// historicamente persistidas em <c>DocumentPattern.Features</c>.
+        /// </summary>
+        /// <param name="documentContent">Conteúdo bruto do documento posicional.</param>
+        /// <param name="expectedLineLength">
+        /// Tamanho de linha esperado — resolva via <see cref="LineLengthResolver"/>; o default
+        /// legado só existe para call-sites historicamente incondicionais.
+        /// </param>
+        public static Dictionary<string, object> Extract(string documentContent, int expectedLineLength = LineLengthResolver.LegacyDefaultLineLength)
+        {
+            var features = new Dictionary<string, object>();
+
+            // ✅ Guarda mínima contra divisão por zero (sem mudar o resultado para valores válidos)
+            if (expectedLineLength <= 0)
+                expectedLineLength = LineLengthResolver.LegacyDefaultLineLength;
+
+            features["totalLength"] = documentContent.Length;
+            features["lineCount"] = documentContent.Length / expectedLineLength;
+            features["hasHeader"] = documentContent.StartsWith("HEADER");
+            features["averageLineLength"] = documentContent.Length / (documentContent.Length / (double)expectedLineLength);
+
+            // Contar tipos de caracteres
+            features["numericCharCount"] = documentContent.Count(char.IsDigit);
+            features["alphaCharCount"] = documentContent.Count(char.IsLetter);
+            features["spaceCharCount"] = documentContent.Count(char.IsWhiteSpace);
+
+            return features;
+        }
+
+        /// <summary>
+        /// Converte um valor de feature em double de forma tolerante.
+        /// Necessário porque padrões carregados do disco chegam como <see cref="JsonElement"/>
+        /// (Features é <c>Dictionary&lt;string, object&gt;</c>), enquanto features recém-extraídas
+        /// chegam como int/double/bool nativos. Booleanos viram 0/1 para entrar na distribuição.
+        /// </summary>
+        public static bool TryToDouble(object? value, out double result)
+        {
+            result = 0;
+
+            switch (value)
+            {
+                case null:
+                    return false;
+
+                case bool b:
+                    result = b ? 1 : 0;
+                    return true;
+
+                case JsonElement element:
+                    switch (element.ValueKind)
+                    {
+                        case JsonValueKind.Number when element.TryGetDouble(out var d):
+                            result = d;
+                            break;
+                        case JsonValueKind.True:
+                            result = 1;
+                            break;
+                        case JsonValueKind.False:
+                            result = 0;
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+
+                case IConvertible convertible:
+                    try
+                    {
+                        result = convertible.ToDouble(System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                    break;
+
+                default:
+                    return false;
+            }
+
+            // NaN/Infinity não entram na distribuição (podem surgir de documentos vazios legados)
+            return !double.IsNaN(result) && !double.IsInfinity(result);
+        }
+    }
+}

--- a/Services/Validation/DocumentMLValidationService.cs
+++ b/Services/Validation/DocumentMLValidationService.cs
@@ -19,15 +19,19 @@ namespace LayoutParserApi.Services.Validation
         private readonly ILogger<DocumentMLValidationService> _logger;
         private readonly string _learningDataPath;
         private readonly string _trainingSamplesPath;
+        private readonly IDocumentAnomalyDetector? _anomalyDetector;
         private Dictionary<string, DocumentPattern> _learnedPatterns = new();
 
         public DocumentMLValidationService(
             ITechLogger techLogger,
             ILogger<DocumentMLValidationService> logger,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            IDocumentAnomalyDetector? anomalyDetector = null)
         {
             _techLogger = techLogger;
             _logger = logger;
+            // ✅ Dependência opcional: sem o detector registrado, o serviço segue funcionando normalmente
+            _anomalyDetector = anomalyDetector;
             _learningDataPath = configuration["ML:LearningDataPath"] ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "DocumentPatterns");
             _trainingSamplesPath = configuration["ML:TrainingSamplesPath"] ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "TrainingSamples");
 
@@ -68,6 +72,32 @@ namespace LayoutParserApi.Services.Validation
                 // Se não houver padrões, gerar sugestões baseadas em regras
                 if (!suggestions.Any())
                     suggestions.AddRange(GenerateRuleBasedSuggestions(lineError, context));
+
+                // ✅ Enriquecimento opcional com o score de anomalia (P2) — resiliente:
+                // qualquer falha aqui é engolida e NUNCA quebra a resposta principal
+                try
+                {
+                    if (_anomalyDetector != null)
+                    {
+                        var anomaly = await _anomalyDetector.DetectAsync(documentContent, layoutGuid);
+                        if (anomaly.AnomalyScore.HasValue && anomaly.IsAnomalous)
+                        {
+                            suggestions.Add(new ErrorSuggestion
+                            {
+                                FieldName = "Documento completo",
+                                CurrentLength = documentContent?.Length ?? 0,
+                                SuggestedLength = 0,
+                                Action = "review",
+                                Reason = $"[Anomalia] {anomaly.Explanation}",
+                                Confidence = anomaly.AnomalyScore.Value * anomaly.Confidence
+                            });
+                        }
+                    }
+                }
+                catch (Exception anomalyEx)
+                {
+                    _logger.LogWarning(anomalyEx, "Falha ao enriquecer sugestões com score de anomalia (ignorada)");
+                }
 
                 // Ordenar por confiança
                 suggestions = suggestions.OrderByDescending(s => s.Confidence).ToList();
@@ -265,19 +295,9 @@ namespace LayoutParserApi.Services.Validation
         /// </summary>
         private Dictionary<string, object> ExtractDocumentFeatures(string documentContent, int expectedLineLength = LineLengthResolver.LegacyDefaultLineLength)
         {
-            var features = new Dictionary<string, object>();
-
-            features["totalLength"] = documentContent.Length;
-            features["lineCount"] = documentContent.Length / expectedLineLength;
-            features["hasHeader"] = documentContent.StartsWith("HEADER");
-            features["averageLineLength"] = documentContent.Length / (documentContent.Length / (double)expectedLineLength);
-
-            // Contar tipos de caracteres
-            features["numericCharCount"] = documentContent.Count(char.IsDigit);
-            features["alphaCharCount"] = documentContent.Count(char.IsLetter);
-            features["spaceCharCount"] = documentContent.Count(char.IsWhiteSpace);
-
-            return features;
+            // ✅ Lógica centralizada no DocumentFeatureExtractor — helper compartilhado com o
+            // DocumentAnomalyDetectorService para garantir features idênticas às do histórico
+            return DocumentFeatureExtractor.Extract(documentContent, expectedLineLength);
         }
 
         /// <summary>

--- a/ai/XslSynth/NtPipeline/XsdDeltaModels.cs
+++ b/ai/XslSynth/NtPipeline/XsdDeltaModels.cs
@@ -1,0 +1,90 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace XslSynth.NtPipeline;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modelos do S1 (XsdDiff) do pipeline "NT nova": o delta entre dois pacotes XSD
+// é POR XPATH, tipado e serializável — o artefato versionável que alimenta os
+// estágios S2 (semântica via PDF da NT) e S3 (delta do catálogo #XML→XPath).
+// Desenho: docs/architecture/nt-pipeline-design.md §4–5 (P-1).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Classificação de uma divergência entre o XSD velho e o novo.</summary>
+public enum XsdDeltaKind
+{
+    /// <summary>Nó existe só no XSD novo.</summary>
+    Added,
+
+    /// <summary>Nó existe só no XSD velho.</summary>
+    Removed,
+
+    /// <summary>Mesmo XPath, tipo declarado diferente.</summary>
+    TypeChanged,
+
+    /// <summary>Mesmo XPath, ocorrência (minOccurs/maxOccurs ou use) diferente.</summary>
+    OccurrenceChanged,
+
+    /// <summary>Mesmo XPath e mesmo tipo, facets (tamanho/pattern/enum…) diferentes.</summary>
+    FacetChanged,
+}
+
+/// <summary>Categoria de um nó no snapshot "diffável" do XSD.</summary>
+public enum XsdNodeKind
+{
+    Elemento,
+    Atributo,
+    TipoComplexo,
+    TipoSimples,
+}
+
+/// <summary>Um nó do snapshot do pacote XSD. O XPath é a CHAVE do diff.</summary>
+/// <param name="Order">Índice sequencial na caminhada (ordem de documento).</param>
+/// <param name="XPath">Caminho enraizado no tipo/elemento global ("TNFe/infNFe/ide/cUF"; atributo: ".../@versao").</param>
+/// <param name="Kind">Categoria do nó.</param>
+/// <param name="TypeName">Tipo declarado ("TCodUfIBGE", "xs:string", "(simples inline: TString)").</param>
+/// <param name="Occurs">"1-1", "0-N"… ("global" para declarações de topo).</param>
+/// <param name="Facets">Assinatura de facets (base + tamanho/pattern/enum…) ou vazio.</param>
+public sealed record XsdDiffNode(
+    int Order,
+    string XPath,
+    XsdNodeKind Kind,
+    string TypeName,
+    string Occurs,
+    string Facets);
+
+/// <summary>Uma divergência classificada. Antes/Depois carregam SÓ a parte que mudou.</summary>
+public sealed record XsdDeltaEntry(
+    XsdDeltaKind Kind,
+    string XPath,
+    string? Antes,
+    string? Depois);
+
+/// <summary>Artefato do S1: o delta completo entre dois XSD (JSON versionável).</summary>
+public sealed class XsdDelta
+{
+    public required string XsdVelho { get; init; }
+    public required string XsdNovo { get; init; }
+    public DateTime GeradoEmUtc { get; init; } = DateTime.UtcNow;
+    public int NosVelho { get; init; }
+    public int NosNovo { get; init; }
+
+    /// <summary>Contagem por tipo de delta (sempre as 5 chaves — schema estável p/ S2/S3).</summary>
+    public required Dictionary<string, int> Resumo { get; init; }
+
+    public required List<XsdDeltaEntry> Entradas { get; init; }
+
+    [JsonIgnore]
+    public int Total => Entradas.Count;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        // Padrão do projeto: preservar '<'/'>' e regex de pattern legíveis no JSON.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public string ToJson() => JsonSerializer.Serialize(this, JsonOpts);
+}

--- a/ai/XslSynth/NtPipeline/XsdDiffer.cs
+++ b/ai/XslSynth/NtPipeline/XsdDiffer.cs
@@ -1,0 +1,421 @@
+using System.Globalization;
+using System.Xml;
+using System.Xml.Schema;
+
+namespace XslSynth.NtPipeline;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// XsdDiffer — S1 do pipeline "NT nova": snapshot diffável de um pacote XSD
+// (arquivo principal + includes do MESMO diretório) e delta por XPath.
+// 100% determinístico — sem LLM, sem rede além do filesystem local.
+//
+// DECISÃO (avaliada contra reusar XsdLeiauteIndex.Load — nt-pipeline-design §5 P-1):
+//   o XsdLeiauteIndex é perfeito para o CATÁLOGO (ordem de documento + docs
+//   PT-BR), mas para o DIFF tem 3 lacunas estruturais:
+//     1. não resolve xs:include/xs:import — os facets de tamanho/pattern/enum
+//        vivem em tiposBasico_v4.00.xsd / DFeTiposBasicos_v1.00.xsd;
+//     2. descarta facets INLINE (guarda só a base da restrição) — mudança de
+//        maxLength num elemento como ide/natOp seria invisível;
+//     3. estendê-lo mexeria numa classe calibrada pelos fluxos --catalog e
+//        --generate (recém-tocados pela B4) sem ganho: o diff não usa as
+//        camadas semânticas (documentation/âncoras).
+//   Portanto: System.Xml.Schema (XmlSchemaSet) — includes resolvidos a partir
+//   da pasta do arquivo, tipos/ocorrências COMPILADOS e facets completos
+//   (inclusive inline). O XsdLeiauteIndex permanece intocado.
+//
+// GRANULARIDADE (dedupe por construção):
+//   • cada TIPO GLOBAL do namespace-alvo é caminhado UMA vez, com XPath
+//     enraizado no nome do tipo ("TNFe/infNFe/ide/cUF");
+//   • elemento que referencia tipo COMPLEXO nomeado vira folha (tipo
+//     registrado, sem descida) — o conteúdo é diffado sob a raiz do próprio
+//     tipo. Mudança em TNFe gera UM delta, sem eco em TEnviNFe/TNfeProc;
+//   • tipos SIMPLES nomeados (TSerie, TDec_1302…) são nós próprios com
+//     assinatura de facets — mudar tiposBasico gera UM FacetChanged no tipo,
+//     não centenas nos campos que o usam. (S3 expande raiz-de-tipo → caminhos
+//     de instância do catálogo.)
+//
+// LIMITE HONESTO: XPaths repetidos em ramos distintos de um xs:choice (ex.:
+// IPI nos dois ramos de imposto) colapsam na 1ª ocorrência — mesmo critério
+// do XsdLeiauteIndex; mudança SÓ no ramo sombreado não aparece. A quantidade
+// colapsada fica visível em DuplicadosIgnorados.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Snapshot "diffável" de um pacote XSD (principal + includes).</summary>
+public sealed class XsdSchemaSnapshot
+{
+    internal XsdSchemaSnapshot(
+        string origem, List<XsdDiffNode> nodes, int duplicados, IReadOnlyList<string> avisos)
+    {
+        Origem = origem;
+        Nodes = nodes;
+        DuplicadosIgnorados = duplicados;
+        Avisos = avisos;
+        var byPath = new Dictionary<string, XsdDiffNode>(nodes.Count, StringComparer.Ordinal);
+        foreach (var n in nodes)
+            byPath.TryAdd(n.XPath, n);
+        ByPath = byPath;
+    }
+
+    public string Origem { get; }
+    public IReadOnlyList<XsdDiffNode> Nodes { get; }
+    public IReadOnlyDictionary<string, XsdDiffNode> ByPath { get; }
+
+    /// <summary>XPaths repetidos (ramos de choice) colapsados na 1ª ocorrência.</summary>
+    public int DuplicadosIgnorados { get; }
+
+    /// <summary>Avisos de validação do XmlSchemaSet (não derrubam o snapshot).</summary>
+    public IReadOnlyList<string> Avisos { get; }
+}
+
+/// <summary>Carrega snapshots de pacotes XSD e computa o delta por XPath.</summary>
+public static class XsdDiffer
+{
+    private const string DsNs = "http://www.w3.org/2000/09/xmldsig#";
+
+    /// <summary>
+    /// Compila o pacote (includes/imports resolvidos a partir da pasta do arquivo)
+    /// e materializa os nós em ordem de documento (principal → includes, DFS).
+    /// </summary>
+    public static XsdSchemaSnapshot LoadSnapshot(string xsdPath)
+    {
+        if (!File.Exists(xsdPath))
+            throw new FileNotFoundException($"XSD não encontrado: {xsdPath}", xsdPath);
+
+        var avisos = new List<string>();
+        var set = new XmlSchemaSet { XmlResolver = new XmlUrlResolver() };
+        set.ValidationEventHandler += (_, e) => avisos.Add($"{e.Severity}: {e.Message}");
+
+        var main = set.Add(null, Path.GetFullPath(xsdPath))
+            ?? throw new InvalidOperationException("XmlSchemaSet devolveu schema nulo.");
+        set.Compile();
+
+        var walker = new Walker(main.TargetNamespace ?? "");
+        foreach (var doc in DocsEmOrdem(main))
+            walker.WalkGlobais(doc);
+
+        return new XsdSchemaSnapshot(Path.GetFullPath(xsdPath), walker.Nodes, walker.Duplicados, avisos);
+    }
+
+    /// <summary>Delta por XPath: Added/Removed/TypeChanged/OccurrenceChanged/FacetChanged.</summary>
+    public static XsdDelta Diff(XsdSchemaSnapshot velho, XsdSchemaSnapshot novo)
+    {
+        var entradas = new List<XsdDeltaEntry>();
+
+        // Ordem de documento do NOVO primeiro (Added/alterações), removidos ao final.
+        foreach (var n in novo.Nodes)
+        {
+            if (!velho.ByPath.TryGetValue(n.XPath, out var v))
+            {
+                entradas.Add(new(XsdDeltaKind.Added, n.XPath, null, Descreve(n)));
+                continue;
+            }
+
+            var mesmoTipo = string.Equals(v.TypeName, n.TypeName, StringComparison.Ordinal);
+            if (!mesmoTipo)
+                entradas.Add(new(XsdDeltaKind.TypeChanged, n.XPath, v.TypeName, n.TypeName));
+            if (!string.Equals(v.Occurs, n.Occurs, StringComparison.Ordinal))
+                entradas.Add(new(XsdDeltaKind.OccurrenceChanged, n.XPath, v.Occurs, n.Occurs));
+            // Tipo mudou ⇒ facets mudam por consequência; FacetChanged só com tipo estável.
+            if (mesmoTipo && !string.Equals(v.Facets, n.Facets, StringComparison.Ordinal))
+            {
+                var (antes, depois) = DiffFacets(v.Facets, n.Facets);
+                entradas.Add(new(XsdDeltaKind.FacetChanged, n.XPath, antes, depois));
+            }
+        }
+
+        foreach (var v in velho.Nodes)
+            if (!novo.ByPath.ContainsKey(v.XPath))
+                entradas.Add(new(XsdDeltaKind.Removed, v.XPath, Descreve(v), null));
+
+        var resumo = new Dictionary<string, int>();
+        foreach (var k in Enum.GetValues<XsdDeltaKind>())
+            resumo[k.ToString()] = entradas.Count(e => e.Kind == k);
+
+        return new XsdDelta
+        {
+            XsdVelho = velho.Origem,
+            XsdNovo = novo.Origem,
+            NosVelho = velho.Nodes.Count,
+            NosNovo = novo.Nodes.Count,
+            Resumo = resumo,
+            Entradas = entradas,
+        };
+    }
+
+    // ── Helpers do diff ───────────────────────────────────────────────────────
+
+    private static string Descreve(XsdDiffNode n) =>
+        $"{n.Kind} tipo={n.TypeName} occurs={n.Occurs}"
+        + (n.Facets.Length > 0 ? $" facets[{n.Facets}]" : "");
+
+    /// <summary>Compacta o FacetChanged: só os facets que saíram/entraram, não a assinatura toda
+    /// (evita listar 400 enumerações de um TCListServ quando só uma mudou).</summary>
+    private static (string Antes, string Depois) DiffFacets(string velho, string novo)
+    {
+        var ve = velho.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+        var no = novo.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+        var so = string.Join("; ", ve.Except(no, StringComparer.Ordinal));
+        var sn = string.Join("; ", no.Except(ve, StringComparer.Ordinal));
+        return (so.Length > 0 ? so : "(nenhum)", sn.Length > 0 ? sn : "(nenhum)");
+    }
+
+    /// <summary>Documentos do pacote no namespace-alvo, em ordem: principal → includes (DFS).</summary>
+    private static List<XmlSchema> DocsEmOrdem(XmlSchema main)
+    {
+        var docs = new List<XmlSchema>();
+        var vistos = new HashSet<XmlSchema>();
+        void Coleta(XmlSchema s)
+        {
+            if (!vistos.Add(s)) return;
+            docs.Add(s);
+            foreach (var ext in s.Includes.OfType<XmlSchemaExternal>())
+            {
+                // Import de namespace estranho (ds:) fica fora do domínio do diff.
+                if (ext is XmlSchemaImport imp && imp.Namespace != main.TargetNamespace) continue;
+                if (ext.Schema is { } inc) Coleta(inc);
+            }
+        }
+        Coleta(main);
+        return docs;
+    }
+
+    // ── Caminhada (uma instância por snapshot, guarda estado do dedupe) ───────
+
+    private sealed class Walker(string targetNs)
+    {
+        private readonly HashSet<string> _seen = new(StringComparer.Ordinal);
+
+        public List<XsdDiffNode> Nodes { get; } = new(4096);
+        public int Duplicados { get; private set; }
+
+        public void WalkGlobais(XmlSchema doc)
+        {
+            foreach (var item in doc.Items.OfType<XmlSchemaObject>())
+            {
+                switch (item)
+                {
+                    case XmlSchemaElement el:
+                        WalkElemento(el, parentPath: null, depth: 0);
+                        break;
+
+                    case XmlSchemaComplexType { Name: not null } ct:
+                    {
+                        var (tipo, facets) = DescreveTipoComplexo(ct);
+                        if (Add(ct.Name, XsdNodeKind.TipoComplexo, tipo, "global", facets))
+                            WalkCorpoComplexo(ct, ct.Name, depth: 1);
+                        break;
+                    }
+
+                    case XmlSchemaSimpleType { Name: not null } st:
+                        Add(st.Name, XsdNodeKind.TipoSimples, BaseDe(st), "global", FacetSignature(st));
+                        break;
+                }
+            }
+        }
+
+        private void WalkElemento(XmlSchemaElement el, string? parentPath, int depth)
+        {
+            if (depth > 64) return;   // guarda-corpo (leiaute real tem ~12 níveis)
+
+            var qn = el.QualifiedName;   // pós-compilação: nome próprio OU do ref resolvido
+            var nome = qn.Namespace == targetNs || qn.Namespace.Length == 0 ? qn.Name : Label(qn);
+            var path = parentPath is null ? nome : $"{parentPath}/{nome}";
+            var occurs = parentPath is null ? "global" : OccursOf(el);
+
+            string tipo;
+            var facets = "";
+            XmlSchemaComplexType? inline = null;
+
+            if (!el.SchemaTypeName.IsEmpty)
+            {
+                tipo = Label(el.SchemaTypeName);
+            }
+            else
+            {
+                switch (el.ElementSchemaType)
+                {
+                    case XmlSchemaComplexType ct when ct.QualifiedName.IsEmpty:
+                        tipo = "(complexo inline)";
+                        inline = ct;
+                        break;
+                    case XmlSchemaSimpleType st when st.QualifiedName.IsEmpty:
+                        tipo = $"(simples inline: {BaseDe(st)})";
+                        facets = FacetSignature(st);
+                        break;
+                    case { } t when !t.QualifiedName.IsEmpty:
+                        tipo = Label(t.QualifiedName);   // ref → tipo do elemento global
+                        break;
+                    default:
+                        tipo = "xs:anyType";
+                        break;
+                }
+            }
+
+            if (!Add(path, XsdNodeKind.Elemento, tipo, occurs, facets)) return;
+
+            // Só desce em complexo ANÔNIMO — tipo nomeado é diffado sob a própria raiz.
+            if (inline is not null)
+                WalkCorpoComplexo(inline, path, depth + 1);
+        }
+
+        private void WalkCorpoComplexo(XmlSchemaComplexType ct, string path, int depth)
+        {
+            if (depth > 64) return;
+
+            // Atributos EFETIVOS (pós-compilação, inclui herdados); ordenados p/ determinismo.
+            foreach (var at in ct.AttributeUses.Values.OfType<XmlSchemaAttribute>()
+                         .OrderBy(a => a.QualifiedName.Name, StringComparer.Ordinal))
+            {
+                var occ = at.Use == XmlSchemaUse.Required ? "1-1" : "0-1";
+                string tipo;
+                var facets = "";
+                if (!at.SchemaTypeName.IsEmpty)
+                {
+                    tipo = Label(at.SchemaTypeName);
+                }
+                else if (at.AttributeSchemaType is { } ast && ast.QualifiedName.IsEmpty)
+                {
+                    tipo = $"(simples inline: {BaseDe(ast)})";
+                    facets = FacetSignature(ast);
+                }
+                else if (at.AttributeSchemaType is { } nomeado)
+                {
+                    tipo = Label(nomeado.QualifiedName);
+                }
+                else
+                {
+                    tipo = "xs:anySimpleType";
+                }
+                Add($"{path}/@{at.QualifiedName.Name}", XsdNodeKind.Atributo, tipo, occ, facets);
+            }
+
+            WalkParticula(ct.ContentTypeParticle, path, depth);
+        }
+
+        private void WalkParticula(XmlSchemaParticle? particula, string path, int depth)
+        {
+            switch (particula)
+            {
+                case XmlSchemaElement el:
+                    WalkElemento(el, path, depth);
+                    break;
+                case XmlSchemaGroupBase grupo:   // sequence | choice | all
+                    foreach (var filho in grupo.Items.OfType<XmlSchemaParticle>())
+                        WalkParticula(filho, path, depth);
+                    break;
+                case XmlSchemaGroupRef gr:
+                    WalkParticula(gr.Particle, path, depth);
+                    break;
+                case XmlSchemaAny any:
+                    Add($"{path}/xs:any", XsdNodeKind.Elemento, "(any)", OccursOf(any), "");
+                    break;
+                    // null / EmptyParticle: sem conteúdo de elemento.
+            }
+        }
+
+        private bool Add(string path, XsdNodeKind kind, string tipo, string occurs, string facets)
+        {
+            if (!_seen.Add(path)) { Duplicados++; return false; }
+            Nodes.Add(new XsdDiffNode(Nodes.Count, path, kind, tipo, occurs, facets));
+            return true;
+        }
+    }
+
+    // ── Helpers de tipo/facet (compartilhados pela caminhada) ─────────────────
+
+    private static string Label(XmlQualifiedName qn) => qn.Namespace switch
+    {
+        XmlSchema.Namespace => $"xs:{qn.Name}",
+        DsNs => $"ds:{qn.Name}",
+        _ => qn.Name,
+    };
+
+    private static string OccursOf(XmlSchemaParticle p)
+    {
+        var min = p.MinOccurs.ToString("G29", CultureInfo.InvariantCulture);
+        var max = p.MaxOccurs == decimal.MaxValue
+            ? "N"
+            : p.MaxOccurs.ToString("G29", CultureInfo.InvariantCulture);
+        return $"{min}-{max}";
+    }
+
+    private static string BaseDe(XmlSchemaSimpleType st) => st.Content switch
+    {
+        XmlSchemaSimpleTypeRestriction r when !r.BaseTypeName.IsEmpty => Label(r.BaseTypeName),
+        XmlSchemaSimpleTypeList => "xs:list",
+        XmlSchemaSimpleTypeUnion => "xs:union",
+        _ => "(restrição inline)",
+    };
+
+    /// <summary>Assinatura: base + facets PRÓPRIOS, em ordem de documento. Facets da base
+    /// nomeada NÃO são expandidos — a base é diffada sob a própria raiz (localidade).</summary>
+    private static string FacetSignature(XmlSchemaSimpleType st)
+    {
+        switch (st.Content)
+        {
+            case XmlSchemaSimpleTypeRestriction r:
+            {
+                var parts = new List<string>
+                {
+                    r.BaseTypeName.IsEmpty
+                        ? r.BaseType is { } aninhada ? $"base=({FacetSignature(aninhada)})" : "base=(inline)"
+                        : $"base={Label(r.BaseTypeName)}",
+                };
+                foreach (var f in r.Facets.OfType<XmlSchemaFacet>())
+                    parts.Add($"{FacetKind(f)}={f.Value}");
+                return string.Join("; ", parts);
+            }
+            case XmlSchemaSimpleTypeList l:
+                return l.ItemTypeName.IsEmpty ? "list(inline)" : $"list(item={Label(l.ItemTypeName)})";
+            case XmlSchemaSimpleTypeUnion u:
+                return $"union({string.Join(",", (u.MemberTypes ?? []).Select(Label))})";
+            default:
+                return "";
+        }
+    }
+
+    private static string FacetKind(XmlSchemaFacet f) => f switch
+    {
+        XmlSchemaLengthFacet => "length",
+        XmlSchemaMinLengthFacet => "minLength",
+        XmlSchemaMaxLengthFacet => "maxLength",
+        XmlSchemaPatternFacet => "pattern",
+        XmlSchemaEnumerationFacet => "enumeration",
+        XmlSchemaWhiteSpaceFacet => "whiteSpace",
+        XmlSchemaTotalDigitsFacet => "totalDigits",
+        XmlSchemaFractionDigitsFacet => "fractionDigits",
+        XmlSchemaMinInclusiveFacet => "minInclusive",
+        XmlSchemaMaxInclusiveFacet => "maxInclusive",
+        XmlSchemaMinExclusiveFacet => "minExclusive",
+        XmlSchemaMaxExclusiveFacet => "maxExclusive",
+        _ => f.GetType().Name,
+    };
+
+    /// <summary>Tipo "declarado" de um complexType global (base de extensão/restrição) +
+    /// facets de simpleContent, quando houver.</summary>
+    private static (string Tipo, string Facets) DescreveTipoComplexo(XmlSchemaComplexType ct)
+    {
+        switch (ct.ContentModel)
+        {
+            case XmlSchemaSimpleContent sc:
+                return sc.Content switch
+                {
+                    XmlSchemaSimpleContentExtension e => ($"simpleContent extends {Label(e.BaseTypeName)}", ""),
+                    XmlSchemaSimpleContentRestriction r => (
+                        $"simpleContent restricts {Label(r.BaseTypeName)}",
+                        string.Join("; ", r.Facets.OfType<XmlSchemaFacet>()
+                            .Select(f => $"{FacetKind(f)}={f.Value}"))),
+                    _ => ("simpleContent", ""),
+                };
+            case XmlSchemaComplexContent cc:
+                return cc.Content switch
+                {
+                    XmlSchemaComplexContentExtension e => ($"extends {Label(e.BaseTypeName)}", ""),
+                    XmlSchemaComplexContentRestriction r => ($"restricts {Label(r.BaseTypeName)}", ""),
+                    _ => ("complexContent", ""),
+                };
+            default:
+                return ("(complexo)", "");
+        }
+    }
+}

--- a/ai/XslSynth/Program.cs
+++ b/ai/XslSynth/Program.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using XslSynth.Core;
 using XslSynth.Excel;
 using XslSynth.Model;
+using XslSynth.NtPipeline;
 using XslSynth.Synthesis;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -14,6 +15,10 @@ using XslSynth.Synthesis;
 //   dotnet run -- --excel <x>  → gera o TCL <MAP> a partir da spec .xlsx (PoC-0/1)
 //   dotnet run -- --catalog <x> → catálogo #XML → XPath NF-e + relatório (PoC-2)
 //   dotnet run -- --generate <x> → TXT→ROOT→XSL→saída + diff vs gabarito (PoC-3)
+//   dotnet run -- --rag <pasta>  → injeta o índice RAG few-shot no tradutor (P1)
+//   dotnet run -- --rag-stats    → tamanho do índice por chave + demo de recuperação
+//   dotnet run -- --xsd-diff <velho.xsd> <novo.xsd> [--delta-out <json>]
+//                              → S1 do pipeline NT: delta de XSD por XPath (B5 P-1)
 //
 // Arquitetura: docs/architecture/ia-xslt-synthesis.md · poc-excel-generator.md
 // ─────────────────────────────────────────────────────────────────────────────
@@ -24,6 +29,12 @@ Log("╔════════════════════════
 Log("║  XslSynth — síntese de XSLT guiada por verificador                 ║");
 Log("╚══════════════════════════════════════════════════════════════════╝");
 Log("");
+
+if (args.Contains("--xsd-diff"))
+    return RunXsdDiff();
+
+if (args.Contains("--rag-stats"))
+    return await RunRagStatsAsync();
 
 if (args.Contains("--generate"))
     return RunGenerate();
@@ -468,6 +479,87 @@ int RunGenerate()
     return a1Ok && falta == 0 && texto == 0 ? 0 : 1;
 }
 
+// ══════════════════════════════════════════════════════════════════════════
+// Fluxo XSD-DIFF (pipeline NT, S1 — protótipo B5 P-1): snapshot dos dois
+// pacotes XSD (includes resolvidos a partir da pasta de CADA arquivo) → delta
+// por XPath (Added/Removed/TypeChanged/OccurrenceChanged/FacetChanged) →
+// JSON versionável + resumo no console. 100% determinístico — SEM LLM.
+// Desenho: docs/architecture/nt-pipeline-design.md §4–5.
+// ══════════════════════════════════════════════════════════════════════════
+int RunXsdDiff()
+{
+    var idx = Array.IndexOf(args, "--xsd-diff");
+    string? Pos(int off) =>
+        idx + off < args.Length && !args[idx + off].StartsWith("--") ? args[idx + off] : null;
+    var velhoPath = Pos(1);
+    var novoPath = Pos(2);
+    if (velhoPath is null || novoPath is null || !File.Exists(velhoPath) || !File.Exists(novoPath))
+    {
+        Log("❌ Informe os dois XSD (arquivos existentes).");
+        Log("   Uso: dotnet run -- --xsd-diff <velho.xsd> <novo.xsd> [--delta-out <arquivo.json>]");
+        return 2;
+    }
+
+    Log("Modo      : XSD-DIFF (pipeline NT, S1 — determinístico, sem LLM)");
+    Log($"XSD velho : {velhoPath}");
+    Log($"XSD novo  : {novoPath}");
+    Log("");
+
+    XsdSchemaSnapshot velho, novo;
+    try
+    {
+        velho = XsdDiffer.LoadSnapshot(velhoPath);
+        novo = XsdDiffer.LoadSnapshot(novoPath);
+    }
+    catch (Exception ex)
+    {
+        Log($"❌ Falha ao compilar os XSD: {ex.Message}");
+        return 1;
+    }
+
+    foreach (var aviso in velho.Avisos.Concat(novo.Avisos).Take(5))
+        Log($"   [aviso XSD] {aviso}");
+
+    Log($"Snapshot velho: {velho.Nodes.Count} nós ({velho.DuplicadosIgnorados} XPaths de choice colapsados).");
+    Log($"Snapshot novo : {novo.Nodes.Count} nós ({novo.DuplicadosIgnorados} colapsados).");
+    Log("");
+
+    var delta = XsdDiffer.Diff(velho, novo);
+
+    Log("── Resumo do delta ───────────────────────────────────────────────");
+    foreach (var (kind, qtd) in delta.Resumo)
+        Log($"   {kind,-18} {qtd,5}");
+    Log($"   {"TOTAL",-18} {delta.Total,5}");
+    Log("");
+
+    if (delta.Total == 0)
+    {
+        Log("✅ IDENTIDADE: 0 deltas — os dois XSD descrevem o mesmo leiaute.");
+    }
+    else
+    {
+        foreach (var g in delta.Entradas.GroupBy(e => e.Kind))
+        {
+            Log($"── {g.Key} ({g.Count()}) ──────────────────────────────────────────");
+            foreach (var e in g.Take(12))
+            {
+                Log($"   {e.XPath}");
+                if (e.Antes is not null) Log($"      antes : {Short(e.Antes, 110)}");
+                if (e.Depois is not null) Log($"      depois: {Short(e.Depois, 110)}");
+            }
+            if (g.Count() > 12) Log($"   … e mais {g.Count() - 12}.");
+        }
+    }
+    Log("");
+
+    var deltaOut = FindArgAfter("--delta-out") ?? Path.Combine(ResolveExportDir(), "xsd-delta.json");
+    Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(deltaOut))!);
+    File.WriteAllText(deltaOut, delta.ToJson());
+    Log($"XsdDelta (JSON) salvo em: {deltaOut}");
+
+    return 0;
+}
+
 // Set-diff por path: multiconjuntos de folhas (elementos sem filhos) e atributos.
 // FALTA = só no gabarito · SOBRA = só no gerado · TEXTO = valor difere (par ordinal).
 (int Falta, int Sobra, int Texto, List<string> Linhas) SetDiffPorPath(XElement esperado, XElement obtido)
@@ -583,6 +675,139 @@ string ResolveExportDir()
 }
 
 // ══════════════════════════════════════════════════════════════════════════
+// Fluxo RAG-STATS (P1): constrói o FewShotIndex a partir do corpus real e
+// imprime (a) o tamanho do índice por chave tipo|versão|padrão e (b) UMA
+// demonstração de recuperação para uma regra DIFÍCIL real (com && ou else)
+// do MapperVO usado no fluxo --generate, quando acessível em disco.
+// Com --ollama: traduz a regra difícil COM e SEM few-shot e compara.
+// ══════════════════════════════════════════════════════════════════════════
+async Task<int> RunRagStatsAsync()
+{
+    var corpusDir = FindArgAfter("--rag") ?? Path.Combine(
+        Path.GetDirectoryName(ResolveExportDir())!, "servidor", "layoutparser", "Examples");
+    if (!Directory.Exists(corpusDir))
+    {
+        Log("❌ Pasta de corpus não encontrada.");
+        Log("   Uso: dotnet run -- --rag-stats [--rag <pasta-corpus>] [--mapper <mapper.decrypted.xml>]");
+        return 2;
+    }
+
+    Log("Modo      : RAG-STATS (índice few-shot, P1 — determinístico, sem embeddings)");
+    Log($"Corpus    : {corpusDir}");
+    Log("");
+
+    var index = FewShotIndex.Build(corpusDir, Log);
+
+    // Regras DSL do mapeador real entram no índice também (DSL análoga + pares fáceis).
+    var mapperPath = FindArgAfter("--mapper") ?? FindMapperByClimb();
+    XslSynth.Model.MapperVo? mapper = null;
+    if (mapperPath is not null && File.Exists(mapperPath))
+    {
+        try
+        {
+            mapper = new RealMapperParser().ParseFile(mapperPath);
+            index.AddMapper(mapper, Path.GetFileName(mapperPath));
+            Log($"[rag] mapeador real indexado: {mapper.Rules.Count} regras DSL ({Path.GetFileName(mapperPath)}).");
+        }
+        catch (Exception ex)
+        {
+            Log($"   [aviso] mapeador ilegível ({ex.Message}) — stats só do corpus.");
+        }
+    }
+    else
+    {
+        Log("   [aviso] MapperVO descriptografado não encontrado — demo de recuperação indisponível.");
+    }
+    Log("");
+
+    // ── (a) Tamanho do índice por chave ──────────────────────────────────
+    Log("── Índice por chave (tipo|versão|padrão) ─────────────────────────");
+    Log($"   {"Chave",-28} {"total",5} {"pares",5} {"sóDSL",5} {"sóXSL",5}");
+    foreach (var (chave, total, pares, soDsl, soXslt) in index.Stats())
+        Log($"   {chave,-28} {total,5} {pares,5} {soDsl,5} {soXslt,5}");
+    Log($"   TOTAL: {index.Count} exemplos.");
+    Log("");
+
+    // ── (b) Demo de recuperação para UMA regra difícil real ──────────────
+    if (mapper is null) return 0;
+
+    var dificil = mapper.Rules.FirstOrDefault(r =>
+    {
+        var t = FewShotIndex.ClassifyTraits(r.ContentValue);
+        return t.HasFlag(DslTraits.CompostaAnd) || t.HasFlag(DslTraits.Else);
+    });
+    if (dificil is null)
+    {
+        Log("   [aviso] nenhuma regra com && ou else no mapeador — demo pulada.");
+        return 0;
+    }
+
+    var traits = FewShotIndex.ClassifyTraits(dificil.ContentValue);
+    Log("── Demo de recuperação (regra difícil real) ──────────────────────");
+    Log($"   Regra   : {dificil.Name}");
+    Log($"   Traços  : {traits} (primário: {FewShotIndex.Rotulo(FewShotIndex.Primario(traits))})");
+    Log($"   DSL     : {Short((dificil.ContentValue ?? "").Trim(), 160)}");
+    Log("");
+    var recuperados = index.Retrieve(dificil, k: 3);
+    Log($"   Recuperados: {recuperados.Count} exemplo(s).");
+    var n = 0;
+    foreach (var ex in recuperados)
+    {
+        n++;
+        var forma = ex is { Dsl: not null, Xslt: not null } ? "par DSL→XSLT"
+            : ex.Xslt is not null ? "estilo XSL real" : "DSL análoga";
+        Log($"   ── #{n} [{ex.Chave}] {forma} · origem: {ex.Origem}");
+        if (ex.Dsl is not null) Log($"      DSL : {Short(ex.Dsl.ReplaceLineEndings(" "), 140)}");
+        if (ex.Xslt is not null) Log($"      XSLT: {Short(ex.Xslt.ReplaceLineEndings(" "), 140)}");
+    }
+    Log("");
+
+    // ── (c) Opcional: tradução da regra difícil COM e SEM few-shot (--ollama) ──
+    if (!args.Contains("--ollama"))
+    {
+        Log("   (passe --ollama para comparar a tradução da regra com e sem few-shot)");
+        return 0;
+    }
+    var client = new OllamaClient(Log);
+    if (!await client.IsReachableAsync())
+    {
+        Log("   [aviso] Ollama indisponível — comparação com/sem few-shot pulada.");
+        return 0;
+    }
+
+    Log($"── Comparação com/sem few-shot (Ollama {client.Model}) ───────────");
+    var sem = await new DslRuleTranslator(client, Log).TranslateAsync(dificil);
+    var com = await new DslRuleTranslator(client, Log, index).TranslateAsync(dificil);
+    foreach (var (rotulo, tr) in new[] { ("SEM few-shot", sem), ("COM few-shot", com) })
+    {
+        // Source==Ollama ⇒ o corpo COMPILOU (o tradutor só aceita XSLT que compila).
+        var compilou = tr.Source == TranslationSource.Ollama;
+        var temChoose = tr.BodyXsl.Contains("xsl:otherwise", StringComparison.Ordinal);
+        var temAnd = System.Text.RegularExpressions.Regex.IsMatch(tr.BodyXsl, @"test=""[^""]*\band\b");
+        Log($"   {rotulo}: fonte={tr.Source} · XSLT do LLM compilou={(compilou ? "sim" : $"não (caiu para {tr.Source})")}"
+            + $" · choose/otherwise={(temChoose ? "sim" : "não")} · test com 'and'={(temAnd ? "sim" : "não")}");
+        Log($"      corpo: {Short(tr.BodyXsl.ReplaceLineEndings(" "), 180)}");
+    }
+
+    return 0;
+}
+
+// Sobe da pasta do exe procurando o MapperVO real (SEM olhar args posicionais —
+// aqui o valor após --rag é uma PASTA e não pode ser confundido com o mapeador).
+string? FindMapperByClimb()
+{
+    var dir = new DirectoryInfo(AppContext.BaseDirectory);
+    while (dir is not null)
+    {
+        var candidate = Path.Combine(dir.FullName,
+            ".claude", "tmp", "export", "MAP_MQSERIES_SEND_ENV_TXT_XML_NFE.decrypted.xml");
+        if (File.Exists(candidate)) return candidate;
+        dir = dir.Parent;
+    }
+    return null;
+}
+
+// ══════════════════════════════════════════════════════════════════════════
 // Fluxo REAL: MapperVO Sysmiddle descriptografado → candidato XSLT + cobertura
 // (verificação POSSÍVEL sem gabarito de runtime: compila + % de cobertura)
 // ══════════════════════════════════════════════════════════════════════════
@@ -630,10 +855,27 @@ async Task<int> RunRealAsync()
         }
     }
 
+    // Índice RAG few-shot (P1) — opt-in via --rag <pasta-corpus>; sem a flag o
+    // comportamento (e o prompt) permanecem idênticos.
+    FewShotIndex? fewShot = null;
+    var ragDir = FindArgAfter("--rag");
+    if (ragDir is not null)
+    {
+        if (Directory.Exists(ragDir))
+        {
+            fewShot = FewShotIndex.Build(ragDir, Log);
+            Log($"[rag] few-shot habilitado: {fewShot.Count} exemplos indexados de {ragDir}.");
+        }
+        else
+        {
+            Log($"   [aviso] pasta de corpus '{ragDir}' não existe — seguindo SEM few-shot.");
+        }
+    }
+
     // Interpretador determinístico (multi-saída) primeiro; só cai no tradutor 1-saída
     // (fallback simples ou Ollama) quando o padrão dominante não é reconhecido.
     var interpreter = new DslBlockInterpreter();
-    var translator = new DslRuleTranslator(ollama, Log);
+    var translator = new DslRuleTranslator(ollama, Log, fewShot);
     var translations = new List<RuleTranslation>(mapper.Rules.Count);
     int rulesInterpreted = 0, rulesFallback = 0, rulesOllama = 0, rulesStub = 0;
 
@@ -710,22 +952,20 @@ string DetermineRoot(MapperVo m)
     return root ?? "nfeProc";
 }
 
-// Resolve o caminho do mapeador real: arg explícito, senão sobe da pasta do exe
-// procurando .claude/tmp/export/MAP_MQSERIES_SEND_ENV_TXT_XML_NFE.decrypted.xml.
+// Resolve o caminho do mapeador real: arg explícito (ignorando VALORES de flags,
+// ex.: a pasta após --rag), senão sobe da pasta do exe procurando
+// .claude/tmp/export/MAP_MQSERIES_SEND_ENV_TXT_XML_NFE.decrypted.xml.
 string? FindRealMapper()
 {
-    var explicitArg = args.FirstOrDefault(a => !a.StartsWith("--"));
+    var flagValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var flag in new[] { "--rag", "--mapper", "--xsd", "--txt", "--xml",
+                 "--excel", "--catalog", "--generate", "--debug-ref" })
+        if (FindArgAfter(flag) is { } v) flagValues.Add(v);
+
+    var explicitArg = args.FirstOrDefault(a => !a.StartsWith("--") && !flagValues.Contains(a));
     if (explicitArg is not null && File.Exists(explicitArg)) return explicitArg;
 
-    var dir = new DirectoryInfo(AppContext.BaseDirectory);
-    while (dir is not null)
-    {
-        var candidate = Path.Combine(dir.FullName,
-            ".claude", "tmp", "export", "MAP_MQSERIES_SEND_ENV_TXT_XML_NFE.decrypted.xml");
-        if (File.Exists(candidate)) return candidate;
-        dir = dir.Parent;
-    }
-    return explicitArg;
+    return FindMapperByClimb() ?? explicitArg;
 }
 
 // ══════════════════════════════════════════════════════════════════════════

--- a/ai/XslSynth/Synthesis/DslRuleTranslator.cs
+++ b/ai/XslSynth/Synthesis/DslRuleTranslator.cs
@@ -37,11 +37,14 @@ public sealed class DslRuleTranslator
 {
     private readonly OllamaClient? _ollama;
     private readonly Action<string> _log;
+    private readonly FewShotIndex? _fewShot;
 
-    public DslRuleTranslator(OllamaClient? ollama, Action<string>? log = null)
+    /// <param name="fewShot">Índice RAG few-shot opcional (P1). Null = prompt idêntico ao anterior.</param>
+    public DslRuleTranslator(OllamaClient? ollama, Action<string>? log = null, FewShotIndex? fewShot = null)
     {
         _ollama = ollama;
         _log = log ?? Console.WriteLine;
+        _fewShot = fewShot;
     }
 
     public bool OllamaEnabled => _ollama is not null;
@@ -77,7 +80,7 @@ public sealed class DslRuleTranslator
 
     // ── Prompt ──────────────────────────────────────────────────────────────
 
-    private static string BuildPrompt(MapperRule rule, string dsl)
+    private string BuildPrompt(MapperRule rule, string dsl)
     {
         var leaf = rule.TargetPath is { } p ? Xslt.Segments(p).LastOrDefault() ?? "valor" : "valor";
         var sb = new StringBuilder();
@@ -98,10 +101,50 @@ public sealed class DslRuleTranslator
         sb.AppendLine("    externo, SEM <xsl:stylesheet>, SEM explicação, SEM cercas de código.");
         sb.AppendLine("  • Namespace: xsl = http://www.w3.org/1999/XSL/Transform");
         sb.AppendLine();
+        AppendFewShot(sb, rule);
         sb.AppendLine($"Regra: {rule.Name}");
         sb.AppendLine("DSL:");
         sb.AppendLine(dsl);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Injeta a seção few-shot no prompt (RAG P1) — só quando um <see cref="FewShotIndex"/>
+    /// foi fornecido no construtor E há exemplos análogos ao padrão da regra. Exemplos podem
+    /// ser: par DSL→XSLT (verificado), fragmento de XSL REAL de produção (estilo) ou DSL
+    /// análoga sem alvo (mostrada por último, apenas como variação do padrão).
+    /// </summary>
+    private void AppendFewShot(StringBuilder sb, MapperRule rule)
+    {
+        var exemplos = _fewShot?.Retrieve(rule, k: 3);
+        if (exemplos is not { Count: > 0 }) return;
+
+        sb.AppendLine("Exemplos análogos do corpus real (siga o MESMO estilo XSLT):");
+        var n = 0;
+        foreach (var ex in exemplos)
+        {
+            n++;
+            var padrao = FewShotIndex.Rotulo(FewShotIndex.Primario(ex.Traits));
+            switch (ex)
+            {
+                case { Dsl: not null, Xslt: not null }:
+                    sb.AppendLine($"── Exemplo {n} (padrão {padrao}, DSL→XSLT verificado):");
+                    sb.AppendLine("DSL:");
+                    sb.AppendLine(ex.Dsl);
+                    sb.AppendLine("XSLT:");
+                    sb.AppendLine(ex.Xslt);
+                    break;
+                case { Xslt: not null }:
+                    sb.AppendLine($"── Exemplo {n} (padrão {padrao}, XSL real de produção {ex.Tipo} {ex.Versao} — estilo alvo):");
+                    sb.AppendLine(ex.Xslt);
+                    break;
+                default:
+                    sb.AppendLine($"── Exemplo {n} (padrão {padrao}, DSL análoga real — sem XSLT alvo conhecido):");
+                    sb.AppendLine(ex.Dsl!);
+                    break;
+            }
+        }
+        sb.AppendLine();
     }
 
     /// <summary>Extrai o XSLT da resposta do LLM (tira cercas ```; desembrulha stylesheet/folha).</summary>

--- a/ai/XslSynth/Synthesis/FewShotIndex.cs
+++ b/ai/XslSynth/Synthesis/FewShotIndex.cs
@@ -1,0 +1,412 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using XslSynth.Core;
+using XslSynth.Model;
+
+namespace XslSynth.Synthesis;
+
+/// <summary>
+/// Traços estruturais de uma regra DSL Sysmiddle (ou de um fragmento XSLT análogo).
+/// Espelham o LIMITE HONESTO do <see cref="DslBlockInterpreter"/>: os traços "difíceis"
+/// (<see cref="CompostaAnd"/>, <see cref="Else"/>, <see cref="Aninhada"/>,
+/// <see cref="TempNoBegin"/>) são exatamente os padrões que hoje viram stub.
+/// </summary>
+[Flags]
+public enum DslTraits
+{
+    None = 0,
+    Direta = 1,        // T.path = rhs; sem condicional
+    GuardedEmit = 2,   // if(IsNullOrEmpty(x) != True()) begin T.path = ... end
+    CompostaAnd = 4,   // condição composta com &&
+    Else = 8,          // bloco else
+    Aninhada = 16,     // if dentro de begin...end
+    TempNoBegin = 32   // atribuição a #.temp dentro do begin
+}
+
+/// <summary>
+/// Um exemplo recuperável do índice few-shot. Três formas possíveis:
+///   • PAR DSL→XSLT   (Dsl + Xslt) — o mais valioso para o prompt;
+///   • DSL análoga    (só Dsl)     — regra real do mesmo padrão, sem alvo conhecido;
+///   • ESTILO XSLT    (só Xslt)    — fragmento de XSL REAL de produção do corpus.
+/// </summary>
+public sealed record FewShotExample(
+    string Tipo,        // NFe | CTe | MDFe | NFSe | "-"
+    string Versao,      // 4.00, 3.10, 2.01… | "-"
+    DslTraits Traits,   // traços detectados
+    string? Dsl,        // DSL Sysmiddle de origem (quando houver)
+    string? Xslt,       // fragmento XSLT alvo/estilo (quando houver)
+    string Origem)      // arquivo de onde o exemplo veio
+{
+    /// <summary>Chave de indexação: tipo × versão × padrão-primário.</summary>
+    public string Chave => $"{Tipo}|{Versao}|{FewShotIndex.Rotulo(FewShotIndex.Primario(Traits))}";
+}
+
+/// <summary>
+/// Índice LEVE, em memória e 100% determinístico (sem embeddings, sem pacote novo)
+/// de exemplos few-shot para a tradução DSL→XSLT — o "P1: indexar o corpus G2KA"
+/// de docs/architecture/poc-excel-generator.md §5.
+///
+/// Fontes indexadas a partir de UMA pasta de corpus:
+///   1. <c>**/*.xsl</c> — XSLs REAIS de produção, classificados por tipo×versão
+///      (derivados do caminho, ex.: <c>xsl/NFe/4.00/…</c>) e por padrão XSLT
+///      (choose/otherwise = else; test com "and" = composta-&amp;&amp;; etc.).
+///      O corpus real NÃO traz pares DSL→XSLT em claro (o exportContext.data do
+///      Sysmiddle é criptografado) — estes fragmentos entram como ESTILO.
+///   2. <c>**/*.decrypted.xml</c> — MapperVOs descriptografados: cada regra DSL é
+///      classificada por traço; as que o <see cref="DslBlockInterpreter"/> resolve
+///      geram PARES DSL→XSLT verificados (compilam); as difíceis entram como DSL
+///      análoga (ajudam o LLM a ver variações reais do padrão).
+///
+/// Recuperação: dado um <see cref="MapperRule"/>, retorna até K exemplos ranqueados
+/// por sobreposição de traços + similaridade lexical (Jaccard de tokens) +
+/// preferência por pares e por tipo/versão. Determinismo é virtude: mesma entrada,
+/// mesmos exemplos, sempre.
+/// </summary>
+public sealed class FewShotIndex
+{
+    private const int MaxSnippetChars = 700;  // fragmento de estilo maior que isso vira ruído no prompt
+    private const int MaxPorChave = 12;       // teto por chave (índice leve por construção)
+
+    private readonly List<FewShotExample> _exemplos;
+
+    private FewShotIndex(List<FewShotExample> exemplos) => _exemplos = exemplos;
+
+    public int Count => _exemplos.Count;
+
+    /// <summary>Contagem de exemplos por chave (tipo|versão|padrão), ordenada — p/ --rag-stats.</summary>
+    public IReadOnlyList<(string Chave, int Total, int Pares, int SoDsl, int SoXslt)> Stats()
+        => _exemplos
+            .GroupBy(e => e.Chave)
+            .Select(g => (g.Key, g.Count(),
+                g.Count(e => e.Dsl is not null && e.Xslt is not null),
+                g.Count(e => e.Dsl is not null && e.Xslt is null),
+                g.Count(e => e.Dsl is null && e.Xslt is not null)))
+            .OrderBy(t => t.Key, StringComparer.Ordinal)
+            .ToList();
+
+    // ── Construção ──────────────────────────────────────────────────────────
+
+    /// <summary>Constrói o índice varrendo a pasta de corpus (xsl + mapeadores descriptografados).</summary>
+    public static FewShotIndex Build(string corpusDir, Action<string>? log = null)
+    {
+        var exemplos = new List<FewShotExample>();
+        var vistos = new HashSet<string>(StringComparer.Ordinal); // dedupe por conteúdo normalizado
+        var porChave = new Dictionary<string, int>(StringComparer.Ordinal);
+        int xslLidos = 0, xslIlegiveis = 0, mappersLidos = 0;
+
+        // 1. XSLs reais (estilo), em ordem determinística de caminho.
+        foreach (var path in Directory.EnumerateFiles(corpusDir, "*.xsl", SearchOption.AllDirectories)
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            XDocument doc;
+            try { doc = XDocument.Load(path); xslLidos++; }
+            catch { xslIlegiveis++; continue; }
+
+            var (tipo, versao) = TipoVersaoDoCaminho(corpusDir, path);
+            if (doc.Root is not null)
+                ColetaSnippets(doc.Root, tipo, versao, Path.GetFileName(path), exemplos, vistos, porChave);
+        }
+
+        // 2. MapperVOs descriptografados (DSL real; pares quando o interpretador resolve).
+        var interpreter = new DslBlockInterpreter();
+        foreach (var path in Directory.EnumerateFiles(corpusDir, "*.decrypted.xml", SearchOption.AllDirectories)
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            MapperVo mapper;
+            try { mapper = new RealMapperParser().ParseFile(path); mappersLidos++; }
+            catch (Exception ex) { log?.Invoke($"[rag] mapeador ilegível '{Path.GetFileName(path)}': {ex.Message}"); continue; }
+
+            IndexaMapper(mapper, Path.GetFileName(path), interpreter, exemplos, vistos, porChave);
+        }
+
+        log?.Invoke($"[rag] índice: {exemplos.Count} exemplos ({xslLidos} XSL lidos, {xslIlegiveis} ilegíveis, "
+                    + $"{mappersLidos} mapeador(es) DSL).");
+        return new FewShotIndex(exemplos);
+    }
+
+    /// <summary>Acrescenta as regras de um MapperVO já carregado (ex.: o mapeador do fluxo real).</summary>
+    public void AddMapper(MapperVo mapper, string origem)
+    {
+        var vistos = new HashSet<string>(_exemplos.Select(e => Normaliza(e.Dsl ?? e.Xslt ?? "")), StringComparer.Ordinal);
+        var porChave = _exemplos.GroupBy(e => e.Chave).ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        IndexaMapper(mapper, origem, new DslBlockInterpreter(), _exemplos, vistos, porChave);
+    }
+
+    private static void IndexaMapper(MapperVo mapper, string origem, DslBlockInterpreter interpreter,
+        List<FewShotExample> exemplos, HashSet<string> vistos, Dictionary<string, int> porChave)
+    {
+        // Tipo/versão do mapeador real: convenção de nome (…_NFE → NFe 4.00 é o corrente).
+        var tipo = TipoDoNome(mapper.Name ?? origem);
+        foreach (var rule in mapper.Rules)
+        {
+            var dsl = StripMarkers(rule.ContentValue ?? "");
+            if (dsl.Length == 0) continue;
+            var traits = ClassifyTraits(dsl);
+            if (traits == DslTraits.None) continue;
+
+            // Par verificado SÓ para regras fáceis (guarded-emit/direta): nelas o
+            // interpretador cobre a DSL inteira. Em regras difíceis ele consome só
+            // os blocos que reconhece — indexar esse parcial como "par" ensinaria
+            // o LLM a IGNORAR o else/&& (tradução errada com cara de verificada).
+            const DslTraits dificeis = DslTraits.CompostaAnd | DslTraits.Else
+                                       | DslTraits.Aninhada | DslTraits.TempNoBegin;
+            string? xslt = null;
+            if ((traits & dificeis) == 0)
+            {
+                var emissoes = interpreter.Interpret(rule);
+                if (emissoes.Count > 0)
+                    xslt = string.Join("\n", emissoes.Select(e => e.BodyXsl));
+                if (xslt is { Length: > MaxSnippetChars }) xslt = null; // par gigante não cabe no prompt
+            }
+
+            Adiciona(new FewShotExample(tipo, "4.00", traits, dsl, xslt, origem), exemplos, vistos, porChave);
+        }
+    }
+
+    private static void Adiciona(FewShotExample ex, List<FewShotExample> exemplos,
+        HashSet<string> vistos, Dictionary<string, int> porChave)
+    {
+        if (ex.Dsl is { Length: > MaxSnippetChars }) return;
+        var norm = Normaliza(ex.Dsl ?? ex.Xslt ?? "");
+        if (norm.Length == 0 || !vistos.Add(norm)) return;
+
+        var n = porChave.GetValueOrDefault(ex.Chave);
+        if (n >= MaxPorChave) return;
+        porChave[ex.Chave] = n + 1;
+        exemplos.Add(ex);
+    }
+
+    // ── Classificação da DSL (regex — mesmas noções do DslBlockInterpreter) ──
+
+    // if(IsNullOrEmpty(x) != True()) begin T.path = rhs; end  (padrão dominante)
+    private static readonly Regex GuardedEmitRx = new(
+        @"if\s*\(\s*IsNullOrEmpty\(\s*(#\.[A-Za-z0-9_]+|I\.[A-Za-z0-9_/]+)\s*\)\s*!=\s*True\(\)\s*\)\s*" +
+        @"begin\s*T\.([A-Za-z0-9_/]+)\s*=\s*(.+?)\s*;\s*end",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex DirectEmitRx =
+        new(@"T\.[A-Za-z0-9_/]+\s*=\s*.+?;", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex ElseRx = new(@"\belse\b", RegexOptions.Compiled);
+    private static readonly Regex IfRx = new(@"\bif\s*\(", RegexOptions.Compiled);
+
+    // if( … ) dentro de um begin ainda não fechado por end (aproximação suficiente p/ classificar).
+    private static readonly Regex IfDentroDeBeginRx =
+        new(@"\bbegin\b(?:(?!\bend\b)[\s\S])*?\bif\s*\(", RegexOptions.Compiled);
+
+    // #.temp = … dentro de um begin ainda não fechado por end.
+    private static readonly Regex TempDentroDeBeginRx =
+        new(@"\bbegin\b(?:(?!\bend\b)[\s\S])*?#\.[A-Za-z0-9_]+\s*=", RegexOptions.Compiled);
+
+    /// <summary>Detecta os traços estruturais de uma DSL (pode combinar vários).</summary>
+    public static DslTraits ClassifyTraits(string? dsl)
+    {
+        var code = StripMarkers(dsl ?? "");
+        if (code.Length == 0) return DslTraits.None;
+
+        var t = DslTraits.None;
+        if (code.Contains("&&", StringComparison.Ordinal)) t |= DslTraits.CompostaAnd;
+        if (ElseRx.IsMatch(code)) t |= DslTraits.Else;
+        if (IfDentroDeBeginRx.IsMatch(code)) t |= DslTraits.Aninhada;
+        if (TempDentroDeBeginRx.IsMatch(code)) t |= DslTraits.TempNoBegin;
+        if (GuardedEmitRx.IsMatch(code)) t |= DslTraits.GuardedEmit;
+        if (t == DslTraits.None && !IfRx.IsMatch(code) && DirectEmitRx.IsMatch(code)) t |= DslTraits.Direta;
+        return t;
+    }
+
+    /// <summary>Traço primário (para chave/estatística): o mais "difícil" presente.</summary>
+    public static DslTraits Primario(DslTraits t)
+    {
+        foreach (var p in new[] { DslTraits.Else, DslTraits.Aninhada, DslTraits.CompostaAnd,
+                     DslTraits.TempNoBegin, DslTraits.GuardedEmit, DslTraits.Direta })
+            if (t.HasFlag(p)) return p;
+        return DslTraits.None;
+    }
+
+    /// <summary>Rótulo kebab-case do padrão (para chave e relatórios).</summary>
+    public static string Rotulo(DslTraits primario) => primario switch
+    {
+        DslTraits.Else => "else",
+        DslTraits.Aninhada => "aninhada",
+        DslTraits.CompostaAnd => "composta-&&",
+        DslTraits.TempNoBegin => "temp-no-begin",
+        DslTraits.GuardedEmit => "guarded-emit",
+        DslTraits.Direta => "direta",
+        _ => "desconhecido"
+    };
+
+    // ── Classificação de fragmentos XSLT (espelho dos traços da DSL) ─────────
+
+    private static void ColetaSnippets(XElement root, string tipo, string versao, string origem,
+        List<FewShotExample> exemplos, HashSet<string> vistos, Dictionary<string, int> porChave)
+    {
+        // Caminhada top-down: indexa o elemento interessante mais EXTERNO e não desce
+        // nele de novo (evita contar o mesmo choose N vezes pelos filhos).
+        foreach (var el in root.Elements())
+        {
+            var traits = TraitsDoXslt(el);
+            if (traits != DslTraits.None)
+            {
+                var texto = el.ToString(SaveOptions.None).Trim();
+                if (texto.Length <= MaxSnippetChars)
+                {
+                    Adiciona(new FewShotExample(tipo, versao, traits, null, texto, origem),
+                        exemplos, vistos, porChave);
+                    continue; // não desce: o snippet externo já carrega os internos
+                }
+                // grande demais: desce em busca de um fragmento interno que caiba
+            }
+            ColetaSnippets(el, tipo, versao, origem, exemplos, vistos, porChave);
+        }
+    }
+
+    /// <summary>Traços de um elemento XSLT: choose/otherwise = else; test com and = composta; etc.</summary>
+    private static DslTraits TraitsDoXslt(XElement el)
+    {
+        if (el.Name != Xslt.Ns + "if" && el.Name != Xslt.Ns + "choose") return DslTraits.None;
+
+        var t = DslTraits.None;
+        if (el.Name == Xslt.Ns + "choose" && el.Elements(Xslt.Ns + "otherwise").Any())
+            t |= DslTraits.Else;
+
+        var testes = el.DescendantsAndSelf()
+            .Where(d => d.Name == Xslt.Ns + "if" || d.Name == Xslt.Ns + "when")
+            .Select(d => d.Attribute("test")?.Value ?? "");
+        foreach (var teste in testes)
+        {
+            if (Regex.IsMatch(teste, @"\band\b")) t |= DslTraits.CompostaAnd;
+            if (teste.Contains("!=''", StringComparison.Ordinal) ||
+                teste.Contains("!= ''", StringComparison.Ordinal)) t |= DslTraits.GuardedEmit;
+        }
+
+        if (el.Elements().SelectMany(c => c.DescendantsAndSelf())
+                .Any(d => d.Name == Xslt.Ns + "if" || d.Name == Xslt.Ns + "choose"))
+            t |= DslTraits.Aninhada;
+        if (el.Descendants(Xslt.Ns + "variable").Any())
+            t |= DslTraits.TempNoBegin;
+
+        // um <xsl:if test="x!=''"> puro e sem nada difícil não vale indexar como estilo
+        // (o DslBlockInterpreter já cobre guarded-emit sem ajuda do LLM)
+        return t is DslTraits.GuardedEmit or DslTraits.None ? DslTraits.None : t;
+    }
+
+    // ── Recuperação ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Recupera até <paramref name="k"/> exemplos análogos à regra: mesma família de
+    /// traços, ranqueados por sobreposição de traços, presença de par DSL→XSLT,
+    /// similaridade lexical (Jaccard) e afinidade de tipo/versão. Determinístico.
+    /// </summary>
+    public IReadOnlyList<FewShotExample> Retrieve(MapperRule rule, int k = 3,
+        string tipo = "NFe", string versao = "4.00")
+    {
+        var dsl = StripMarkers(rule.ContentValue ?? "");
+        var traits = ClassifyTraits(dsl);
+        if (traits == DslTraits.None || k <= 0) return Array.Empty<FewShotExample>();
+
+        var tokens = Tokens(dsl);
+        var normSelf = Normaliza(dsl);
+
+        return _exemplos
+            .Select((ex, i) => (Ex: ex, Ordem: i, Score: Score(ex, traits, tokens, tipo, versao)))
+            .Where(c => c.Score > 0 && Normaliza(c.Ex.Dsl ?? "") != normSelf) // exclui a própria regra
+            .OrderByDescending(c => c.Score)
+            .ThenBy(c => c.Ordem) // desempate determinístico pela ordem de indexação
+            .Take(k)
+            .Select(c => c.Ex)
+            .ToList();
+    }
+
+    private static double Score(FewShotExample ex, DslTraits ruleTraits,
+        IReadOnlySet<string> ruleTokens, string tipo, string versao)
+    {
+        var overlap = CountBits(ex.Traits & ruleTraits);
+        if (overlap == 0) return 0;
+
+        double score = overlap * 10;
+        if (ex.Dsl is not null && ex.Xslt is not null) score += 6; // par completo vale mais
+        else if (ex.Xslt is not null) score += 3;                  // estilo XSLT real
+        if (string.Equals(ex.Tipo, tipo, StringComparison.OrdinalIgnoreCase)) score += 2;
+        if (string.Equals(ex.Versao, versao, StringComparison.OrdinalIgnoreCase)) score += 1;
+        if (ex.Dsl is not null && ruleTokens.Count > 0)
+            score += 5 * Jaccard(ruleTokens, Tokens(ex.Dsl));
+        return score;
+    }
+
+    private static int CountBits(DslTraits t)
+    {
+        int v = (int)t, n = 0;
+        while (v != 0) { n += v & 1; v >>= 1; }
+        return n;
+    }
+
+    // ── Similaridade lexical (determinística, sem embeddings) ────────────────
+
+    private static readonly Regex TokenRx = new(@"[A-Za-z][A-Za-z0-9_]{2,}", RegexOptions.Compiled);
+    private static readonly HashSet<string> StopWords = new(StringComparer.OrdinalIgnoreCase)
+        { "begin", "end", "else", "true", "isnullorempty", "linha" };
+
+    private static HashSet<string> Tokens(string dsl)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match m in TokenRx.Matches(dsl))
+            if (!StopWords.Contains(m.Value)) set.Add(m.Value);
+        return set;
+    }
+
+    private static double Jaccard(IReadOnlySet<string> a, IReadOnlySet<string> b)
+    {
+        if (a.Count == 0 || b.Count == 0) return 0;
+        var inter = a.Count(b.Contains);
+        return (double)inter / (a.Count + b.Count - inter);
+    }
+
+    // ── Tipo × versão a partir do caminho/nome ───────────────────────────────
+
+    private static readonly string[] Tipos = ["NFe", "CTe", "MDFe", "NFSe"];
+
+    private static (string Tipo, string Versao) TipoVersaoDoCaminho(string corpusDir, string path)
+    {
+        var rel = Path.GetRelativePath(corpusDir, path);
+        var partes = rel.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        for (var i = 0; i < partes.Length; i++)
+        {
+            var tipo = Tipos.FirstOrDefault(t => string.Equals(t, partes[i], StringComparison.OrdinalIgnoreCase));
+            if (tipo is null) continue;
+            var versao = i + 2 < partes.Length && Regex.IsMatch(partes[i + 1], @"^\d")
+                ? NormalizaVersao(partes[i + 1])
+                : VersaoDoNome(partes[^1]);
+            return (tipo, versao);
+        }
+        return (TipoDoNome(partes[^1]), VersaoDoNome(partes[^1]));
+    }
+
+    private static string TipoDoNome(string nome)
+    {
+        // Ordem do mais específico para o mais genérico (NFSe/MDFe antes de NFe/CTe).
+        foreach (var t in new[] { "NFSe", "MDFe", "CTe", "NFe" })
+            if (nome.Contains(t, StringComparison.OrdinalIgnoreCase)) return t;
+        return "-";
+    }
+
+    private static string VersaoDoNome(string nome)
+    {
+        var m = Regex.Match(nome, @"(\d+\.\d{2}[a-z]?)");
+        return m.Success ? NormalizaVersao(m.Groups[1].Value) : "-";
+    }
+
+    /// <summary>Normaliza variações do corpus: "4.000" → "4.00".</summary>
+    private static string NormalizaVersao(string v)
+    {
+        var m = Regex.Match(v, @"^(\d+\.\d{2})0+$");
+        return m.Success ? m.Groups[1].Value : v;
+    }
+
+    // ── Utilitários ──────────────────────────────────────────────────────────
+
+    private static string StripMarkers(string dsl) =>
+        dsl.Replace("%beginRuleContent;", "").Replace("%endRuleContent;", "").Trim();
+
+    private static string Normaliza(string s) => Regex.Replace(s, @"\s+", " ").Trim();
+}

--- a/docs/architecture/multi-client-layout-generalization.md
+++ b/docs/architecture/multi-client-layout-generalization.md
@@ -204,8 +204,8 @@ justifica a omissão" — rastreabilidade da decisão, não comparação posicio
 | Fase | Entregável | Dono | Depende de |
 |---|---|---|---|
 | G0 | ✅ **Concluído (2026-07-15, arquiteto inline)** — Investigar `LayoutLineSizeConfiguration` vs `Layout.LimitOfCaracters`. Achado: `LimitOfCaracters=0` real para ao menos 1 dos 9 GUIDs (evidência em XML decriptado); a allowlist compensa dado sujo conhecido, não é redundante (§4.2) | Aria | nada |
-| G1 | Implementar resolução mesclada (`LimitOfCaracters` > 0 → override da allowlist → null) e substituir os ~20 literais `600` no núcleo (`Services/`) por essa função única | Dex | G0 ✅ |
-| G2 | `RootTreeBuilder`/`NfeGabaritoMiner` recebem tamanho de linha como parâmetro, não constante | Dex | nada — independente de G1 |
+| G1 | ✅ **Concluído (2026-07-15, Trilha B — commit `d096364`, merged PR #3, auditado pela Aria):** `Models/Configuration/LineLengthResolver.cs` (precedência `LimitOfCaracters>0` → allowlist → null; `LegacyDefaultLineLength=600` é o único literal remanescente); 3 gates de allowlist migrados (`ParseController`, `MonitoringController`, `LayoutValidationService`); fallback de parse `? limit : 600` corrigido para `? limit : 0` (um 600 fabricado venceria a allowlist e quebraria os layouts de 2500); literais residuais só em `Services/Generation/**` (fora do escopo, follow-up registrado) | Dex | G0 ✅ |
+| G2 | ✅ **Concluído (2026-07-15, Trilha B — mesmo commit):** `RootTreeBuilder.Build`/`NfeGabarito.Load` com parâmetro `lineLength` (default 600 p/ CLI; guard `ArgumentOutOfRangeException` p/ ≤0); valor real virá de `Layout.LimitOfCaracters` via `LineLengthResolver` na integração C1 | Dex | nada |
 | G3 | `LayoutSpecExtractor` — 2º adaptador de ingestão de spec via Connect Us/LowCodeRunner (Fonte B, §4.3) | Lia | runner em modo lote (`poc-excel-generator.md` §11 item 2) |
 | G4 | Generalizar `MapperEmissionGuide` de "8 campos conhecidos" para motor de condicionalidade genérico (§4.4) | Lia | G3 (precisa de mais mapeadores reais para generalizar o padrão) |
 | G5 | Corrigir a redação da pendência #1 em `poc-excel-generator.md` §11 (feito nesta sessão, ver §7 abaixo) | Aria | — |

--- a/docs/architecture/poc-excel-generator.md
+++ b/docs/architecture/poc-excel-generator.md
@@ -488,7 +488,12 @@ complexo). Gate: **set-diff do DOCUMENTO COMPLETO = 0/0/0** (hoje: FALTA=18, SOB
 > CNPJ-raiz(8)+'_'+IdOverlay; (d) grupo Conv51/ST = ramo else `'0,00'` pt-BR; (e) `dadosAdic/infCpl` clonado do
 > `infAdic/infCpl` (garante igualdade); (f) **`bloco290`**: as larguras dos `PadRight` IGUALAM as dos campos LINHA000
 > → `substring(concat(campo,espaços),1,n)` por segmento; 24 segmentos, 337 chars, **char a char** com o gabarito.
-> Únicas difs byte restantes = declaração XML + ordem de atributos `Id`/`versao` (cosméticas). O mapeamento
+> ~~Únicas difs byte restantes = declaração XML + ordem de atributos `Id`/`versao` (cosméticas).~~
+> **Fechado (2026-07-15, fase B3 da Trilha B):** havia na verdade **três** difs cosméticas — declaração XML,
+> ordem `Id`/`versao` e uma 3ª não registrada aqui (o serializador do mapeador nunca emite tag self-closing:
+> `<B2BDirectory></B2BDirectory>`, não `<B2BDirectory/>`). Todas fechadas via serialização fiel opt-in
+> (`XsltApplier.Apply(..., fielAoGabarito: true)`, usada pelo fluxo `--generate`): `cmp` retorna **IDÊNTICO
+> byte a byte** ao gabarito (4245 bytes, linha única). O mapeamento
 > input→slug veio da Lia (R4-followup). XSD do `<NFe>` continua VÁLIDO.
 
 ### 8.3 Semântica das funções DSL — fonte da verdade (2026-07-13)
@@ -675,12 +680,13 @@ Artefatos: `.csproj` (PlatformTarget x86) + `Functions/SysMiddle.ConnectUs.Funct
 | PoC-2: `NfeLeiauteCatalog` (#XML→XPath) | ✅ | §4/§7.8 — 62 Alta/400 Média/166 não-resolvidos, cobertura 71,5% |
 | Etapa A (PoC-3): `RootTreeBuilder`+`XslGenerator`, diff==0 no `<infNFe>` | ✅ | §7.9 — set-diff FALTA=0/SOBRA=0/TEXTO=0, XSD válido |
 | Etapa B1: `MapperEmissionGuide` (máscara das 8 SOBRAs de `retTrib`/`cobr`) | ✅ | §7.9 |
-| Etapa B2: `DadosAdicEmitter`+`Bloco290Emitter` (envelope+extensão FIAT) | ✅ | §8.2 — **documento COMPLETO diff==0** (só cosmético restante) |
+| Etapa B2: `DadosAdicEmitter`+`Bloco290Emitter` (envelope+extensão FIAT) | ✅ | §8.2 — **documento COMPLETO diff==0** |
+| **Trilha B (2026-07-15): B1 resolver de linha no núcleo · B2 `lineLength` paramétrico · B3 byte-idêntico** | ✅ | commit `d096364` (merged PR #3) — `LineLengthResolver` + gates de allowlist; §8.2 (cosmético fechado, `cmp` idêntico) |
 | **LowCodeRunner: bootstrap + licença OFFLINE + execução do mapeador** | ✅ | §9.4 — muro de licença (o bloqueio histórico do projeto) caiu |
 | **LowCodeRunner: saída COMPLETA (fim do "envelope-only")** — fix de bitness x86 | ✅ | §9.5 — reproduz o `gabarito-esperado-env.xml` **byte-a-byte** (só 1 espaço na decl. XML) |
 
 **Leitura:** a cadeia determinística Excel→TCL→ROOT→XSL está **provada ponta-a-ponta contra um gabarito real**
-(reproduz `enviNFe` completo, byte a byte, exceto ordem de atributos), e o runner Sysmiddle — que travava o
+(reproduz `enviNFe` completo, **byte a byte absoluto** — cosmético fechado na fase B3, 2026-07-15), e o runner Sysmiddle — que travava o
 projeto desde o início — **valida licença e executa sem VPN/host**. Estes dois fatos, juntos, são o que muda o
 projeto de "PoC de viabilidade" para "motor pronto para generalizar".
 
@@ -692,7 +698,7 @@ projeto de "PoC de viabilidade" para "motor pronto para generalizar".
 | 2 | **Modo lote do runner** (varrer `Examples/LAY_*`, gravar pares input→XML em `.claude/tmp/gabaritos/`) | Runner | Dex | #1 |
 | 3 | **Generalização além do par único**: variantes ICMS10/20/30/40/51/60/70/90/CSOSN, grupos especializados (veículos/ANVISA/ANP/combustível/DI), 2ª aba do Excel (Layout-Receb = retorno), outras versões/NT | Cobertura | Lia (domínio) + Dex | #2 (precisa de gabaritos novos p/ testar) |
 | 4 | **P0 — Catálogo GUID→XPath** (destrava os 237 LinkMappings do XslSynth, cruzamento com o catálogo Excel) | Roadmap P0 | Lia | runner funcional — **já destravado**, ainda não iniciado |
-| 5 | Diffs cosméticos residuais (declaração XML, ordem de atributos `Id`/`versao`) | Etapa B2 | Dex | nada — trivial, só não foi fechado |
+| 5 | ~~Diffs cosméticos residuais~~ — **fechado (2026-07-15, Trilha B fase B3):** eram 3 (declaração XML, ordem `Id`/`versao`, self-closing vs par aberto/fechado); serialização fiel opt-in no `XsltApplier` + `@Id` como atributo literal AVT no XSL; verificado por reexecução (`cmp` = idêntico). Candidato a teste de regressão no gate C2 (Quinn). | Etapa B2 | ~~Dex~~ | **fechado** |
 | 6 | ~~Assinatura digital (`<Signature>`)~~ — **fechado (2026-07-15, usuário): fora do escopo PERMANENTE desta aplicação**, não é um item de PoC a completar depois. Quem assina o documento é o **e-forms**; esta aplicação cobre apenas geração de TCL/XSL/XSLT + validação posicional do TXT. Não faz parte de nenhuma fase futura. | — | — | **fechado** |
 | 7 | P1 — RAG few-shot sobre corpus G2KA (9 regras difíceis do `DslBlockInterpreter`: `&&`, `else`, aninhamento) | Roadmap P1 | Lia | nada — não iniciado |
 | 8 | **Integração no runtime de produção**: hoje tudo vive em `ai/XslSynth` (fora do build da API) + `tools/LowCodeRunner` (exe separado); nada plugado em `Services/LowCode/LowCodeTransformationService` ou exposto por endpoint — **confirmado pelo usuário (2026-07-15): essa decisão só faz sentido depois que #3 provar que o motor generaliza, não só o par único.** Não é tarefa desta rodada. | Arquitetura | Aria (decide) → Dex (implementa) | #3 (generalizar antes de promover) |


### PR DESCRIPTION
Adiciona detecção de anomalias e índice few-shot

Foram implementados novos componentes para detecção de anomalias em documentos posicionais, utilizando análise estatística (z-score) das features extraídas de históricos do mesmo layout. Inclui interface, serviço, modelo de resultado e centralização da extração de features. Adiciona índice determinístico de exemplos few-shot para tradução DSL→XSLT. Atualiza MEMORY.md para refletir as mudanças e ausência de pares few-shot no corpus.