### PR TITLE
feat(ai-metrics): persiste candidato do Job 1 (XSLT+prompt+validacao)

### DIFF
--- a/ai/XslSynth/Metrics/AttemptArtifactWriter.cs
+++ b/ai/XslSynth/Metrics/AttemptArtifactWriter.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace XslSynth.Metrics;
+
+/// <summary>
+/// Persistência de AUDITORIA do Job 1 (issue #35 / gap #2 de
+/// docs/../.claude/agent-memory/lp-architect/ai-metrics-job1-job2-gaps.md): hoje o job gera
+/// o XSLT, valida em memória (<see cref="OutputValidator"/>) e descarta tudo — nada sobrevive
+/// além da linha de log agregada. Este arquivo grava TODO candidato gerado (o XSLT bruto, o
+/// prompt que o produziu e o resultado da validação), independente de o caso virar (ou não)
+/// um XML elegível ao Pollux.
+///
+/// É um artefato SEPARADO do contrato Job1→Job2 (<see cref="RunManifest"/>/<c>manifest.json</c>,
+/// shape FIXO e lido pelo Cypress) — este <c>attempts-manifest.json</c> é só para
+/// diagnóstico/auditoria humana (ex.: "por que este caso não ficou elegível?", "o que o
+/// modelo respondeu de fato?") e não é consumido por nenhum job downstream. Por não ter
+/// contrato externo, o shape aqui pode evoluir livremente.
+/// </summary>
+public sealed class AttemptManifest
+{
+    [JsonPropertyName("runId")] public string RunId { get; init; } = "";
+    [JsonPropertyName("startedAt")] public string StartedAt { get; init; } = "";
+    [JsonPropertyName("finishedAt")] public string FinishedAt { get; init; } = "";
+    [JsonPropertyName("model")] public string Model { get; init; } = "";
+    [JsonPropertyName("totalAttempts")] public int TotalAttempts { get; init; }
+    [JsonPropertyName("attempts")] public IReadOnlyList<AttemptRecord> Attempts { get; init; } = [];
+}
+
+/// <summary>Uma tentativa de geração (um caso do dataset, um candidato do LLM).</summary>
+public sealed class AttemptRecord
+{
+    /// <summary>Mesmo id do <see cref="DatasetPair.Id"/> — igual ao campo <c>layout</c> do
+    /// <see cref="ManifestCandidate"/>, para permitir cruzar os dois manifestos pelo mesmo caso.</summary>
+    [JsonPropertyName("layoutName")] public string LayoutName { get; init; } = "";
+    [JsonPropertyName("timestamp")] public string Timestamp { get; init; } = "";
+    [JsonPropertyName("modeloOllama")] public string ModeloOllama { get; init; } = "";
+    [JsonPropertyName("sucesso")] public bool Sucesso { get; init; }
+    [JsonPropertyName("erro")] public string? Erro { get; init; }
+
+    /// <summary>Caminho RELATIVO ao diretório do run (<c>attempts/&lt;id&gt;.xsl</c>) — o XSLT
+    /// GERADO PELO LLM (não a saída da transformação, que é o que <see cref="ManifestCandidate"/>
+    /// guarda). Null quando o Ollama não devolveu nada aproveitável.</summary>
+    [JsonPropertyName("xsltGerado")] public string? XsltGeradoPath { get; init; }
+
+    /// <summary>Caminho RELATIVO do prompt exato enviado ao Ollama para este caso (inclui os
+    /// exemplos few-shot recuperados). Guardado em arquivo à parte — não inline — porque o
+    /// prompt real inclui o XSLT de 2-3 exemplos análogos e facilmente passa de dezenas de KB.</summary>
+    [JsonPropertyName("promptUsado")] public string? PromptUsadoPath { get; init; }
+
+    [JsonPropertyName("validationResult")] public AttemptValidation? ValidationResult { get; init; }
+
+    [JsonPropertyName("tokensPorSegundo")] public double TokensPorSegundo { get; init; }
+    [JsonPropertyName("duracaoSegundos")] public double DuracaoSegundos { get; init; }
+}
+
+/// <summary>Cópia serializável do resultado hoje calculado em memória por
+/// <see cref="OutputValidator"/> — antes descartado assim que o log agregado era escrito.</summary>
+public sealed class AttemptValidation
+{
+    [JsonPropertyName("wellFormedXml")] public bool WellFormedXml { get; init; }
+    [JsonPropertyName("tagOverlapRatio")] public double TagOverlapRatio { get; init; }
+    [JsonPropertyName("textSimilarityRatio")] public double TextSimilarityRatio { get; init; }
+    [JsonPropertyName("xsdValid")] public bool? XsdValid { get; init; }
+    [JsonPropertyName("fewShotSimilarity")] public double FewShotSimilarity { get; init; }
+    [JsonPropertyName("parseError")] public string? ParseError { get; init; }
+}
+
+/// <summary>
+/// Grava <c>attempts/&lt;id&gt;.xsl</c> + <c>attempts/&lt;id&gt;.prompt.txt</c> por caso, e o
+/// <c>attempts-manifest.json</c> agregado ao final (mesmo padrão de commit do
+/// <see cref="RunArtifactWriter"/>: escreve num <c>.tmp</c> e troca por <c>rename</c>).
+/// Resiliência: qualquer falha de escrita aqui é logada e NÃO derruba o lote — a auditoria é
+/// valiosa, mas não pode ser motivo de o job de métricas parar de rodar.
+/// </summary>
+public sealed class AttemptArtifactWriter
+{
+    // WriteIndented: assim como o manifest.json do Job 2, este arquivo é lido por humanos.
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    private readonly Action<string> _log;
+    private readonly List<AttemptRecord> _attempts = [];
+
+    public string RunDirectory { get; }
+    public string AttemptsDirectory { get; }
+
+    public AttemptArtifactWriter(string runDirectory, Action<string>? log = null)
+    {
+        RunDirectory = Path.GetFullPath(runDirectory);
+        AttemptsDirectory = Path.Combine(RunDirectory, "attempts");
+        _log = log ?? Console.WriteLine;
+        Directory.CreateDirectory(AttemptsDirectory);
+    }
+
+    /// <summary>Registra uma tentativa (grava os arquivos de XSLT/prompt na hora; o registro só
+    /// entra no manifesto agregado em <see cref="TryCommit"/>, ao final do lote).</summary>
+    public void RecordAttempt(string layoutId, string modelo, bool sucesso, string? erro,
+        string? xsltGerado, string? promptUsado, bool wellFormedXml, double tagOverlapRatio,
+        double textSimilarityRatio, bool? xsdValid, double fewShotSimilarity, string? parseError,
+        double tokensPorSegundo, double duracaoSegundos)
+    {
+        var safeId = ToSafeFileName(layoutId);
+        string? xsltPath = TryWriteArtifact(safeId + ".xsl", xsltGerado, layoutId, "XSLT gerado");
+        string? promptPath = TryWriteArtifact(safeId + ".prompt.txt", promptUsado, layoutId, "prompt");
+
+        _attempts.Add(new AttemptRecord
+        {
+            LayoutName = layoutId,
+            Timestamp = RunArtifactWriter.Iso(DateTime.UtcNow),
+            ModeloOllama = modelo,
+            Sucesso = sucesso,
+            Erro = erro,
+            XsltGeradoPath = xsltPath,
+            PromptUsadoPath = promptPath,
+            ValidationResult = new AttemptValidation
+            {
+                WellFormedXml = wellFormedXml,
+                TagOverlapRatio = tagOverlapRatio,
+                TextSimilarityRatio = textSimilarityRatio,
+                XsdValid = xsdValid,
+                FewShotSimilarity = fewShotSimilarity,
+                ParseError = parseError
+            },
+            TokensPorSegundo = tokensPorSegundo,
+            DuracaoSegundos = duracaoSegundos
+        });
+    }
+
+    private string? TryWriteArtifact(string fileName, string? conteudo, string layoutId, string descricao)
+    {
+        if (string.IsNullOrEmpty(conteudo)) return null;
+        try
+        {
+            var destino = Path.Combine(AttemptsDirectory, fileName);
+            File.WriteAllText(destino, conteudo, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            return $"attempts/{fileName}";
+        }
+        catch (Exception ex)
+        {
+            _log($"   [attempts] falha ao gravar {descricao} de {layoutId}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Publica o <c>attempts-manifest.json</c> agregado. Best-effort: diferente do
+    /// commit do Job 2, a ausência deste arquivo não invalida o run — é só auditoria a menos.</summary>
+    public bool TryCommit(string runId, DateTime startedAt, DateTime finishedAt, string modelo)
+    {
+        var manifesto = new AttemptManifest
+        {
+            RunId = runId,
+            StartedAt = RunArtifactWriter.Iso(startedAt),
+            FinishedAt = RunArtifactWriter.Iso(finishedAt),
+            Model = modelo,
+            TotalAttempts = _attempts.Count,
+            Attempts = _attempts
+        };
+
+        var destino = Path.Combine(RunDirectory, "attempts-manifest.json");
+        var temporario = destino + ".tmp";
+        try
+        {
+            var json = JsonSerializer.Serialize(manifesto, JsonOpts);
+            File.WriteAllText(temporario, json, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.Move(temporario, destino, overwrite: true);
+            _log($"   [attempts] manifesto de auditoria publicado: {destino} ({_attempts.Count} tentativa(s)).");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _log($"   [attempts] falha ao publicar manifesto de auditoria: {ex.Message}");
+            TryDelete(temporario);
+            return false;
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* melhor esforço */ }
+    }
+
+    private static string ToSafeFileName(string id)
+    {
+        var invalidos = Path.GetInvalidFileNameChars();
+        var chars = id.Select(c => invalidos.Contains(c) || c is '\\' or '/' ? '_' : c).ToArray();
+        return new string(chars);
+    }
+}

--- a/ai/XslSynth/Metrics/MetricsBatchRunner.cs
+++ b/ai/XslSynth/Metrics/MetricsBatchRunner.cs
@@ -24,10 +24,14 @@ public sealed record MetricsBatchOptions(
 /// <summary>Um resultado individual do lote (para o resumo agregado ao final).</summary>
 /// <param name="Candidato">XSLT gerado neste caso (null quando não houve saída utilizável) —
 /// insumo do run dir do Job 2, não entra em nenhuma métrica.</param>
+/// <param name="Prompt">Prompt exato enviado ao Ollama para este caso — insumo do manifesto de
+/// auditoria (<see cref="AttemptArtifactWriter"/>), null nos caminhos que não chegam a montar
+/// prompt real (dry-run, exceção antes da chamada).</param>
 internal sealed record CaseResult(
     string Layout, bool Sucesso, double TokensPerSecond, double DurationSeconds,
     double FewShotSimilarity, double TagOverlapRatio, double TextSimilarityRatio, string? Erro,
-    string? Candidato = null);
+    string? Candidato = null, string? Prompt = null, bool WellFormedXml = false,
+    bool? XsdValid = null, string? ParseError = null);
 
 /// <summary>
 /// Item 1 do plano de métricas de IA em produção (docs/architecture/plano-metricas-ia-servidor-producao.md):
@@ -126,9 +130,14 @@ public static class MetricsBatchRunner
             var writer = opts.RunDirectory is null ? null
                 : new RunArtifactWriter(opts.RunDirectory, opts.RunId ?? RunArtifactWriter.NewRunId(iniciadoEm), log);
             var factory = new CandidateXmlFactory(opts.InstancesDirectory, opts.NfeXsdPath, log);
+            // Manifesto de AUDITORIA (issue #35): sobe junto com o run dir, mas é artefato
+            // separado do contrato Job1→Job2 — grava TODO candidato (XSLT+prompt+validação),
+            // não só os elegíveis ao Pollux. Mesmo diretório de run, para não introduzir um
+            // segundo mecanismo de configuração de path (reaproveita --run-dir/LP_METRICS_RUN_DIR).
+            var attemptsWriter = opts.RunDirectory is null ? null : new AttemptArtifactWriter(opts.RunDirectory, log);
             if (writer is null)
                 log("[metrics-batch] run dir NÃO configurado (--run-dir/LP_METRICS_RUN_DIR ausente) — "
-                    + "nenhum artefato para o Job 2 será publicado nesta rodada.");
+                    + "nenhum artefato para o Job 2 nem manifesto de auditoria será publicado nesta rodada.");
             else
                 log($"[metrics-batch] run dir: {writer.RunDirectory} (runId={writer.RunId}) · {factory.DescribeSources()}");
             log("");
@@ -158,7 +167,26 @@ public static class MetricsBatchRunner
                     LogCaso(caso.Id, modelo, sucesso: false, tokensPorSegundo: 0, promptChars: 0,
                         duracaoSegundos: 0, fewShotSimilarity: 0, tagOverlap: 0, textSim: 0, xsdValido: null);
                     resultados.Add(new CaseResult(caso.Id, false, 0, 0, 0, 0, 0, ex.Message));
+                    attemptsWriter?.RecordAttempt(caso.Id, modelo, sucesso: false, erro: ex.Message,
+                        xsltGerado: null, promptUsado: null, wellFormedXml: false, tagOverlapRatio: 0,
+                        textSimilarityRatio: 0, xsdValid: null, fewShotSimilarity: 0, parseError: null,
+                        tokensPorSegundo: 0, duracaoSegundos: 0);
                     continue;
+                }
+
+                // ── Manifesto de auditoria: TODA tentativa entra, elegível ao Pollux ou não
+                // (issue #35) — falha aqui NUNCA derruba o lote. ───────────────────────────
+                try
+                {
+                    attemptsWriter?.RecordAttempt(caso.Id, modelo, resultado.Sucesso, resultado.Erro,
+                        resultado.Candidato, resultado.Prompt, resultado.WellFormedXml,
+                        resultado.TagOverlapRatio, resultado.TextSimilarityRatio, resultado.XsdValid,
+                        resultado.FewShotSimilarity, resultado.ParseError, resultado.TokensPerSecond,
+                        resultado.DurationSeconds);
+                }
+                catch (Exception ex)
+                {
+                    log($"   [attempts] falha ao registrar tentativa (lote SEGUE): {ex.Message}");
                 }
 
                 // ── Publicação do candidato (XML primeiro; manifesto só no fim) ────────
@@ -197,6 +225,8 @@ public static class MetricsBatchRunner
                 writer.TryCommit(manifesto);
                 LogResumoCandidatos(candidatos, casos.Count, log);
             }
+            attemptsWriter?.TryCommit(writer?.RunId ?? opts.RunId ?? RunArtifactWriter.NewRunId(iniciadoEm),
+                iniciadoEm, DateTime.UtcNow, modelo);
 
             return resultados.Any(r => r.Sucesso) ? 0 : 1;
         }
@@ -232,7 +262,7 @@ public static class MetricsBatchRunner
                 promptChars: metrics.PromptChars, duracaoSegundos: metrics.DurationSeconds,
                 fewShotSimilarity: similaridadeMedia, tagOverlap: 0, textSim: 0, xsdValido: null);
             return new CaseResult(caso.Id, false, metrics.TokensPerSecond, metrics.DurationSeconds,
-                similaridadeMedia, 0, 0, erro);
+                similaridadeMedia, 0, 0, erro, Prompt: prompt);
         }
 
         var candidato = ExtractXml(respostaBruta);
@@ -248,7 +278,9 @@ public static class MetricsBatchRunner
             textSim: validacao.TextSimilarityRatio, xsdValido: validacao.XsdValid);
 
         return new CaseResult(caso.Id, true, metrics.TokensPerSecond, metrics.DurationSeconds,
-            similaridadeMedia, validacao.TagOverlapRatio, validacao.TextSimilarityRatio, null, candidato);
+            similaridadeMedia, validacao.TagOverlapRatio, validacao.TextSimilarityRatio, null, candidato,
+            Prompt: prompt, WellFormedXml: validacao.WellFormedXml, XsdValid: validacao.XsdValid,
+            ParseError: validacao.ParseError);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problema
O `--mode=metrics-batch` gerava o XSLT, validava em memória (`OutputValidator`) e descartava tudo, sobrando só a linha de log agregada — sem rastro do que o LLM realmente produziu.

## Mudança
Adiciona `AttemptArtifactWriter` em `ai/XslSynth/Metrics/`: grava TODO candidato gerado (não só os elegíveis ao Pollux) em `attempts/<id>.xsl` + `attempts/<id>.prompt.txt`, com `attempts-manifest.json` agregando `runId`, timestamps, layout, paths do XSLT/prompt, `validationResult` (wellFormed/tagOverlap/textSim/xsdValid/fewShotSimilarity) e modelo.

É um artefato **separado** do contrato Job1→Job2 (`manifest.json`, shape fixo, só candidatos elegíveis ao Pollux) — não mexe nesse contrato, só acrescenta auditoria. Reaproveita o mecanismo de path já existente (`--run-dir`/`LP_METRICS_RUN_DIR`) em vez de introduzir um novo `appsettings.json`, porque `XslSynth` é console app standalone sem DI/config do ASP.NET Core.

## Testes
Testado com `--dry-run` + dataset sintético de 1 par. Builds de `ai/XslSynth` e da API raiz verdes.

Closes #35