### PR TITLE
chore: adiciona CodeQL/Dependabot e corrige retry do smoke test de deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,84 @@
+version: 2
+
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      aspnetcore-runtime:
+        patterns:
+          - Microsoft.AspNetCore.*
+          - Microsoft.Extensions.*
+        update-types:
+          - minor
+          - patch
+      sqlclient-and-data:
+        patterns:
+          - Microsoft.Data.SqlClient
+          - Microsoft.EntityFrameworkCore*
+        update-types:
+          - minor
+          - patch
+      serilog-toolchain:
+        patterns:
+          - Serilog*
+        update-types:
+          - minor
+          - patch
+      testing-toolchain:
+        patterns:
+          - Microsoft.NET.Test.Sdk
+          - xunit*
+          - Moq
+          - FluentAssertions
+        update-types:
+          - minor
+          - patch
+      runtime-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Majors de framework exigem migração conjunta (TFM, breaking changes) e nunca devem abrir
+      # PR isolado — mesma política do LayoutParserReact para o toolchain de front-end.
+      - dependency-name: Microsoft.AspNetCore.*
+        update-types: [version-update:semver-major]
+      - dependency-name: Microsoft.Extensions.*
+        update-types: [version-update:semver-major]
+      - dependency-name: Microsoft.Data.SqlClient
+        update-types: [version-update:semver-major]
+      - dependency-name: Microsoft.EntityFrameworkCore*
+        update-types: [version-update:semver-major]
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:30'
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: chore(actions)
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -583,32 +583,72 @@ jobs:
         # Readiness pode responder 503 durante o warm-up do catalogo (dependencia essencial ainda
         # subindo). 503 NAO e sucesso e tambem NAO e falha definitiva: e "ainda nao pronto" - por
         # isso o laco RETENTA ate 200 ou esgotar. So 200 encerra com sucesso.
-        $status = $null
-        $tentativas = 24
-        for ($i = 1; $i -le $tentativas; $i++) {
-          try {
-            $resp = Invoke-WebRequest -Uri $smokeUrl -UseBasicParsing -TimeoutSec 5 -Headers $smokeHeaders
-            $status = [int]$resp.StatusCode
-          } catch {
-            $r = $_.Exception.Response
-            $status = if ($r -and $r.StatusCode) { [int]$r.StatusCode } else { $null }
-          }
+        #
+        # [ATENCAO] Causa raiz investigada em 2026-08-13 (run 31687154272): o warm-up do catalogo
+        # (CachePermanentWarmupBackgroundService) roda UMA UNICA VEZ apos o app subir - nao ha
+        # retry. Se o SQL estiver com um blip de rede TRANSITORIO exatamente nesse instante
+        # (confirmado no log do host: "SqlException... error: 40 - Nao foi possivel abrir uma
+        # conexao com o SQL Server", recuperado segundos depois), o catalogo fica marcado com 0
+        # layouts PARA SEMPRE (CatalogHealthCheck Unhealthy -> /health/ready 503 permanente) ate
+        # o servico ser reiniciado manualmente - mesmo com o SQL saudavel de novo. O laco de
+        # retentativas abaixo nao ajuda nesse caso porque a sonda em si e reexecutada, mas o
+        # ESTADO do warm-up (CatalogWarmupState) nunca e recalculado. Por isso: se a janela
+        # inicial esgotar, tenta UM restart do servico (reexecuta o warm-up do zero) antes de
+        # desistir. Corrigir a causa raiz de verdade (retry no warm-up em si) e codigo de negocio
+        # -> @lp-backend-dev; aqui so mitigamos no nivel de deploy.
+        function Test-Readiness {
+          param([int]$Tentativas, [int]$EsperaSegundos)
+          $statusLocal = $null
+          for ($i = 1; $i -le $Tentativas; $i++) {
+            $corpo = $null
+            try {
+              $resp = Invoke-WebRequest -Uri $smokeUrl -UseBasicParsing -TimeoutSec 5 -Headers $smokeHeaders
+              $statusLocal = [int]$resp.StatusCode
+              $corpo = $resp.Content
+            } catch {
+              $r = $_.Exception.Response
+              $statusLocal = if ($r -and $r.StatusCode) { [int]$r.StatusCode } else { $null }
+              if ($r) {
+                try {
+                  $stream = $r.GetResponseStream()
+                  $reader = New-Object System.IO.StreamReader($stream)
+                  $corpo = $reader.ReadToEnd()
+                } catch { }
+              }
+            }
 
-          if ($status -eq 200) {
-            Write-Host "Smoke test: HTTP 200 em $smokeUrl (readiness OK, tentativa $i/$tentativas)."
-            break
-          }
+            if ($statusLocal -eq 200) {
+              Write-Host "Smoke test: HTTP 200 em $smokeUrl (readiness OK, tentativa $i/$Tentativas)."
+              return 200
+            }
 
-          $descr = if ($null -eq $status) { "sem resposta" } else { "HTTP $status" }
-          if ($i -lt $tentativas) {
-            Write-Host "  tentativa $i/$($tentativas): readiness ainda nao pronta ($descr), aguardando 5s..."
-            Start-Sleep -Seconds 5
+            $descr = if ($null -eq $statusLocal) { "sem resposta" } else { "HTTP $statusLocal" }
+            Write-Host "  tentativa $i/$($Tentativas): readiness ainda nao pronta ($descr), aguardando ${EsperaSegundos}s..."
+            # Corpo do /health/ready mostra QUAL dependencia esta Unhealthy (sql/redis/decryptor/
+            # lowcode-runner/catalog) - sem isso so se descobre a causa lendo o log do host depois.
+            if ($corpo) { Write-Host "    corpo: $corpo" }
+            if ($i -lt $Tentativas) { Start-Sleep -Seconds $EsperaSegundos }
           }
+          return $statusLocal
+        }
+
+        $status = Test-Readiness -Tentativas 24 -EsperaSegundos 5
+
+        if ($status -ne 200) {
+          Write-Warning ("Readiness nao ficou 200 na janela inicial (ultimo: " +
+            $(if ($null -eq $status) { "sem resposta" } else { "HTTP $status" }) +
+            "). Tentando UM restart do servico para reexecutar o warm-up do catalogo " +
+            "(mitigacao de blip transitorio de rede no SQL durante o warm-up unico) e retestando...")
+          Restart-Service -Name $serviceName -ErrorAction SilentlyContinue
+          $svc = Get-Service -Name $serviceName
+          $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(30))
+          Start-Sleep -Seconds 8
+          $status = Test-Readiness -Tentativas 24 -EsperaSegundos 5
         }
 
         if ($status -ne 200) {
           $ultimo = if ($null -eq $status) { "sem resposta" } else { "HTTP $status" }
-          Write-Error "Readiness nao ficou 200 em $smokeUrl apos $tentativas tentativas (ultimo: $ultimo). Deploy de dev abortado."
+          Write-Error "Readiness nao ficou 200 em $smokeUrl apos restart (ultimo: $ultimo). Deploy de dev abortado."
           exit 1
         }
         Write-Host "Deploy de dev concluido com sucesso."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL Security Analysis
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+# O workflow apenas le o codigo e publica resultados de code scanning.
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # PRs, inclusive de forks, executam exclusivamente em runner hospedado pelo GitHub.
+    # Nunca substituir por self-hosted neste workflow de analise de codigo nao confiavel.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - csharp
+          - actions
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configurar .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Inicializar CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          # C# nao suporta build-mode "none": o CodeQL precisa compilar para extrair o banco de
+          # dados. "autobuild" resolve o(s) .csproj/.sln na raiz do checkout (LayoutParserApi.sln
+          # cobre a API, mcp/LayoutParserMcp, ai/XslSynth[.Core] e tools/LowCodeRunner via
+          # referencia de projeto/solution). "actions" (analise de workflow YAML) continua sem build.
+          build-mode: ${{ matrix.language == 'csharp' && 'autobuild' || 'none' }}
+          queries: security-extended
+
+      - name: Analisar e publicar resultados
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Resumo

- **CodeQL + Dependabot**: adiciona análise de segurança CodeQL (linguagem `csharp`) e Dependabot (ecossistema `nuget`) para o stack C#/.NET, espelhando o que já existe no `LayoutParserReact`.
- **Fix no smoke test do `ci-dev.yml`**: adiciona retry com `Restart-Service` no warm-up do smoke test, mitigando falha de deploy causada por blip transitório de conexão SQL durante o warm-up (single-shot, sem tolerância a falha momentânea).

## Contexto

O warm-up single-shot do smoke test falhava permanentemente o deploy quando o SQL Server tinha uma indisponibilidade transitória logo na subida do serviço. Esta PR mitiga o sintoma no pipeline de deploy; o fix definitivo (tornar o warm-up da própria API resiliente a esse blip) é a **issue #67**, de escopo do `@lp-backend-dev`.

## Observações

- Branch protection nativa do GitHub segue indisponível nos repos privados no plano atual (ver `.claude/rules/agent-authority.md`) — sem mudança relacionada nesta PR.

## Test plan

- [ ] Validar que o workflow CodeQL roda sem erro na primeira execução (Actions)
- [ ] Confirmar que o Dependabot abre PRs de dependência normalmente
- [ ] Acompanhar o próximo deploy dev e confirmar que o retry evita falso-negativo do smoke test em caso de blip do SQL