### PR TITLE
fix(seguranca): auditoria e enforcement por papel nos endpoints privilegiados

### DIFF
--- a/Controllers/DataGenerationController.cs
+++ b/Controllers/DataGenerationController.cs
@@ -7,6 +7,7 @@ using LayoutParserApi.Services.Generation.TxtGenerator;
 using LayoutParserApi.Services.Generation.TxtGenerator.Enum;
 using LayoutParserApi.Services.Interfaces;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using System.IO.Compression;
@@ -42,6 +43,8 @@ namespace LayoutParserApi.Controllers
             _logger = logger;
         }
 
+        // Issue #32: geração de dados sintéticos é operação privilegiada — restrita ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpPost("generate-synthetic")]
         public async Task<IActionResult> GenerateSyntheticData(
             IFormFile layoutFile,
@@ -146,6 +149,8 @@ namespace LayoutParserApi.Controllers
             }
         }
 
+        // Issue #32: idem generate-synthetic — restrito ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpPost("process-excel")]
         public async Task<IActionResult> ProcessExcel(IFormFile excelFile)
         {
@@ -378,6 +383,8 @@ namespace LayoutParserApi.Controllers
             public List<object> Details { get; set; } = new List<object>();
         }
 
+        // Issue #32: idem generate-synthetic — restrito ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpPost("generate-synthetic-zip")]
         public async Task<IActionResult> GenerateSyntheticDataZip(IFormFile layoutFile, IFormFile excelFile = null, int numberOfRecords = 2, int numberOfFiles = 1, string generationMode = "Random")
         {

--- a/Controllers/DataGenerationController.cs
+++ b/Controllers/DataGenerationController.cs
@@ -1,5 +1,6 @@
 using LayoutParserApi.Models.Entities;
 using LayoutParserApi.Models.Generation;
+using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Services.Generation.Implementations;
 using LayoutParserApi.Services.Generation.Interfaces;
 using LayoutParserApi.Services.Generation.TxtGenerator;
@@ -15,6 +16,7 @@ namespace LayoutParserApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [ServiceFilter(typeof(AuditActionFilter))]
     public class DataGenerationController : ControllerBase
     {
         private readonly ISyntheticDataGeneratorService _dataGenerator;

--- a/Controllers/LogsController.cs
+++ b/Controllers/LogsController.cs
@@ -5,6 +5,7 @@ using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Services.Interfaces;
 using LayoutParserApi.Services.Logging;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Serilog.Context;
@@ -93,6 +94,9 @@ namespace LayoutParserApi.Controllers
         /// <summary>
         /// Leitura unificada e paginada dos 3 arquivos de log do ecossistema (Api/Lib/Decrypt).
         /// </summary>
+        // Issue #32: leitura de log é operação sensível (pode expor dado de outros usuários/
+        // tenants) — restrita ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpGet]
         public async Task<IActionResult> GetLogs([FromQuery] UnifiedLogFilter filter)
         {

--- a/Controllers/LogsController.cs
+++ b/Controllers/LogsController.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 
 using LayoutParserApi.Models.Logging;
+using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Services.Interfaces;
 using LayoutParserApi.Services.Logging;
 
@@ -20,6 +21,7 @@ namespace LayoutParserApi.Controllers
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
+    [ServiceFilter(typeof(AuditActionFilter))]
     public class LogsController : ControllerBase
     {
         // Níveis aceitos pelo endpoint de ingestão (Tarefa 1) — mapeiam 1:1 pros métodos do ILogger.

--- a/Controllers/MapperDatabaseController.cs
+++ b/Controllers/MapperDatabaseController.cs
@@ -1,6 +1,7 @@
 using LayoutParserApi.Services.Database;
 using LayoutParserApi.Services.Interfaces;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LayoutParserApi.Controllers
@@ -193,6 +194,9 @@ namespace LayoutParserApi.Controllers
         /// <summary>
         /// Atualiza o cache de mapeadores com dados do banco
         /// </summary>
+        // Issue #32: rebuild de cache é operação operacional, não de negócio — restrita ao
+        // papel "operador" (mais permissivo que "admin", coerente com a tabela de decisão).
+        [Authorize(Roles = "operador")]
         [HttpPost("refresh-cache")]
         public async Task<IActionResult> RefreshCache()
         {

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -3,6 +3,7 @@ using LayoutParserApi.Services.XmlAnalysis;
 using LayoutParserApi.Models;
 using LayoutParserApi.Services.Transformation.LowCode;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using LayoutParserApi.Services.XmlAnalysis.Models;
@@ -153,6 +154,9 @@ namespace LayoutParserApi.Controllers
         /// (casos-limite de zero candidatos, falha parcial, timeout etc.) em
         /// docs/architecture/multi-candidato-e-diagnostico-ia-contrato.md (Gap 1).
         /// </summary>
+        // Issue #32: dispara processos externos (runner x86) e é operação privilegiada —
+        // restrita ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpPost("execute-candidates")]
         public async Task<IActionResult> ExecuteTransformationCandidates([FromBody] TransformationRequest request)
         {
@@ -527,6 +531,8 @@ namespace LayoutParserApi.Controllers
         /// <summary>
         /// Executa transformação usando o motor low-code (SysMiddle) via runner x86.
         /// </summary>
+        // Issue #32: idem execute-candidates — restrito ao papel "admin".
+        [Authorize(Roles = "admin")]
         [HttpPost("execute-lowcode")]
         public async Task<IActionResult> ExecuteLowCode([FromBody] LowCodeTransformationRequest request)
         {

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using LayoutParserApi.Services.XmlAnalysis.Models;
 using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Models.Database;
 using LayoutParserApi.Models.Transformation;
 
@@ -23,6 +24,7 @@ namespace LayoutParserApi.Controllers
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
+    [ServiceFilter(typeof(AuditActionFilter))]
     public class TransformationExecutionController : ControllerBase
     {
         private readonly ILogger<TransformationExecutionController> _logger;

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,9 @@ using LayoutParserApi.Services.Database;
 using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Services.Health;
 using LayoutParserApi.Services.Generation.Implementations;
+using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Generation.TxtGenerator;
+using LayoutParserApi.Services.Generation.TxtGenerator.Parsers;
 using LayoutParserApi.Services.Implementations;
 using LayoutParserApi.Services.Interfaces;
 using LayoutParserApi.Services.Learning;
@@ -390,6 +393,18 @@ try
 
     // Transformation Services
     builder.Services.AddScoped<IMapperTransformationService, MapperTransformationService>();
+
+    // Generation Services (issue #33 — faltavam no DI; endpoints de
+    // DataGenerationController quebravam em runtime por falta de resolução).
+    builder.Services.AddScoped<ISyntheticDataGeneratorService, SyntheticDataGeneratorService>();
+    builder.Services.AddScoped<IExcelDataProcessor, ExcelDataProcessor>();
+    builder.Services.AddScoped<ILayoutAnalysisService, LayoutAnalysisService>();
+    // Dependências internas do TxtFileGeneratorFactory (resolvidas via IServiceProvider
+    // dentro da factory) — sem registro, o Create() do factory lançava em runtime.
+    builder.Services.AddScoped<XmlLayoutParser>();
+    builder.Services.AddScoped<ExcelRulesParser>();
+    builder.Services.AddScoped<LayoutParserApi.Services.Generation.TxtGenerator.Validators.LayoutValidator>();
+    builder.Services.AddScoped<TxtFileGeneratorFactory>();
 
     // Learning Services
     builder.Services.AddScoped<ExampleLearningService>();

--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,7 @@ using LayoutParserApi.Services.Validation;
 using LayoutParserApi.Services.Transformation.LowCode;
 using LayoutParserApi.Services.XmlAnalysis;
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http.Features;
@@ -161,6 +162,16 @@ try
     // Add services to the container.
     // Configurar opções JSON para não escapar caracteres XML/HTML
     // Isso preserva o XML intacto no JSON (não converte < para \u003C, etc.)
+    // ✅ Issue #32: enforcement por papel em cima da identidade que o TrustedIdentityMiddleware já
+    // populava em HttpContext.User (pronto desde o P2, mas sem consumidor até agora). O esquema
+    // "TrustedHeader" não autentica nada por conta própria — só formaliza o que o middleware
+    // preencheu para o AuthorizationMiddleware conseguir desafiar (401)/negar (403) via
+    // [Authorize(Roles = "...")] nos controllers marcados.
+    builder.Services.AddAuthentication(TrustedHeaderAuthenticationHandler.SchemeName)
+        .AddScheme<AuthenticationSchemeOptions, TrustedHeaderAuthenticationHandler>(
+            TrustedHeaderAuthenticationHandler.SchemeName, options => { });
+    builder.Services.AddAuthorization();
+
     builder.Services.AddControllers(options =>
         {
             // A porta de entrada da API é a REDE (a API só aceita o BFF, trava do @lp-devops) somada à
@@ -653,8 +664,11 @@ try
     // Only use HTTPS redirection if actually using HTTPS
     // app.UseHttpsRedirection();
 
-    // Remove Authorization if not needed - it can interfere with CORS preflight
-    // app.UseAuthorization();
+    // Issue #32: reativado. TrustedIdentityMiddleware (linha acima) já populou HttpContext.User;
+    // UseAuthorization roda depois de UseCors (evita interferir no preflight) e habilita os
+    // [Authorize(Roles = "...")] marcados nos controllers sensíveis.
+    app.UseAuthentication();
+    app.UseAuthorization();
 
     app.MapControllers();
 

--- a/Services/Filters/AuditActionFilter .cs
+++ b/Services/Filters/AuditActionFilter .cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace LayoutParserApi.Services.Filters
 {
-    public class AuditActionFilter : IActionFilter
+    public class AuditActionFilter : IActionFilter, IOrderedFilter
     {
         private readonly IAuditLogger _auditLogger;
         private readonly ICurrentUser _currentUser;
@@ -18,6 +18,17 @@ namespace LayoutParserApi.Services.Filters
             _auditLogger = auditLogger;
             _currentUser = currentUser;
         }
+
+        // ⚠️ Issue #31: o [ApiController] registra automaticamente um filtro interno
+        // (ModelStateInvalidFilterFactory) com Order = -3000 que curto-circuita a pipeline
+        // (seta context.Result = BadRequest) ANTES de qualquer outro ActionFilter rodar quando
+        // o ModelState é inválido. Com Order padrão (0), o AuditActionFilter nunca chegava a
+        // executar OnActionExecuting nesse caso — request malformada não gerava linha AUDIT.
+        // Fixamos Order abaixo de -3000 para que este filtro seja o PRIMEIRO da pipeline: ele
+        // roda antes do filtro de validação do model state e, mesmo que este curto-circuite
+        // depois, o pipeline de ActionFilter ainda chama OnActionExecuted dos filtros que já
+        // haviam entrado (unwind), então a auditoria também é registrada nesse caminho.
+        public int Order => int.MinValue;
 
         public void OnActionExecuting(ActionExecutingContext context)
         {

--- a/Services/Security/TrustedHeaderAuthenticationHandler.cs
+++ b/Services/Security/TrustedHeaderAuthenticationHandler.cs
@@ -1,0 +1,49 @@
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Security
+{
+    /// <summary>
+    /// Handler de autenticação mínimo que NÃO autentica nada por conta própria: apenas lê o
+    /// <see cref="HttpContext.User"/> já preenchido pelo <see cref="TrustedIdentityMiddleware"/>
+    /// (que roda antes, na pipeline) e o expõe ao <c>AuthorizationMiddleware</c>.
+    /// </summary>
+    /// <remarks>
+    /// Existe só porque <c>[Authorize(Roles = "...")]</c> (issue #32) precisa de um esquema de
+    /// autenticação registrado — sem ele, o <c>AuthorizationMiddleware</c> lança ao tentar
+    /// desafiar (401) ou negar (403) uma requisição, mesmo com <c>HttpContext.User</c> já
+    /// populado por fora. A fonte da verdade da identidade continua sendo exclusivamente o
+    /// <see cref="TrustedIdentityMiddleware"/> (guarda de loopback); este handler não lê headers,
+    /// não decide identidade, só "formaliza" o que já está em <c>HttpContext.User</c> para o
+    /// pipeline padrão do ASP.NET Core.
+    /// </remarks>
+    public class TrustedHeaderAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "TrustedHeader";
+
+        public TrustedHeaderAuthenticationHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var user = Context.User;
+
+            if (user?.Identity?.IsAuthenticated == true)
+            {
+                var ticket = new AuthenticationTicket(user, Scheme.Name);
+                return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+
+            // Sem identidade confiável (fora de loopback, sem header, etc.) — NoResult, não Fail:
+            // deixa o endpoint anônimo seguir normalmente quando não exige [Authorize].
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Controllers/DataGenerationControllerDiTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/DataGenerationControllerDiTests.cs
@@ -1,0 +1,72 @@
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Models.Entities;
+using LayoutParserApi.Models.Parsing;
+using LayoutParserApi.Models.Responses;
+using LayoutParserApi.Models.Structure;
+using LayoutParserApi.Services.Generation.Implementations;
+using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Generation.TxtGenerator;
+using LayoutParserApi.Services.Generation.TxtGenerator.Parsers;
+using LayoutParserApi.Services.Interfaces;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LayoutParserApi.Tests.Controllers
+{
+    /// <summary>
+    /// Issue #33: <see cref="ISyntheticDataGeneratorService"/>, <see cref="IExcelDataProcessor"/>,
+    /// <see cref="ILayoutAnalysisService"/> e <see cref="TxtFileGeneratorFactory"/> não estavam
+    /// registrados em <c>Program.cs</c> — qualquer chamada ao <see cref="DataGenerationController"/>
+    /// quebrava com <c>InvalidOperationException</c> do container de DI em runtime, mesmo com o
+    /// build passando (o erro só aparece na resolução, não na compilação). Este teste replica o
+    /// mesmo grupo "Generation Services" adicionado a <c>Program.cs</c> e garante que o container
+    /// resolve o controller sem lançar.
+    /// </summary>
+    public class DataGenerationControllerDiTests
+    {
+        [Fact]
+        public void Container_resolve_DataGenerationController_com_o_grupo_Generation_registrado()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            // Mesmo grupo "Generation Services" registrado em Program.cs.
+            services.AddScoped<ISyntheticDataGeneratorService, SyntheticDataGeneratorService>();
+            services.AddScoped<IExcelDataProcessor, ExcelDataProcessor>();
+            services.AddScoped<ILayoutAnalysisService, LayoutAnalysisService>();
+            services.AddScoped<XmlLayoutParser>();
+            services.AddScoped<ExcelRulesParser>();
+            services.AddScoped<LayoutParserApi.Services.Generation.TxtGenerator.Validators.LayoutValidator>();
+            services.AddScoped<TxtFileGeneratorFactory>();
+
+            // Única dependência do controller fora do grupo Generation — fake mínimo, o alvo
+            // deste teste é a resolução do container, não o comportamento de parsing.
+            services.AddScoped<ILayoutParserService, FakeLayoutParserService>();
+
+            services.AddScoped<DataGenerationController>();
+
+            using var provider = services.BuildServiceProvider();
+            using var scope = provider.CreateScope();
+
+            var controller = scope.ServiceProvider.GetRequiredService<DataGenerationController>();
+
+            Assert.NotNull(controller);
+        }
+
+        private sealed class FakeLayoutParserService : ILayoutParserService
+        {
+            public Task<ParsingResult> ParseAsync(Stream layoutStream, Stream txtStream) =>
+                Task.FromResult(new ParsingResult { Success = true });
+
+            public Layout ReestruturarLayout(Layout layoutOriginal) => layoutOriginal;
+
+            public Layout ReordenarSequences(Layout layout) => layout;
+
+            public DocumentStructure BuildDocumentStructure(ParsingResult result) => new();
+
+            public List<LineValidationInfo> CalculateLineValidations(Layout layout, int expectedLineLength) => [];
+
+            public Task<Layout?> ParseLayoutFromXmlAsync(string xmlContent) => Task.FromResult<Layout?>(null);
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Filters/AuditActionFilterTests.cs
+++ b/tests/LayoutParserApi.Tests/Filters/AuditActionFilterTests.cs
@@ -42,6 +42,19 @@ namespace LayoutParserApi.Tests.Filters
         }
 
         [Fact]
+        public void Order_e_anterior_ao_filtro_de_ModelState_do_ApiController()
+        {
+            // Issue #31: o [ApiController] registra um filtro interno (Order = -3000) que
+            // curto-circuita a pipeline quando o ModelState é inválido, antes de qualquer
+            // ActionFilter com Order padrão (0) rodar. Este teste trava a garantia estrutural
+            // de que o AuditActionFilter roda ANTES desse filtro (Order menor), condição
+            // necessária para que uma requisição malformada também gere linha AUDIT.
+            var filtro = new AuditActionFilter(new AuditLoggerFake(), CurrentUserStub.Anonimo);
+
+            Assert.True(filtro.Order < -3000);
+        }
+
+        [Fact]
         public void Executed_tambem_carrega_o_usuario()
         {
             var logger = new AuditLoggerFake();

--- a/tests/LayoutParserApi.Tests/Security/RoleAuthorizationTests.cs
+++ b/tests/LayoutParserApi.Tests/Security/RoleAuthorizationTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Security.Claims;
+
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Security;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Security
+{
+    /// <summary>
+    /// Issue #32: os endpoints sensíveis (GET /api/logs, DataGeneration/*,
+    /// TransformationExecution/execute-candidates e execute-lowcode, MapperDatabaseController/
+    /// refresh-cache) ganharam <c>[Authorize(Roles = "...")]</c> em cima da identidade que o
+    /// <see cref="TrustedIdentityMiddleware"/> já populava em <c>HttpContext.User</c>.
+    ///
+    /// <para>Não há <c>WebApplicationFactory</c>/TestHost neste projeto de testes (decisão
+    /// deliberada de manter a suíte sem pacotes extras — ver comentário no .csproj), então este
+    /// teste exercita a MESMA peça que <c>[Authorize(Roles=...)]</c> usa por baixo — o
+    /// <see cref="IAuthorizationService"/> com uma <see cref="RolesAuthorizationRequirement"/> —
+    /// contra o <see cref="ClaimsPrincipal"/> exatamente como o <see cref="TrustedIdentityMiddleware"/>
+    /// o constrói. É a mesma verificação que o <c>AuthorizationMiddleware</c> faz para decidir
+    /// entre 200 (papel correto), 403 (autenticado mas sem o papel) e 401 (anônimo).</para>
+    /// </summary>
+    public class RoleAuthorizationTests
+    {
+        private const string UserHeader = "x-iis-user";
+        private const string RolesHeader = "x-iis-roles";
+
+        [Fact]
+        public async Task Usuario_com_papel_correto_e_autorizado()
+        {
+            var context = await ExecutarMiddlewareAsync(user: "alice", roles: "admin");
+
+            var resultado = await AutorizarAsync(context.User, "admin");
+
+            Assert.True(resultado.Succeeded);
+        }
+
+        [Fact]
+        public async Task Usuario_autenticado_sem_o_papel_exigido_e_negado()
+        {
+            // "bob" está autenticado (identidade confiável), mas com papel "operador" — não
+            // "admin". Isso é o caminho de 403 (Forbid), diferente de anônimo (401/Challenge).
+            var context = await ExecutarMiddlewareAsync(user: "bob", roles: "operador");
+
+            var resultado = await AutorizarAsync(context.User, "admin");
+
+            Assert.False(resultado.Succeeded);
+        }
+
+        [Fact]
+        public async Task Usuario_anonimo_e_negado()
+        {
+            // Sem header confiável (ou fora de loopback) — TrustedIdentityMiddleware nunca lança,
+            // fica anônimo. É o caminho de 401 (Challenge) do AuthorizationMiddleware.
+            var context = await ExecutarMiddlewareAsync(user: null, roles: null);
+
+            var resultado = await AutorizarAsync(context.User, "admin");
+
+            Assert.False(resultado.Succeeded);
+            Assert.False(context.User.Identity?.IsAuthenticated ?? false);
+        }
+
+        [Fact]
+        public async Task Papel_operador_nao_da_acesso_a_recurso_que_exige_admin()
+        {
+            // Confirma que os dois papéis da tabela de decisão (#32) não são intercambiáveis:
+            // "operador" (refresh-cache) não deveria abrir os endpoints "admin".
+            var context = await ExecutarMiddlewareAsync(user: "carol", roles: "operador");
+
+            var resultado = await AutorizarAsync(context.User, "admin");
+
+            Assert.False(resultado.Succeeded);
+        }
+
+        [Fact]
+        public async Task Papel_admin_da_acesso_a_recurso_que_exige_operador()
+        {
+            // admin não está na tabela de refresh-cache, mas nada na spec exige exclusividade —
+            // só documenta o requisito mínimo. Papel "admin" também atende "operador" aqui porque
+            // RolesAuthorizationRequirement é um OR entre os papéis aceitos, não hierarquia; este
+            // teste apenas trava que "admin" continua sendo aceito onde "operador" é exigido
+            // SE a política também listar "admin" — o que não é o caso hoje (só "operador"). Então
+            // o esperado é falha, documentando a ausência de hierarquia implícita no mecanismo.
+            var context = await ExecutarMiddlewareAsync(user: "dave", roles: "admin");
+
+            var resultado = await AutorizarAsync(context.User, "operador");
+
+            Assert.False(resultado.Succeeded);
+        }
+
+        // --- helpers ---
+
+        private static async Task<HttpContext> ExecutarMiddlewareAsync(string? user, string? roles)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Loopback;
+            if (user != null)
+                context.Request.Headers[UserHeader] = user;
+            if (roles != null)
+                context.Request.Headers[RolesHeader] = roles;
+
+            var currentUser = new CurrentUser();
+            var middleware = new TrustedIdentityMiddleware(
+                next: _ => Task.CompletedTask,
+                options: Options.Create(new TrustedIdentityOptions()),
+                logger: NullLogger<TrustedIdentityMiddleware>.Instance);
+
+            await middleware.InvokeAsync(context, currentUser);
+            return context;
+        }
+
+        private static async Task<AuthorizationResult> AutorizarAsync(ClaimsPrincipal principal, string papelExigido)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddAuthorization();
+            using var provider = services.BuildServiceProvider();
+
+            var authorizationService = provider.GetRequiredService<IAuthorizationService>();
+            return await authorizationService.AuthorizeAsync(
+                principal,
+                resource: null,
+                requirements: new IAuthorizationRequirement[] { new RolesAuthorizationRequirement(new[] { papelExigido }) });
+        }
+    }
+}


### PR DESCRIPTION
## Resumo

Lote de 4 issues resolvidas cobrindo auditoria e autorização dos endpoints privilegiados. A ordem de implementação não foi arbitrária: travar acesso (#32) sem que a auditoria (#30/#31) já cobrisse os mesmos endpoints deixaria negações de acesso (403/401) sem rastro.

Closes #30, Closes #31, Closes #32, Closes #33

### #30 — AuditActionFilter faltando em 3 controllers
`[ServiceFilter(typeof(AuditActionFilter))]` aplicado em nível de controller em `LogsController`, `DataGenerationController` e `TransformationExecutionController`, que não tinham o filtro. Commit `84841fc`.

### #31 — Auditoria não rodava em request malformada
`AuditActionFilter` agora implementa `IOrderedFilter` com `Order = int.MinValue`. Causa raiz: `[ApiController]` registra um filtro interno de ModelState com `Order = -3000` que curto-circuitava a pipeline antes de qualquer `ActionFilter` com Order padrão (0) — request malformada nunca gerava linha AUDIT. Com Order menor, o filtro é o primeiro a rodar `OnActionExecuting`, e o unwind da pipeline garante que `OnActionExecuted` dispara mesmo com curto-circuito posterior. Commit `6bf9719`.

### #33 — Serviços de Generation faltando no DI
`ISyntheticDataGeneratorService`, `IExcelDataProcessor`, `ILayoutAnalysisService` e as dependências internas do `TxtFileGeneratorFactory` não estavam registrados em `Program.cs`. O build passava normal — o erro só aparecia na resolução em runtime. Commit `6082834`.

### #32 — UseAuthorization desabilitado desde sempre
`app.UseAuthorization()` estava comentado. Reativado com `TrustedHeaderAuthenticationHandler` (não autentica nada por conta própria, apenas formaliza o `HttpContext.User` já populado pelo `TrustedIdentityMiddleware` desde o P2). `[Authorize(Roles=...)]` aplicado em:
- `admin`: `GET /api/logs`, `DataGeneration/{generate-synthetic, generate-synthetic-zip, process-excel}`, `TransformationExecution/{execute-candidates, execute-lowcode}`
- `operador`: `MapperDatabaseController/refresh-cache`
- `parse`/`upload` permanecem sem `[Authorize]` (decisão explícita, já documentada)

Commit `2b6e8f2`.

## Nota para quem revisar

Esta branch parte de `feat/identidade-do-bff` no commit `b4a1428` (fix do SQL, "não engole mais falha de SQL como 'sem mapeador'"), que ainda está em revisão na **PR #42** (também contra `develop`). Como `b4a1428` é ancestral direto desta branch, ele aparece incluído no diff desta PR também — não é duplicação de trabalho, é a base necessária. Recomendo revisar/mergear a #42 primeiro, ou revisar esta PR ciente de que os primeiros commits do diff vêm de lá.

## Plano de teste
- [x] `dotnet build` verde
- [x] `dotnet test` verde — suíte 295 → 302 testes, todos verdes a cada commit