### PR TITLE
fix: agrega ocorrências posicionais de LineElement (infCpl/LINHA081)

### DIFF
--- a/Services/Implementations/LayoutParserService .cs
+++ b/Services/Implementations/LayoutParserService .cs
@@ -387,7 +387,98 @@ namespace LayoutParserApi.Services.Implementations
 
             ValidateLineOccurrences(layout, parsedFields);
 
+            // ✅ Issue #37: agrega ocorrências físicas de LineElements marcados com
+            // IsPositionalGroupRepetition num único ParsedField lógico (Occurrence=0).
+            // Roda DEPOIS de ValidateLineOccurrences para não contaminar a contagem de
+            // ocorrências físicas (MinimalOccurrence/MaximumOccurrence).
+            AggregatePositionalGroupRepetitions(layout, parsedFields);
+
             return parsedFields;
+        }
+
+        /// <summary>
+        /// Issue #37: agrega, campo a campo, os valores das ocorrências físicas de uma
+        /// <see cref="LineElement"/> marcada com <c>IsPositionalGroupRepetition=true</c> num único
+        /// valor lógico — por exemplo, o campo <c>infCpl</c> da NF-e (LINHA081 do layout MQSeries),
+        /// que é formado por N ocorrências físicas da mesma linha no documento posicional.
+        ///
+        /// Aditivo, não substitutivo: os <see cref="ParsedField"/>s de cada ocorrência física
+        /// (Occurrence = 1..N) são preservados intactos — <see cref="ValidateLineOccurrences"/>
+        /// depende deles para validar MinimalOccurrence/MaximumOccurrence. O valor agregado é
+        /// anexado como um novo ParsedField adicional com Occurrence = 0, que não interfere na
+        /// contagem por GroupBy(f => f.Occurrence) porque essa validação já rodou antes desta etapa.
+        ///
+        /// Concatenação pura, sem separador — validado contra o par gabarito real
+        /// (QMWNFe1_QMWNFE1.SAPiens_MRB.INBOX_07-11-2025.mq_series) do layout
+        /// LAY_TXT_MQSERIES_ENVNFE_4.00_NFe: o XML esperado não tem separador artificial entre
+        /// fragmentos, e RemoveWhiteSpaceType=All já remove o padding fixo de cada ocorrência antes
+        /// da concatenação.
+        /// </summary>
+        private void AggregatePositionalGroupRepetitions(Layout layout, List<ParsedField> parsedFields)
+        {
+            if (layout?.Elements == null || parsedFields == null || parsedFields.Count == 0)
+                return;
+
+            var allLineConfigs = new List<LineElement>();
+            foreach (var lineElement in layout.Elements)
+                CollectAllLineElements(lineElement, allLineConfigs);
+
+            var aggregatedFields = new List<ParsedField>();
+
+            foreach (var lineConfig in allLineConfigs.Where(l => l.IsPositionalGroupRepetition))
+            {
+                string lineName = ObterLineNameSemHierarquia(lineConfig.Name);
+
+                // Apenas fragmentos físicos reais (Occurrence >= 1) — nunca reagregar um agregado.
+                var lineFields = parsedFields.Where(f => f.LineName == lineName && f.Occurrence > 0).ToList();
+                if (lineFields.Count == 0)
+                    continue;
+
+                foreach (var fieldGroup in lineFields.GroupBy(f => f.FieldName))
+                {
+                    var ordered = fieldGroup.OrderBy(f => f.Occurrence).ToList();
+                    var first = ordered[0];
+
+                    // Trim por fragmento antes de concatenar (não um trim único no resultado final):
+                    // cada ocorrência física já teve TrimEnd aplicado por ApplyAlignment (padding de
+                    // fim de campo), mas o padding de INÍCIO do campo (alinhamento à direita do texto
+                    // dentro da largura fixa) permanece — sem isso o valor agregado sai com espaços
+                    // internos que não existem no documento lógico. Confirmado contra o par gabarito
+                    // real (infCpl da amostra QMWNFe1_QMWNFE1.SAPiens_MRB.INBOX_07-11-2025.mq_series):
+                    // concatenação pura SEM separador, mas COM trim de cada fragmento.
+                    string aggregatedValue = string.Concat(ordered.Select(f => f.Value?.Trim() ?? string.Empty));
+
+                    string aggregatedStatus = "ok";
+                    if (ordered.Any(f => f.Status == "error"))
+                        aggregatedStatus = "error";
+                    else if (ordered.Any(f => f.Status == "warning"))
+                        aggregatedStatus = "warning";
+
+                    aggregatedFields.Add(new ParsedField
+                    {
+                        LineName = first.LineName,
+                        FieldName = first.FieldName,
+                        Sequence = first.Sequence,
+                        Start = first.Start,
+                        Length = aggregatedValue.Length,
+                        Value = aggregatedValue,
+                        Status = aggregatedStatus,
+                        IsRequired = first.IsRequired,
+                        Occurrence = 0,
+                        LineSequence = first.LineSequence
+                    });
+                }
+
+                _techLogger.LogTechnical(new TechLogEntry
+                {
+                    RequestId = Guid.NewGuid().ToString(),
+                    Endpoint = "AggregatePositionalGroupRepetitions",
+                    Level = "Info",
+                    Message = $"{lineName}: agregadas {lineFields.Select(f => f.Occurrence).Distinct().Count()} ocorrencia(s) fisica(s) em {lineFields.Select(f => f.FieldName).Distinct().Count()} campo(s) logico(s) (Occurrence=0)"
+                });
+            }
+
+            parsedFields.AddRange(aggregatedFields);
         }
 
         /// <summary>
@@ -1161,6 +1252,9 @@ namespace LayoutParserApi.Services.Implementations
                 MinimalOccurrence = GetElementIntValue(lineElem, "MinimalOccurrence"),
                 MaximumOccurrence = GetElementIntValue(lineElem, "MaximumOccurrence"),
                 InitialValue = GetElementValue(lineElem, "InitialValue"),
+                // ✅ Issue #37: sem isto, IsPositionalGroupRepetition ficava sempre false — o
+                // deserializer nunca lia a flag do XML, então a agregação nunca disparava.
+                IsPositionalGroupRepetition = GetElementBoolValue(lineElem, "IsPositionalGroupRepetition"),
                 Elements = new List<string>()
             };
 

--- a/tests/LayoutParserApi.Tests/Parsing/PositionalFormatRegressionTests.cs
+++ b/tests/LayoutParserApi.Tests/Parsing/PositionalFormatRegressionTests.cs
@@ -49,7 +49,11 @@ namespace LayoutParserApi.Tests.Parsing
             var resultado = await ParseAsync(layoutPath, txtPath);
 
             Assert.True(resultado.Success, resultado.ErrorMessage);
-            Assert.Equal(702, resultado.ParsedFields.Count);
+            // ✅ Issue #37: 702 (baseline legado) + 2 = 704. A agregação de LINHA081
+            // (IsPositionalGroupRepetition=true, campo infCpl) anexa 2 ParsedFields adicionais
+            // (Occurrence=0: InformacoesParaEDI e Filler agregados) sem remover nenhum dos 702
+            // fragmentos originais — ver AggregatePositionalGroupRepetitions.
+            Assert.Equal(704, resultado.ParsedFields.Count);
 
             string dump = DumpCampos(resultado.ParsedFields);
             string hash = Sha256(dump);
@@ -69,11 +73,53 @@ namespace LayoutParserApi.Tests.Parsing
         }
 
         /// <summary>
-        /// Baseline do MQSeries de controle — SHA-256 do dump dos 702 campos parseados.
-        /// Recapturado por execução do commit legado <c>de92c9f</c> (pai de <c>5123e5c</c>,
-        /// antes do PositionalFormat) contra exatamente a mesma amostra usada por este teste.
+        /// Baseline do MQSeries de controle — SHA-256 do dump dos 704 campos parseados
+        /// (702 fragmentos físicos legados + 2 valores agregados de LINHA081, issue #37).
+        /// Recapturado por execução deste commit contra exatamente a mesma amostra usada por
+        /// este teste. O hash anterior (pré-#37, 702 campos) era
+        /// <c>eea774e6409e10a9806015b49816b98a1fbb487550aa309469d9dc49dd1e2375</c>.
         /// </summary>
-        private const string MqBaselineSha256 = "eea774e6409e10a9806015b49816b98a1fbb487550aa309469d9dc49dd1e2375";
+        private const string MqBaselineSha256 = "99e4688590b1ec6df01146bf3c43a3c429b1ecdaa03e6b75a2069ed45e690024";
+
+        /// <summary>
+        /// Issue #37: LINHA081 (<c>IsPositionalGroupRepetition=true</c>) forma o campo <c>infCpl</c>
+        /// da NF-e concatenando N ocorrências físicas da mesma linha no MQSeries. Este teste trava o
+        /// valor agregado byte a byte contra o XML final REAL esperado para esta amostra
+        /// (<c>.claude/tmp/exemplos/xml output/...-env.xml</c>, tag <c>&lt;infCpl&gt;</c>) — não uma
+        /// hipótese sintética. Confirma: concatenação SEM separador artificial, COM trim de cada
+        /// fragmento (o padding de alinhamento de texto dentro do campo de largura fixa não é parte
+        /// do valor lógico).
+        /// </summary>
+        [Fact]
+        public async Task LINHA081_agrega_infCpl_igual_ao_xml_esperado_do_gabarito_real()
+        {
+            var amostra = ResolveAmostra(MqLayoutRelPath, MqTxtRelPath);
+            if (amostra is null) return; // amostra real ausente nesta máquina
+
+            var (layoutPath, txtPath) = amostra.Value;
+
+            var resultado = await ParseAsync(layoutPath, txtPath);
+
+            Assert.True(resultado.Success, resultado.ErrorMessage);
+
+            const string infCplEsperado =
+                "Solicitante: Ana B Costa// Pamela GuedesPIS ST - Valor 0,00COFINS ST - Valor 0,00";
+
+            var agregado = resultado.ParsedFields.SingleOrDefault(f =>
+                f.LineName == "LINHA081" && f.FieldName == "InformacoesParaEDI" && f.Occurrence == 0);
+
+            Assert.NotNull(agregado);
+            Assert.Equal(infCplEsperado, agregado!.Value);
+
+            // Aditivo: os 4 fragmentos físicos (Occurrence 1..4) continuam intactos — é deles que
+            // ValidateLineOccurrences deriva o MinimalOccurrence/MaximumOccurrence de LINHA081.
+            var fragmentos = resultado.ParsedFields
+                .Where(f => f.LineName == "LINHA081" && f.FieldName == "InformacoesParaEDI" && f.Occurrence > 0)
+                .OrderBy(f => f.Occurrence)
+                .ToList();
+            Assert.Equal(4, fragmentos.Count);
+            Assert.Equal(new[] { 1, 2, 3, 4 }, fragmentos.Select(f => f.Occurrence));
+        }
 
         /// <summary>
         /// O defeito real: no IDOC da Marelli o offset do sequencial MQ (6 chars) era aplicado a um


### PR DESCRIPTION
## O que muda

Corrige a agregação de `LineElement` marcados com `IsPositionalGroupRepetition`
(caso real: LINHA081/infCpl). Causa raiz era dupla: o deserializer nunca lia a
flag `IsPositionalGroupRepetition` do XML (sempre `false`), então a lógica de
agregação nunca disparava mesmo depois de implementada.

## Validação

Testado contra gabarito real (par TXT/XML de produção), byte a byte. Novo
teste de regressão trava o valor esperado de `infCpl` e confere que os 4
fragmentos físicos permanecem intactos. `dotnet build` limpo, `dotnet test`
296/296.

Closes #37