### PR TITLE
docs(ci): documenta limitacao de GHAS no upload do CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,14 @@ on:
   workflow_dispatch:
 
 # O workflow apenas le o codigo e publica resultados de code scanning.
+#
+# NOTA (2026-08-13): a analise roda e conclui normalmente ("Running queries" ok), mas o step de
+# upload do SARIF falha com "Advanced Security must be enabled for this repository to use code
+# scanning." Isso NAO e' bug de permissions/YAML deste workflow -- e' limitacao de plano: GitHub
+# Advanced Security (GHAS) e' recurso pago exigido para code scanning em repositorio PRIVADO, e o
+# repo esta privado desde 2026-08-12 (mesma classe de limitacao que a perda de branch protection
+# nativa, ver .claude/rules/agent-authority.md). Nao mexer em permissions/config aqui tentando
+# "consertar" -- so' desbloqueia assinando GHAS ou tornando o repo publico de novo.
 permissions:
   contents: read
 


### PR DESCRIPTION
Segue a PR #70 (ja mergeada so com o primeiro commit, pois auto-merge disparou antes do segundo push). Adiciona apenas um comentario em codeql.yml explicando que a analise CodeQL roda e conclui normalmente mas o upload do SARIF falha com Advanced Security must be enabled -- limitacao de plano (GHAS pago, necessario para code scanning em repo privado), nao bug de permissions/YAML. Sem mudanca funcional.