### PR TITLE
fix(ci): corrige schema do dependabot.yml e permissões do CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
     rebase-strategy: auto
-    versioning-strategy: increase-if-necessary
     commit-message:
       prefix: chore(deps)
     groups:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: read
       security-events: write
     strategy:


### PR DESCRIPTION
## Summary
- `dependabot.yml`: remove `versioning-strategy` do bloco `nuget` — essa chave não é suportada por esse ecossistema (GitHub exclui docker, elm, github-actions, gitsubmodule, mix, nuget, swift, terraform da opção). O schema rejeitava `updates[0]` com "additional properties" fora do permitido.
- `codeql.yml`: adiciona `actions: read` às `permissions` do job `analyze`, necessário para o `codeql-action` consultar a REST API de workflow-runs durante upload do SARIF (erro "Resource not accessible by integration").

## Test plan
- [x] YAML validado sintaticamente (`yaml.safe_load`)
- [ ] Dependabot re-valida o `dependabot.yml` automaticamente após o merge (sem CLI local de validação)
- [ ] CodeQL roda verde no push/PR seguinte contra `develop`