### PR TITLE
fix(catalog-warmup): retry com backoff no warm-up do cache

### DIFF
--- a/Services/Database/CachePermanentWarmupBackgroundService.cs
+++ b/Services/Database/CachePermanentWarmupBackgroundService.cs
@@ -19,36 +19,57 @@ namespace LayoutParserApi.Services.Database
     /// </summary>
     public class CachePermanentWarmupBackgroundService : BackgroundService
     {
+        // ✅ Issue #67: backoff progressivo entre tentativas de warm-up (5s, 15s, 30s, depois
+        // fixo em 60s). Sem teto de tentativas — é warm-up de cache, não algo crítico de request;
+        // desistir permanentemente reintroduz o bug original (readiness Unhealthy até restart
+        // manual). O loop só para com sucesso ou com o processo sendo encerrado (cancellation).
+        private static readonly TimeSpan[] RetryDelays =
+        {
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(15),
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(60)
+        };
+
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<CachePermanentWarmupBackgroundService> _logger;
         private readonly CatalogWarmupState _catalogState;
+
+        // Injetável só para teste: evita esperar o backoff real (segundos/minutos) na suíte.
+        private readonly Func<TimeSpan, CancellationToken, Task> _delay;
 
         public CachePermanentWarmupBackgroundService(
             IServiceProvider serviceProvider,
             ILogger<CachePermanentWarmupBackgroundService> logger,
             CatalogWarmupState catalogState)
+            : this(serviceProvider, logger, catalogState, Task.Delay)
+        {
+        }
+
+        public CachePermanentWarmupBackgroundService(
+            IServiceProvider serviceProvider,
+            ILogger<CachePermanentWarmupBackgroundService> logger,
+            CatalogWarmupState catalogState,
+            Func<TimeSpan, CancellationToken, Task> delay)
         {
             _serviceProvider = serviceProvider;
             _logger = logger;
             _catalogState = catalogState;
+            _delay = delay;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            // Executa uma única vez, em segundo plano, após o app já estar respondendo requisições.
-            // Qualquer falha aqui é logada e degradada: o cache fica vazio (ou parcial) até o
-            // próximo refresh manual/reconexão, o que já é tolerado pelo smoke test do CI
-            // (aceita 404 em catálogo vazio).
+            // Roda em segundo plano, após o app já estar respondendo requisições, com retry até
+            // conseguir. Antes, uma única tentativa falha (ex.: blip transitório de SQL) travava
+            // CatalogWarmupState.LayoutCount em 0 para sempre e o /health/ready ficava Unhealthy
+            // permanentemente — só recuperava com restart manual do processo.
             try
             {
                 _logger.LogInformation("Iniciando populacao em background do cache permanente de layouts e mapeadores");
 
-                using var scope = _serviceProvider.CreateScope();
-                var cachedLayoutService = scope.ServiceProvider.GetRequiredService<ICachedLayoutService>();
-                var cachedMapperService = scope.ServiceProvider.GetRequiredService<ICachedMapperService>();
-
-                await RefreshLayoutCacheAsync(cachedLayoutService, stoppingToken);
-                await RefreshMapperCacheAsync(cachedMapperService, stoppingToken);
+                await RefreshLayoutCacheWithRetryAsync(stoppingToken);
+                await RefreshMapperCacheWithRetryAsync(stoppingToken);
 
                 _logger.LogInformation("Populacao em background do cache permanente concluida");
             }
@@ -64,52 +85,95 @@ namespace LayoutParserApi.Services.Database
         }
 
         /// <summary>
-        /// Popula o cache de layouts a partir do banco. Falha isolada não impede o cache de mapeadores.
+        /// Popula o cache de layouts a partir do banco, tentando de novo com backoff progressivo
+        /// enquanto falhar. Só desiste em caso de cancelamento (shutdown).
         /// </summary>
-        private async Task RefreshLayoutCacheAsync(ICachedLayoutService cachedLayoutService, CancellationToken stoppingToken)
+        private async Task RefreshLayoutCacheWithRetryAsync(CancellationToken stoppingToken)
         {
-            var layoutCount = 0;
-            try
+            var attempt = 0;
+            while (true)
             {
-                _logger.LogInformation("Populando cache de layouts em background...");
-                await cachedLayoutService.RefreshCacheFromDatabaseAsync();
+                stoppingToken.ThrowIfCancellationRequested();
+                attempt++;
+                var layoutCount = 0;
+                try
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var cachedLayoutService = scope.ServiceProvider.GetRequiredService<ICachedLayoutService>();
 
-                // ✅ P1.3: registra a contagem EFETIVA para a sonda de readiness. Lê o catálogo
-                // recém-populado (cache "all" se houver Redis, senão banco) — reflete o que a API
-                // consegue servir, não o tamanho de um cache que pode nem existir sem Redis.
-                var todos = await cachedLayoutService.SearchLayoutsAsync(new LayoutSearchRequest { SearchTerm = "" });
-                layoutCount = todos.Success ? todos.TotalFound : 0;
+                    _logger.LogInformation("Populando cache de layouts em background (tentativa {Attempt})...", attempt);
+                    await cachedLayoutService.RefreshCacheFromDatabaseAsync();
 
-                _logger.LogInformation("Cache de layouts populado com sucesso em background: {Count} layouts", layoutCount);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Erro ao popular cache de layouts em background (SQL indisponivel/lento?). Cache pode ficar vazio ate proximo refresh");
-            }
-            finally
-            {
-                // Sempre registra o resultado (0 em caso de falha) para a readiness refletir a realidade.
-                _catalogState.SetResult(layoutCount);
+                    // ✅ P1.3: registra a contagem EFETIVA para a sonda de readiness. Lê o catálogo
+                    // recém-populado (cache "all" se houver Redis, senão banco) — reflete o que a API
+                    // consegue servir, não o tamanho de um cache que pode nem existir sem Redis.
+                    var todos = await cachedLayoutService.SearchLayoutsAsync(new LayoutSearchRequest { SearchTerm = "" });
+                    layoutCount = todos.Success ? todos.TotalFound : 0;
+
+                    _logger.LogInformation("Cache de layouts populado com sucesso em background: {Count} layouts (tentativa {Attempt})", layoutCount, attempt);
+                    _catalogState.SetResult(layoutCount);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var delay = GetRetryDelay(attempt);
+                    _logger.LogWarning(ex, "Erro ao popular cache de layouts em background (SQL indisponivel/lento? tentativa {Attempt}). Nova tentativa em {DelaySeconds}s", attempt, delay.TotalSeconds);
+
+                    // Não registra 0 aqui de propósito: registrar travaria a readiness em Unhealthy
+                    // "definitivo" mesmo enquanto o retry ainda está em andamento e prestes a
+                    // recuperar sozinho — CatalogWarmupState.Completed=false até o 1º sucesso é o
+                    // sinal correto (readiness segue Unhealthy do mesmo jeito, mas reflete "ainda
+                    // não pronto", não "falhou de vez").
+                    await _delay(delay, stoppingToken);
+                }
             }
         }
 
         /// <summary>
-        /// Popula o cache de mapeadores a partir do banco. Falha isolada não impede o cache de layouts.
+        /// Popula o cache de mapeadores a partir do banco, com o mesmo retry do cache de layouts.
+        /// Falha isolada não impede (nem é impedida por) o cache de layouts, que já terminou antes.
         /// </summary>
-        private async Task RefreshMapperCacheAsync(ICachedMapperService cachedMapperService, CancellationToken stoppingToken)
+        private async Task RefreshMapperCacheWithRetryAsync(CancellationToken stoppingToken)
         {
-            try
+            var attempt = 0;
+            while (true)
             {
-                _logger.LogInformation("Populando cache de mapeadores em background...");
-                await cachedMapperService.RefreshCacheFromDatabaseAsync();
+                stoppingToken.ThrowIfCancellationRequested();
+                attempt++;
+                try
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var cachedMapperService = scope.ServiceProvider.GetRequiredService<ICachedMapperService>();
 
-                var allMappers = await cachedMapperService.GetAllMappersAsync();
-                _logger.LogInformation("Cache de mapeadores populado com sucesso em background: {Count} mapeadores disponiveis", allMappers?.Count ?? 0);
+                    _logger.LogInformation("Populando cache de mapeadores em background (tentativa {Attempt})...", attempt);
+                    await cachedMapperService.RefreshCacheFromDatabaseAsync();
+
+                    var allMappers = await cachedMapperService.GetAllMappersAsync();
+                    _logger.LogInformation("Cache de mapeadores populado com sucesso em background: {Count} mapeadores disponiveis (tentativa {Attempt})", allMappers?.Count ?? 0, attempt);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var delay = GetRetryDelay(attempt);
+                    _logger.LogWarning(ex, "Erro ao popular cache de mapeadores em background (SQL indisponivel/lento? tentativa {Attempt}). Nova tentativa em {DelaySeconds}s", attempt, delay.TotalSeconds);
+                    await _delay(delay, stoppingToken);
+                }
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Erro ao popular cache de mapeadores em background (SQL indisponivel/lento?). Cache pode ficar vazio ate proximo refresh");
-            }
+        }
+
+        /// <summary>Backoff progressivo: 5s, 15s, 30s, depois fixo em 60s.</summary>
+        private static TimeSpan GetRetryDelay(int attempt)
+        {
+            var index = attempt - 1;
+            return index < RetryDelays.Length ? RetryDelays[index] : RetryDelays[^1];
         }
     }
 }

--- a/tests/LayoutParserApi.Tests/Database/CachePermanentWarmupBackgroundServiceRetryTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/CachePermanentWarmupBackgroundServiceRetryTests.cs
@@ -1,0 +1,179 @@
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Entities;
+using LayoutParserApi.Services.Database;
+using LayoutParserApi.Services.Health;
+using LayoutParserApi.Services.Interfaces;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LayoutParserApi.Tests.Database
+{
+    /// <summary>
+    /// Issue #67: SQL indisponível numa tentativa isolada de warm-up não pode travar
+    /// <see cref="CatalogWarmupState.LayoutCount"/> em 0 (e a readiness em Unhealthy) para
+    /// sempre. Estes testes provam que <see cref="CachePermanentWarmupBackgroundService"/>
+    /// tenta de novo (com backoff) até conseguir, sem precisar de restart externo.
+    /// </summary>
+    public class CachePermanentWarmupBackgroundServiceRetryTests
+    {
+        /// <summary>
+        /// Falha SQL (banco indisponível) na 1ª tentativa, sucede na 2ª — o cenário exato do
+        /// critério de aceite da issue.
+        /// </summary>
+        [Fact]
+        public async Task Falha_na_primeira_tentativa_recupera_na_segunda_sem_restart()
+        {
+            var fakeLayoutService = new FakeCachedLayoutService(failuresBeforeSuccess: 1, successCount: 10);
+            var fakeMapperService = new FakeCachedMapperService(failuresBeforeSuccess: 0);
+            var catalogState = new CatalogWarmupState();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ICachedLayoutService>(fakeLayoutService);
+            services.AddSingleton<ICachedMapperService>(fakeMapperService);
+            await using var provider = services.BuildServiceProvider();
+
+            // Delay "instantâneo": prova o retry sem esperar o backoff real em segundos.
+            var delayCalls = 0;
+            Task NoDelay(TimeSpan _, CancellationToken __) { delayCalls++; return Task.CompletedTask; }
+
+            var sut = new CachePermanentWarmupBackgroundService(
+                provider,
+                NullLogger<CachePermanentWarmupBackgroundService>.Instance,
+                catalogState,
+                NoDelay);
+
+            using var cts = new CancellationTokenSource();
+            await sut.StartAsync(cts.Token);
+
+            // BackgroundService.ExecuteAsync roda em background (Task interno); aguarda a
+            // conclusão explicitamente em vez de confiar em timing.
+            await WaitUntilAsync(() => catalogState.Completed, TimeSpan.FromSeconds(5));
+
+            Assert.True(catalogState.Completed);
+            Assert.Equal(10, catalogState.LayoutCount);
+            Assert.Equal(2, fakeLayoutService.RefreshAttempts); // 1 falha + 1 sucesso
+            Assert.True(delayCalls >= 1); // esperou antes de tentar de novo
+
+            await sut.StopAsync(cts.Token);
+        }
+
+        /// <summary>
+        /// Enquanto o warm-up ainda está tentando (nenhuma tentativa teve sucesso ainda),
+        /// <see cref="CatalogWarmupState"/> permanece "não concluído" — nunca registra 0 de forma
+        /// definitiva por causa de uma falha isolada que o retry ainda vai corrigir sozinho.
+        /// </summary>
+        [Fact]
+        public async Task Enquanto_todas_as_tentativas_falham_estado_permanece_nao_concluido()
+        {
+            // Nunca sucede (simula SQL indisponível de forma persistente nesta janela).
+            var fakeLayoutService = new FakeCachedLayoutService(failuresBeforeSuccess: int.MaxValue, successCount: 5);
+            var fakeMapperService = new FakeCachedMapperService(failuresBeforeSuccess: 0);
+            var catalogState = new CatalogWarmupState();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ICachedLayoutService>(fakeLayoutService);
+            services.AddSingleton<ICachedMapperService>(fakeMapperService);
+            await using var provider = services.BuildServiceProvider();
+
+            // O fake de delay cancela o CTS após algumas tentativas — sem isso o loop
+            // (corretamente) tentaria para sempre, o que é o comportamento de produção, mas
+            // travaria o teste. stoppingToken.ThrowIfCancellationRequested() no topo do loop de
+            // produção garante que o cancelamento é respeitado independente do delay usado.
+            var delayCalls = 0;
+            using var cts = new CancellationTokenSource();
+            Task NoDelay(TimeSpan _, CancellationToken ct)
+            {
+                delayCalls++;
+                if (delayCalls >= 5) cts.Cancel();
+                return Task.CompletedTask;
+            }
+
+            var sut = new CachePermanentWarmupBackgroundService(
+                provider,
+                NullLogger<CachePermanentWarmupBackgroundService>.Instance,
+                catalogState,
+                NoDelay);
+
+            await sut.StartAsync(cts.Token);
+
+            // Dá tempo para várias tentativas ocorrerem (todas falhando) e o cancelamento encerrar o loop.
+            await WaitUntilAsync(() => cts.IsCancellationRequested && fakeLayoutService.RefreshAttempts >= 5, TimeSpan.FromSeconds(5));
+
+            Assert.False(catalogState.Completed);
+            Assert.Equal(-1, catalogState.LayoutCount);
+            Assert.True(fakeLayoutService.RefreshAttempts >= 5);
+
+            await sut.StopAsync(CancellationToken.None);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!condition() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        /// <summary>Fake do cache de layouts: falha N vezes seguidas antes de suceder.</summary>
+        private sealed class FakeCachedLayoutService : ICachedLayoutService
+        {
+            private readonly int _failuresBeforeSuccess;
+            private readonly int _successCount;
+            public int RefreshAttempts { get; private set; }
+
+            public FakeCachedLayoutService(int failuresBeforeSuccess, int successCount)
+            {
+                _failuresBeforeSuccess = failuresBeforeSuccess;
+                _successCount = successCount;
+            }
+
+            public Task RefreshCacheFromDatabaseAsync()
+            {
+                RefreshAttempts++;
+                if (RefreshAttempts <= _failuresBeforeSuccess)
+                {
+                    throw new InvalidOperationException("SQL indisponivel (simulado)");
+                }
+                return Task.CompletedTask;
+            }
+
+            public Task<LayoutSearchResponse> SearchLayoutsAsync(LayoutSearchRequest request)
+            {
+                return Task.FromResult(new LayoutSearchResponse { Success = true, TotalFound = _successCount });
+            }
+
+            public Task<LayoutRecord?> GetLayoutByIdAsync(int id) => Task.FromResult<LayoutRecord?>(null);
+            public Task<LayoutRecord?> GetLayoutByGuidAsync(string layoutGuid) => Task.FromResult<LayoutRecord?>(null);
+            public Task ClearCacheAsync() => Task.CompletedTask;
+            public ILayoutDatabaseService GetLayoutDatabaseService() => null!;
+        }
+
+        /// <summary>Fake do cache de mapeadores: falha N vezes seguidas antes de suceder.</summary>
+        private sealed class FakeCachedMapperService : ICachedMapperService
+        {
+            private readonly int _failuresBeforeSuccess;
+            public int RefreshAttempts { get; private set; }
+
+            public FakeCachedMapperService(int failuresBeforeSuccess)
+            {
+                _failuresBeforeSuccess = failuresBeforeSuccess;
+            }
+
+            public Task RefreshCacheFromDatabaseAsync()
+            {
+                RefreshAttempts++;
+                if (RefreshAttempts <= _failuresBeforeSuccess)
+                {
+                    throw new InvalidOperationException("SQL indisponivel (simulado)");
+                }
+                return Task.CompletedTask;
+            }
+
+            public Task<List<Mapper>> GetAllMappersAsync() => Task.FromResult(new List<Mapper>());
+            public Task<List<Mapper>> GetMappersByInputLayoutGuidAsync(string inputLayoutGuid) => Task.FromResult(new List<Mapper>());
+            public Task<List<Mapper>> GetMappersByTargetLayoutGuidAsync(string targetLayoutGuid) => Task.FromResult(new List<Mapper>());
+        }
+    }
+}


### PR DESCRIPTION
## Resumo
- `CachePermanentWarmupBackgroundService` ganha retry com backoff no warm-up do catálogo.
- Corrige travamento permanente de `/health/ready` quando ocorre um blip transitório de SQL durante o startup.

## Testes
- 316/316 testes verdes, build limpo.

Closes #67