### PR TITLE
fix: correcoes da auditoria de gates e bugs (2026-08-14) - DI, TTL da store de IA, gate de teste no deploy, readiness do catalogo

### DIFF
--- a/.claude/agent-memory/lp-architect/MEMORY.md
+++ b/.claude/agent-memory/lp-architect/MEMORY.md
@@ -17,4 +17,5 @@
 - [Specs reais do servidor de produção (2026-07-21)](production-server-hardware.md) — `BRNDDAPPBLD01`, i7-4790 Haswell 2014, sem GPU, sem upgrade previsto; recomendação de modelo revisada pra 1-2B + medir de verdade.
 - [Gaps do pipeline Job1→Job2 de métricas de IA (2026-07-30)](ai-metrics-job1-job2-gaps.md) — painel do Gap 3 lê log no Windows e o job escreve na VM (nunca casou); Job 1 não persiste candidato; escopo real é 4/54 pares.
 - [SEFAZ: PL_009 já espelhado no GitHub (2026-07-21)](sefaz-xsd-schema-source.md) — `nfephp-org/sped-nfe` resolve o bloqueio do XSD antigo sem scraping; WebFetch na SEFAZ falhou (TLS, causa não confirmada).
+- [Auditoria review-arch 2026-08-14: regressão de DI + issue #51 fechada errada](audit-2026-08-14-di-regression.md) — DataGenerationController quebrado de novo (bloco DI apagado em merge); AiCandidateStore leak segue presente apesar de #51 CLOSED.
 - [TextPositional é sobrecarregado: MQ vs IDOC (2026-08-03)](idoc-textpositional-overload.md) — `WithBreakLines` é o discriminador real e o parser nunca o lê; IDOC parseia "com sucesso" e 100% dos campos saem errados.

--- a/.claude/agent-memory/lp-architect/audit-2026-08-14-di-regression.md
+++ b/.claude/agent-memory/lp-architect/audit-2026-08-14-di-regression.md
@@ -1,0 +1,34 @@
+---
+name: audit-2026-08-14-di-regression
+description: Auditoria review-arch achou DataGenerationController quebrado de novo (regressão silenciosa da issue #33) e AiCandidateStore leak (issue #51) fechada com fix no subsistema errado
+metadata:
+  type: project
+---
+
+Auditoria ampla (`review-arch`, 2026-08-14) em `docs/architecture/auditoria-gates-bugs-2026-08-14.md`
+achou dois achados críticos que passaram por issues JÁ FECHADAS:
+
+1. **DataGenerationController regrediu.** Issue #33 (fechada 2026-08-13) registrou os serviços de
+   Generation no DI. Um commit posterior (`9e52791`, merge `612a5a3`, remoção do Pathway 1) apagou
+   o bloco inteiro como dano colateral de resolução de conflito. Confirmado em `HEAD=1dc58f2`: o
+   bloco não existe mais em `Program.cs`, o controller ainda injeta o serviço → quebra em runtime.
+   Causa raiz do porquê o CI não pegou: `DataGenerationControllerDiTests.cs` testa um
+   `ServiceCollection` próprio com os registros **copiados manualmente**, nunca o `Program.cs` real
+   — um padrão de teste que pode voltar a falhar da mesma forma para qualquer outro serviço.
+
+2. **AiCandidateStore leak (issue #51) fechado errado.** O comentário de fechamento cita fix em
+   `ai/XslSynth/Metrics/RunManifest.cs` (retenção do Job 1 de métricas) — subsistema DIFERENTE do
+   `Services/Transformation/Ai/AiCandidateStore.cs` que a issue #51 realmente descrevia. Confirmado:
+   `AiCandidateStore.cs` ainda não tem TTL/cleanup nenhum, leak segue presente.
+
+**Why:** ambos são casos de "issue fechada ≠ problema resolvido" — vale, ao auditar, sempre
+verificar se o commit/arquivo citado no fechamento bate com o arquivo que a issue realmente
+descrevia, não só confiar no status CLOSED.
+
+**How to apply:** ao revisar arquitetura/gates no futuro, tratar toda issue fechada citando fix
+"em outro lugar" (nome de arquivo diferente do mencionado no corpo da issue) como suspeita até
+verificar o código atual. Padrão de teste "DI isolado copiado manualmente" (como
+`DataGenerationControllerDiTests`) é um anti-padrão a sinalizar sempre que aparecer de novo —
+recomendação dada: smoke test que resolve TODOS os controllers a partir do `Program.cs` real.
+
+Related: [[gemini-openai-decommission-decision]]

--- a/.claude/agent-memory/lp-devops/git-fetch-hang-gcm-workaround.md
+++ b/.claude/agent-memory/lp-devops/git-fetch-hang-gcm-workaround.md
@@ -22,3 +22,13 @@ git merge --ff-only FETCH_HEAD
 ```
 Confirmado funcional em 2026-08-13 após merge da PR #72. Ver também [[gh-cli-nao-autenticado]] (gh
 já autenticado, PATH precisa export por sessão).
+
+**Duas armadilhas medidas em 2026-08-14** (tentativa de fetch a partir de um worktree isolado):
+
+1. `Authorization: Bearer <token>` **não funciona** para o transporte git-http — o servidor devolve
+   401 e o git cai em "could not read Username". Tem que ser `Basic` com base64 de
+   `x-access-token:<token>`, exatamente como está no bloco acima. Não improvise o esquema.
+2. Em sessão de agente **isolada em worktree**, o comando composto (`$(...)`/pipe com `base64`)
+   pode ser barrado pelo classificador de permissão do Bash tool. Nesse caso não há fetch: siga
+   com o ref `origin/<branch>` que já existe localmente e **registre no relatório** que a base
+   pode estar desatualizada, em vez de ramificar do HEAD errado.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ on:
 # Serializa deploys de producao. cancel-in-progress: false de PROPOSITO - cancelar um deploy
 # no meio (durante a troca de binario / Stop-Service -> copia -> Start-Service) deixaria a
 # instalacao pela metade. Runs concorrentes ENFILEIRAM; nenhum e abortado no meio do caminho.
+#
+# O grupo e uma constante ('deploy-prod'), NAO derivado de workflow+ref (github.workflow /
+# github.ref) como nos demais workflows: este arquivo dispara por main, por master e por
+# workflow_dispatch, e os tres publicam no MESMO host e no MESMO servico Windows. Agrupar por
+# ref permitiria dois runs simultaneos disputando os mesmos binarios - e o step de copia falha
+# com .exe/.dll em uso (hoje isso ABORTA o deploy, deixando a instalacao parcial). Constante
+# serializa tudo que aponta para producao, que e a propriedade que interessa aqui.
 concurrency:
   group: deploy-prod
   cancel-in-progress: false
@@ -149,7 +156,9 @@ jobs:
     # argumento pela SOLUTION. Desde que o projeto de testes entrou na LayoutParserApi.sln
     # (para o `dotnet test` deixar de mentir), um build pela solution passaria a restaurar
     # xUnit e compilar testes AQUI, em producao - uma falha de restore quebraria o deploy.
-    # Producao compila exatamente o que publica: o projeto da API, e mais nada.
+    # Producao compila exatamente o que PUBLICA: o projeto da API, e mais nada. O projeto de
+    # testes tambem passa a ser compilado neste host, mas por um step proprio e explicito logo
+    # abaixo (quality gate) - nunca por inferencia da solution, e nada dele entra no publish.
     - name: Build LayoutParserApi (.NET 10.0)
       run: |
         $WORK_DIR = $PWD.Path
@@ -183,7 +192,81 @@ jobs:
         }
 
         Write-Host "LayoutParserApi compilado com sucesso"
-    
+
+    # -- Quality gate: suite de testes ANTES de tocar producao (FATAL) ----------------
+    #
+    # POR QUE ESTE STEP EXISTE: ate aqui SOMENTE o ci-dev.yml rodava `dotnet test`. Producao
+    # buildava e publicava sem NUNCA executar a suite. O unico caminho que garantia o gate
+    # (feat -> develop -> master via PR, com o ci-dev rodando no meio) deixou de ser obrigatorio
+    # quando a branch protection nativa do GitHub foi perdida ao tornar os repos privados
+    # (recurso pago no plano free - ver .claude/rules/agent-authority.md). Ou seja: um push
+    # direto em master ia para PRODUCAO sem um unico teste ter rodado, e nada bloqueava.
+    #
+    # POSICAO: logo apos o build da API (a suite depende do LayoutParserLib.dll e do assembly da
+    # API, compilados nos steps acima) e ANTES de qualquer step que escreva no host - publicacao
+    # do runner low-code, Environment do servico, Stop-Service/copia de binarios. Falhar aqui
+    # custa tempo de build; falhar depois custa producao pela metade: este workflow nao tem swap
+    # atomico nem backup dos binarios anteriores.
+    #
+    # CONTRAPARTIDA ACEITA: este step restaura xUnit e compila o projeto de testes no host de
+    # producao - justamente o que o comentario do step de build acima evita fazer por ACIDENTE
+    # (build pela solution). Aqui e deliberado e escopado a UM csproj explicito; o publish
+    # continua saindo so do LayoutParserApi.csproj.
+    #
+    # SEM BYPASS de proposito: nao ha input de workflow_dispatch para pular a suite. Deploy de
+    # emergencia com teste vermelho e exatamente a situacao que este gate existe para impedir.
+    - name: Quality gate - suite de testes (pre-producao)
+      run: |
+        $WORK_DIR = $PWD.Path
+        $TEST_PROJECT = Join-Path $WORK_DIR "LayoutParserApi\tests\LayoutParserApi.Tests\LayoutParserApi.Tests.csproj"
+        $RESULTS_DIR = Join-Path $WORK_DIR "test-results"
+        $TRX = Join-Path $RESULTS_DIR "prod-gate.trx"
+
+        if (-not (Test-Path $TEST_PROJECT)) {
+          Write-Error "Projeto de testes nao encontrado: $TEST_PROJECT - deploy de PRODUCAO abortado (gate sem suite nao e gate)."
+          exit 1
+        }
+
+        New-Item -ItemType Directory -Path $RESULTS_DIR -Force | Out-Null
+        Remove-Item $TRX -Force -ErrorAction SilentlyContinue
+
+        Write-Host "Executando a suite completa antes de tocar o host de producao..."
+        dotnet test "$TEST_PROJECT" --configuration Release --logger "console;verbosity=minimal" --logger "trx;LogFileName=prod-gate.trx" --results-directory "$RESULTS_DIR"
+        $testExit = $LASTEXITCODE
+
+        # [ATENCAO] Exit code 0 NAO basta como veredito. Este repo ja teve um gate que mentia:
+        # `dotnet test` pela solution reportava SUCESSO tendo executado ZERO teste (ver o
+        # comentario do step "Testes (xUnit)" no ci-dev.yml). Por isso o veredito sai do TRX -
+        # total/passed/failed - e a ausencia do relatorio e tratada como FALHA, nao como sucesso.
+        if (-not (Test-Path $TRX)) {
+          Write-Error "Relatorio TRX nao gerado em $TRX - impossivel confirmar que a suite rodou. Deploy de PRODUCAO abortado."
+          exit 1
+        }
+
+        [xml]$relatorio = Get-Content $TRX -Raw
+        $contadores = $relatorio.TestRun.ResultSummary.Counters
+        if ($null -eq $contadores) {
+          Write-Error "TRX sem ResultSummary/Counters ($TRX) - gate inconclusivo. Deploy de PRODUCAO abortado."
+          exit 1
+        }
+
+        $total = [int]$contadores.total
+        $passed = [int]$contadores.passed
+        $failed = [int]$contadores.failed
+        Write-Host "Suite: total=$total passed=$passed failed=$failed (exit do dotnet test: $testExit)"
+
+        if ($testExit -ne 0 -or $failed -gt 0) {
+          Write-Error "Teste(s) falharam ($failed de $total) - deploy de PRODUCAO abortado ANTES de qualquer alteracao no host."
+          exit 1
+        }
+
+        if ($total -le 0) {
+          Write-Error "A suite executou ZERO teste - gate inconclusivo, tratado como FALHA. Deploy de PRODUCAO abortado."
+          exit 1
+        }
+
+        Write-Host "Quality gate verde: $passed/$total testes passaram - liberado a tocar producao."
+
     - name: Publish LayoutParserApi
       run: |
         $WORK_DIR = $PWD.Path

--- a/Program.cs
+++ b/Program.cs
@@ -711,7 +711,11 @@ try
                     name = e.Key,
                     status = e.Value.Status.ToString(),
                     description = e.Value.Description,
-                    error = e.Value.Exception?.Message
+                    error = e.Value.Exception?.Message,
+                    // "data" carrega a classificação estruturada da sonda (o catálogo publica
+                    // estado/transitorio aqui). Sem isso, "aquecendo" e "vazio definitivo" —
+                    // que respondem o MESMO 503 — só se distinguiriam lendo o texto da descrição.
+                    data = e.Value.Data.Count > 0 ? e.Value.Data : null
                 })
             };
             await httpContext.Response.WriteAsync(System.Text.Json.JsonSerializer.Serialize(payload));

--- a/Program.cs
+++ b/Program.cs
@@ -2,10 +2,8 @@ using LayoutParserApi.Services.Cache;
 using LayoutParserApi.Services.Database;
 using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Services.Health;
+using LayoutParserApi.Services.Generation;
 using LayoutParserApi.Services.Generation.Implementations;
-using LayoutParserApi.Services.Generation.Interfaces;
-using LayoutParserApi.Services.Generation.TxtGenerator;
-using LayoutParserApi.Services.Generation.TxtGenerator.Parsers;
 using LayoutParserApi.Services.Implementations;
 using LayoutParserApi.Services.Interfaces;
 using LayoutParserApi.Services.Learning;
@@ -428,6 +426,14 @@ try
     // ✅ Item 4.4 do roadmap de IA: checagem de near-duplicate obrigatória para QUALQUER
     // saída "sintética" antes de indexar - este projeto é material de TCC.
     builder.Services.AddScoped<NearDuplicateChecker>();
+
+    // Generation Services (geração sintética / TXT — DataGenerationController)
+    // ✅ Issue #33: o grupo não existia e QUALQUER chamada ao controller quebrava na resolução de
+    // DI (build passa, o erro só aparece em runtime). Foi restaurado depois de ser apagado como
+    // dano colateral na resolução de conflito do merge que removeu o Pathway 1 — por isso a
+    // composição mora em AddGenerationServices (Services/Generation), chamada aqui e exercitada
+    // pelo teste DataGenerationControllerDiTests: uma composição só, sem réplica que diverge.
+    builder.Services.AddGenerationServices();
 
     // RAG Services (retrieval de exemplos para geração sintética)
     // ✅ Fix incidental (item 1.4 do roadmap de IA, 2026-07-21): RAGService nunca esteve

--- a/Program.cs
+++ b/Program.cs
@@ -383,6 +383,10 @@ try
     builder.Services.Configure<LayoutParserApi.Services.Transformation.Ai.AiTransformationCandidateOptions>(
         builder.Configuration.GetSection("AiTransformationCandidate"));
     builder.Services.AddSingleton<LayoutParserApi.Services.Transformation.Ai.AiCandidateStore>();
+    // ✅ Issue #51: a store não tinha expiração — cada ticket ficava para sempre em memória e em
+    // disco. A poda roda em BackgroundService (previsível e independente de tráfego) justamente
+    // para o polling de status não pagar por varredura de diretório no caminho de request.
+    builder.Services.AddHostedService<LayoutParserApi.Services.Transformation.Ai.AiCandidateStoreCleanupBackgroundService>();
     builder.Services.AddHttpClient<LayoutParserApi.Services.Transformation.Ai.IAiTransformationCandidateService,
         LayoutParserApi.Services.Transformation.Ai.AiTransformationCandidateService>(client =>
     {

--- a/Services/Database/CachePermanentWarmupBackgroundService.cs
+++ b/Services/Database/CachePermanentWarmupBackgroundService.cs
@@ -95,7 +95,6 @@ namespace LayoutParserApi.Services.Database
             {
                 stoppingToken.ThrowIfCancellationRequested();
                 attempt++;
-                var layoutCount = 0;
                 try
                 {
                     using var scope = _serviceProvider.CreateScope();
@@ -108,9 +107,35 @@ namespace LayoutParserApi.Services.Database
                     // recém-populado (cache "all" se houver Redis, senão banco) — reflete o que a API
                     // consegue servir, não o tamanho de um cache que pode nem existir sem Redis.
                     var todos = await cachedLayoutService.SearchLayoutsAsync(new LayoutSearchRequest { SearchTerm = "" });
-                    layoutCount = todos.Success ? todos.TotalFound : 0;
 
-                    _logger.LogInformation("Cache de layouts populado com sucesso em background: {Count} layouts (tentativa {Attempt})", layoutCount, attempt);
+                    // ✅ "Nao consegui LER o catalogo" != "o catalogo esta vazio". CachedLayoutService/
+                    // LayoutDatabaseService ENGOLEM a exceção de SQL e devolvem Success=false em vez de
+                    // propagar — ou seja, o catch abaixo NUNCA dispara num blip de SQL. Antes,
+                    // Success=false virava contagem 0 e SetResult(0) marcava o warm-up como CONCLUÍDO:
+                    // estado "Vazio" (definitivo) + `return` matavam o retry da issue #67 justamente no
+                    // cenário que ele existe para cobrir. Agora conta como tentativa falha: o estado
+                    // fica "Aquecendo" e o backoff tenta de novo até o SQL voltar.
+                    if (!todos.Success)
+                    {
+                        var delayLeitura = GetRetryDelay(attempt);
+                        _catalogState.RegisterFailedAttempt("BuscaDeLayoutsSemSucesso");
+                        _logger.LogWarning(
+                            "Busca do catalogo apos o refresh nao teve sucesso (tentativa {Attempt}): {Erro}. Warm-up segue AQUECENDO; nova tentativa em {DelaySeconds}s",
+                            attempt, todos.ErrorMessage, delayLeitura.TotalSeconds);
+                        await _delay(delayLeitura, stoppingToken);
+                        continue;
+                    }
+
+                    var layoutCount = todos.TotalFound;
+
+                    // Contagem 0 com busca BEM-SUCEDIDA é conclusão de verdade: o catálogo está mesmo
+                    // vazio. Registra como concluído (estado "Vazio") — readiness Unhealthy definitivo,
+                    // que é o sinal correto para o operador, e não fica retentando à toa.
+                    if (layoutCount <= 0)
+                        _logger.LogError("Warm-up concluiu mas o catalogo veio VAZIO (0 layouts) na tentativa {Attempt} — readiness ficara Unhealthy ate haver layouts", attempt);
+                    else
+                        _logger.LogInformation("Cache de layouts populado com sucesso em background: {Count} layouts (tentativa {Attempt})", layoutCount, attempt);
+
                     _catalogState.SetResult(layoutCount);
                     return;
                 }
@@ -121,6 +146,7 @@ namespace LayoutParserApi.Services.Database
                 catch (Exception ex)
                 {
                     var delay = GetRetryDelay(attempt);
+                    _catalogState.RegisterFailedAttempt(ex.GetType().Name);
                     _logger.LogWarning(ex, "Erro ao popular cache de layouts em background (SQL indisponivel/lento? tentativa {Attempt}). Nova tentativa em {DelaySeconds}s", attempt, delay.TotalSeconds);
 
                     // Não registra 0 aqui de propósito: registrar travaria a readiness em Unhealthy

--- a/Services/Generation/GenerationServiceCollectionExtensions.cs
+++ b/Services/Generation/GenerationServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using LayoutParserApi.Services.Generation.Implementations;
+using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Generation.TxtGenerator;
+using LayoutParserApi.Services.Generation.TxtGenerator.Generators;
+using LayoutParserApi.Services.Generation.TxtGenerator.Parsers;
+
+namespace LayoutParserApi.Services.Generation
+{
+    /// <summary>
+    /// Grupo "Generation Services" do DI — tudo que o <c>DataGenerationController</c> precisa para
+    /// resolver e para gerar arquivo (geração sintética / TXT a partir do layout XML).
+    ///
+    /// Por que isso é um método de extensão e não um bloco solto no <c>Program.cs</c>: o grupo já foi
+    /// perdido DUAS vezes. Na primeira (issue #33) ele nunca existiu; na segunda, a resolução de
+    /// conflito do merge que removeu o Pathway 1 apagou o bloco inteiro como dano colateral e o
+    /// teste que deveria travar a regressão continuou verde, porque ele COPIAVA os registros num
+    /// <c>ServiceCollection</c> próprio em vez de exercitar a composição real. Com a composição num
+    /// único lugar, o teste chama exatamente o que o <c>Program.cs</c> chama — não uma réplica que
+    /// pode divergir.
+    /// </summary>
+    public static class GenerationServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registra o grupo Generation (Scoped, como o resto dos serviços de request).
+        /// </summary>
+        public static IServiceCollection AddGenerationServices(this IServiceCollection services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            // Dependências diretas do construtor do DataGenerationController.
+            services.AddScoped<ISyntheticDataGeneratorService, SyntheticDataGeneratorService>();
+            services.AddScoped<IExcelDataProcessor, ExcelDataProcessor>();
+            services.AddScoped<ILayoutAnalysisService, LayoutAnalysisService>();
+            services.AddScoped<TxtFileGeneratorFactory>();
+
+            // Dependências internas do TxtFileGeneratorFactory: ele recebe só o IServiceProvider e
+            // resolve estas por GetRequiredService dentro do Create() — ou seja, a falta delas NÃO
+            // aparece ao resolver o controller, só quando o endpoint chama o factory.
+            services.AddScoped<XmlLayoutParser>();
+            services.AddScoped<ExcelRulesParser>();
+            // Nome totalmente qualificado de propósito: LayoutValidator existe em
+            // Generation.TxtGenerator.Validators E em Parsing.Implementations (este último já
+            // registrado como ILayoutValidator no grupo Parsing). Aqui é o de Generation.
+            services.AddScoped<LayoutParserApi.Services.Generation.TxtGenerator.Validators.LayoutValidator>();
+
+            // Geradores de valor escolhidos por GenerationMode dentro do TxtFileGeneratorService.
+            // Lá a resolução é por GetService (nullable): sem registro NÃO lança na criação — o campo
+            // fica null e o estouro vira NullReferenceException no meio da geração do arquivo.
+            services.AddScoped<DeterministicGenerator>();
+            services.AddScoped<RandomGenerator>();
+
+            return services;
+        }
+    }
+}

--- a/Services/Health/CatalogWarmupState.cs
+++ b/Services/Health/CatalogWarmupState.cs
@@ -1,6 +1,24 @@
 namespace LayoutParserApi.Services.Health
 {
     /// <summary>
+    /// Os TRÊS estados possíveis do warm-up do catálogo. Existem separados de propósito: "ainda
+    /// aquecendo" e "aqueceu e veio vazio" respondem o mesmo HTTP (503), mas são problemas
+    /// diferentes — o primeiro se resolve sozinho (retry da issue #67), o segundo exige
+    /// intervenção (SQL/decryptor fora, catálogo realmente sem layouts).
+    /// </summary>
+    public enum CatalogWarmupStatus
+    {
+        /// <summary>Warm-up ainda não concluiu (1ª tentativa ou retry em andamento). <b>Transitório.</b></summary>
+        Aquecendo = 0,
+
+        /// <summary>Warm-up concluiu e o catálogo tem layouts (&gt; 0). Único estado saudável.</summary>
+        Pronto = 1,
+
+        /// <summary>Warm-up concluiu e o catálogo veio <b>VAZIO</b>. Definitivo — não é saudável.</summary>
+        Vazio = 2
+    }
+
+    /// <summary>
     /// Estado compartilhado (Singleton) do resultado do warm-up do catálogo de layouts.
     ///
     /// <para>Existe para a sonda de <b>readiness</b> responder a pergunta que importa: "o warm-up
@@ -12,11 +30,18 @@ namespace LayoutParserApi.Services.Health
     /// <para>Deliberadamente independente do Redis: guarda a CONTAGEM que o warm-up conseguiu
     /// carregar do banco, não o tamanho do cache — sem Redis, o catálogo funciona por disco/banco
     /// e a readiness não pode falhar só por Redis ausente (que é Degraded, não Unhealthy).</para>
+    ///
+    /// <para><b>Três estados, não dois</b> (ver <see cref="CatalogWarmupStatus"/>): só se chama
+    /// <see cref="SetResult(int)"/> quando o warm-up REALMENTE concluiu — uma tentativa que falhou
+    /// (SQL fora, busca sem sucesso) usa <see cref="RegisterFailedAttempt(string)"/> e mantém o
+    /// estado em <see cref="CatalogWarmupStatus.Aquecendo"/>, preservando o retry da issue #67.</para>
     /// </summary>
     public sealed class CatalogWarmupState
     {
         private volatile bool _completed;
         private int _layoutCount = -1; // -1 = warm-up ainda não concluiu
+        private int _failedAttempts;
+        private volatile string? _lastFailureReason;
 
         /// <summary>Warm-up já concluiu (com sucesso ou com contagem zero)?</summary>
         public bool Completed => _completed;
@@ -24,11 +49,50 @@ namespace LayoutParserApi.Services.Health
         /// <summary>Quantidade de layouts que o warm-up conseguiu carregar. -1 enquanto não concluiu.</summary>
         public int LayoutCount => Volatile.Read(ref _layoutCount);
 
-        /// <summary>Registra o resultado do warm-up. Chamado uma vez, ao fim da população do cache.</summary>
+        /// <summary>Quantas tentativas de warm-up falharam até agora (retry em andamento).</summary>
+        public int FailedAttempts => Volatile.Read(ref _failedAttempts);
+
+        /// <summary>
+        /// Motivo curto da última tentativa que falhou (ex.: nome do tipo da exceção). Só categoria —
+        /// <b>nunca</b> mensagem crua de exceção, porque este valor é exposto anonimamente no corpo
+        /// de <c>/health/ready</c> e mensagem de erro de SQL pode carregar detalhe de conexão.
+        /// </summary>
+        public string? LastFailureReason => _lastFailureReason;
+
+        /// <summary>Classificação em três estados consumida pelo <c>CatalogHealthCheck</c>.</summary>
+        public CatalogWarmupStatus Status
+        {
+            get
+            {
+                if (!_completed)
+                    return CatalogWarmupStatus.Aquecendo;
+
+                return LayoutCount > 0 ? CatalogWarmupStatus.Pronto : CatalogWarmupStatus.Vazio;
+            }
+        }
+
+        /// <summary>
+        /// Registra o resultado de um warm-up que CONCLUIU. Chamado uma vez, ao fim da população do
+        /// cache. Contagem zero aqui significa "o catálogo está mesmo vazio" (estado definitivo) —
+        /// não use para falha de leitura; para isso existe <see cref="RegisterFailedAttempt(string)"/>.
+        /// </summary>
         public void SetResult(int layoutCount)
         {
             Volatile.Write(ref _layoutCount, layoutCount);
             _completed = true;
+        }
+
+        /// <summary>
+        /// Registra uma tentativa de warm-up que falhou. NÃO conclui o warm-up de propósito: o estado
+        /// permanece <see cref="CatalogWarmupStatus.Aquecendo"/> para que a readiness reporte
+        /// "ainda não pronto" (transitório, o retry ainda pode recuperar) em vez de "catálogo vazio"
+        /// (definitivo). Só serve para diagnóstico — não muda o resultado HTTP.
+        /// </summary>
+        /// <param name="motivo">Categoria curta e não sensível (ex.: <c>SqlException</c>).</param>
+        public void RegisterFailedAttempt(string motivo)
+        {
+            Interlocked.Increment(ref _failedAttempts);
+            _lastFailureReason = motivo;
         }
     }
 }

--- a/Services/Health/ReadinessHealthChecks.cs
+++ b/Services/Health/ReadinessHealthChecks.cs
@@ -120,8 +120,23 @@ namespace LayoutParserApi.Services.Health
     }
 
     /// <summary>
-    /// Contagem do warm-up. Catálogo vazio (ou warm-up não concluído) = <b>Unhealthy</b> → readiness
-    /// falha (503). É o gate que fecha a classe "deploy publica versão inoperante e declara sucesso".
+    /// Contagem do warm-up. É o gate que fecha a classe "deploy publica versão inoperante e declara
+    /// sucesso" — e distingue <b>TRÊS</b> estados, não dois:
+    ///
+    /// <list type="bullet">
+    ///   <item><b>Aquecendo</b> (warm-up não concluiu / retry em andamento) → Unhealthy, mas marcado
+    ///   como <c>transitorio=true</c>: é "ainda não pronto", não "quebrado".</item>
+    ///   <item><b>Pronto</b> (concluiu com layouts &gt; 0) → Healthy. Único estado saudável.</item>
+    ///   <item><b>Vazio</b> (concluiu e o catálogo veio VAZIO) → Unhealthy <c>transitorio=false</c>:
+    ///   falha definitiva, exige intervenção (SQL/decryptor fora, catálogo sem layouts).</item>
+    /// </list>
+    ///
+    /// <para><b>Por que "Aquecendo" é Unhealthy e não Degraded:</b> Degraded mapeia para 200 em
+    /// <c>/health/ready</c> (ver Program.cs) e o smoke test de deploy exige 200 ESTRITO — reportar
+    /// Degraded enquanto aquece faria o deploy declarar sucesso com o catálogo ainda vazio, que é
+    /// exatamente o bug que esta sonda existe para fechar. O smoke test já trata 503 como "ainda não
+    /// pronto" e retenta, então manter Unhealthy não trava deploy nenhum; o que muda é a
+    /// <b>descrição/payload</b>, que agora diz claramente qual dos dois 503 é.</para>
     /// </summary>
     public sealed class CatalogHealthCheck : IHealthCheck
     {
@@ -131,13 +146,43 @@ namespace LayoutParserApi.Services.Health
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            if (!_state.Completed)
-                return Task.FromResult(HealthCheckResult.Unhealthy("Warm-up do catalogo ainda nao concluiu — instancia nao esta pronta."));
+            var status = _state.Status;
 
-            if (_state.LayoutCount <= 0)
-                return Task.FromResult(HealthCheckResult.Unhealthy("Catalogo de layouts VAZIO apos warm-up (SQL/decryptor fora?) — instancia nao esta pronta."));
+            // Payload legível pelo operador (o corpo do /health/ready aparece no log do smoke test)
+            // e por monitoramento — permite alertar só no estado definitivo, sem barulho de warm-up.
+            var data = new Dictionary<string, object>
+            {
+                ["estado"] = status.ToString(),
+                ["layoutCount"] = _state.LayoutCount,
+                ["transitorio"] = status == CatalogWarmupStatus.Aquecendo,
+                ["tentativasFalhas"] = _state.FailedAttempts
+            };
 
-            return Task.FromResult(HealthCheckResult.Healthy($"Catalogo com {_state.LayoutCount} layouts."));
+            if (!string.IsNullOrEmpty(_state.LastFailureReason))
+                data["ultimaFalha"] = _state.LastFailureReason!;
+
+            var resultado = status switch
+            {
+                CatalogWarmupStatus.Pronto =>
+                    HealthCheckResult.Healthy($"Catalogo com {_state.LayoutCount} layouts.", data),
+
+                CatalogWarmupStatus.Vazio =>
+                    HealthCheckResult.Unhealthy(
+                        "Catalogo de layouts VAZIO apos warm-up CONCLUIDO (SQL/decryptor fora, ou catalogo sem layouts) — " +
+                        "falha DEFINITIVA, nao se resolve sozinha: exige intervencao.",
+                        exception: null,
+                        data: data),
+
+                // Aquecendo (inclui a 1ª tentativa e todo retry com backoff da issue #67).
+                _ =>
+                    HealthCheckResult.Unhealthy(
+                        $"Catalogo AQUECENDO — warm-up ainda nao concluiu ({_state.FailedAttempts} tentativa(s) falharam ate agora). " +
+                        "Transitorio: o retry com backoff ainda pode recuperar sozinho, NAO e falha definitiva.",
+                        exception: null,
+                        data: data)
+            };
+
+            return Task.FromResult(resultado);
         }
     }
 }

--- a/Services/Transformation/Ai/AiCandidateStore.cs
+++ b/Services/Transformation/Ai/AiCandidateStore.cs
@@ -18,7 +18,12 @@ namespace LayoutParserApi.Services.Transformation.Ai
     {
         private readonly ILogger<AiCandidateStore> _logger;
         private readonly string _storePath;
-        private readonly ConcurrentDictionary<string, AiCandidateStatus> _memory = new();
+        private readonly TimeSpan _ttl;
+        private readonly Func<DateTimeOffset> _clock;
+        private readonly ConcurrentDictionary<string, StoredEntry> _memory = new();
+
+        /// <summary>Ticket em memória + carimbo de quando foi escrito (base do TTL da issue #51).</summary>
+        private readonly record struct StoredEntry(AiCandidateStatus Status, DateTime StoredAtUtc);
 
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
@@ -29,9 +34,20 @@ namespace LayoutParserApi.Services.Transformation.Ai
             WriteIndented = true
         };
 
-        public AiCandidateStore(ILogger<AiCandidateStore> logger, IOptions<AiTransformationCandidateOptions> options)
+        /// <param name="clock">
+        /// Relógio injetável (issue #51). Em produção fica nulo e cai em <c>DateTimeOffset.UtcNow</c>;
+        /// nos testes permite envelhecer tickets sem <c>Task.Delay</c> real. É opcional de propósito
+        /// para o registro no DI continuar sendo o <c>AddSingleton&lt;AiCandidateStore&gt;()</c> simples.
+        /// </param>
+        public AiCandidateStore(
+            ILogger<AiCandidateStore> logger,
+            IOptions<AiTransformationCandidateOptions> options,
+            Func<DateTimeOffset>? clock = null)
         {
             _logger = logger;
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+            var ttlHoras = options.Value.TicketTtlHours;
+            _ttl = TimeSpan.FromHours(ttlHoras > 0 ? ttlHoras : AiTransformationCandidateOptions.DefaultTicketTtlHours);
             _storePath = options.Value.StorePath
                 ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "AiTransformationCandidates");
 
@@ -46,8 +62,13 @@ namespace LayoutParserApi.Services.Transformation.Ai
             }
         }
 
+        /// <summary>Janela de retenção efetiva do ticket (<c>AiTransformationCandidate:TicketTtlHours</c>).</summary>
+        public TimeSpan Ttl => _ttl;
+
         public void Set(string ticket, AiCandidateStatus status)
         {
+            var agoraUtc = _clock().UtcDateTime;
+
             // Grava em disco ANTES de publicar em memória: quem consulta GetStatusAsync via
             // polling só pode ver "pronto" depois que o arquivo já está completo e fechado.
             // Antes desta correção a ordem era invertida (memória primeiro) e sob contenção de
@@ -58,7 +79,25 @@ namespace LayoutParserApi.Services.Transformation.Ai
             {
                 var path = ResolvePath(ticket);
                 if (path != null)
+                {
                     File.WriteAllText(path, JsonSerializer.Serialize(status, JsonOptions), Encoding.UTF8);
+
+                    // Idade do ticket em disco = LastWriteTime do arquivo. Carimbar explicitamente
+                    // (em vez de deixar o do sistema) mantém disco e memória no MESMO relógio —
+                    // inclusive o injetado nos testes — e evita ter que sujar o DTO de status, que
+                    // é o corpo da resposta do endpoint, com um campo de controle interno.
+                    // Try próprio: se só o carimbo falhar (antivírus/indexador segurando o handle),
+                    // a persistência em si deu certo — logar "falha ao persistir" seria mentira, e
+                    // o arquivo fica com o LastWriteTime do sistema, que em produção é o mesmo instante.
+                    try
+                    {
+                        File.SetLastWriteTimeUtc(path, agoraUtc);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Falha ao carimbar a data do ticket do pathway IA (ticket={Ticket})", ticket);
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -68,13 +107,24 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 _logger.LogWarning(ex, "Falha ao persistir em disco o status do pathway IA (ticket={Ticket})", ticket);
             }
 
-            _memory[ticket] = status;
+            _memory[ticket] = new StoredEntry(status, agoraUtc);
         }
 
         public AiCandidateStatus? Get(string ticket)
         {
+            var limiteUtc = ExpiracaoUtc();
+
             if (_memory.TryGetValue(ticket, out var cached))
-                return cached;
+            {
+                if (cached.StoredAtUtc > limiteUtc)
+                    return cached.Status;
+
+                // Ticket vencido: sai da memória na hora, custo O(1). Nada de varrer diretório
+                // aqui — a limpeza em disco é do BackgroundService, o caminho de request (polling
+                // de GetStatusAsync) não pode pagar por I/O de manutenção.
+                _memory.TryRemove(ticket, out _);
+                return null;
+            }
 
             try
             {
@@ -82,10 +132,16 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 if (path == null || !File.Exists(path))
                     return null;
 
+                // Ticket lido do disco (ex.: depois de um restart da API) não ganha vida nova: o
+                // TTL é absoluto a partir da última escrita, não deslizante por leitura.
+                var escritoEmUtc = File.GetLastWriteTimeUtc(path);
+                if (escritoEmUtc <= limiteUtc)
+                    return null;
+
                 var json = File.ReadAllText(path, Encoding.UTF8);
                 var status = JsonSerializer.Deserialize<AiCandidateStatus>(json, JsonOptions);
                 if (status != null)
-                    _memory[ticket] = status;
+                    _memory[ticket] = new StoredEntry(status, escritoEmUtc);
                 return status;
             }
             catch (Exception ex)
@@ -94,6 +150,67 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 return null;
             }
         }
+
+        /// <summary>
+        /// Remove tickets vencidos das DUAS camadas — memória e disco (issue #51). Chamado pelo
+        /// <see cref="AiCandidateStoreCleanupBackgroundService"/>, fora do caminho de request.
+        /// Best-effort ponta a ponta: nenhuma falha de I/O aborta a varredura nem sobe para o host.
+        /// </summary>
+        /// <remarks>
+        /// Síncrono de propósito: é I/O de arquivo (<c>EnumerateFiles</c>/<c>Delete</c>), que não
+        /// tem contrapartida async real no BCL — envolver em <c>Task.Run</c> só criaria indireção.
+        /// Roda numa thread de background, nunca numa request.
+        /// </remarks>
+        public AiCandidateStoreCleanupResult RemoveExpired()
+        {
+            var limiteUtc = ExpiracaoUtc();
+            var memoriaRemovida = 0;
+            var arquivosRemovidos = 0;
+
+            foreach (var entrada in _memory)
+            {
+                if (entrada.Value.StoredAtUtc > limiteUtc)
+                    continue;
+
+                // Remoção condicional (par chave+valor): se um Set() concorrente republicou o
+                // ticket entre a leitura e a remoção, a entrada nova não é derrubada por engano.
+                if (_memory.TryRemove(entrada))
+                    memoriaRemovida++;
+            }
+
+            try
+            {
+                if (Directory.Exists(_storePath))
+                {
+                    foreach (var arquivo in Directory.EnumerateFiles(_storePath, "*.json"))
+                    {
+                        try
+                        {
+                            if (File.GetLastWriteTimeUtc(arquivo) > limiteUtc)
+                                continue;
+
+                            File.Delete(arquivo);
+                            arquivosRemovidos++;
+                        }
+                        catch (Exception ex)
+                        {
+                            // Best-effort por arquivo (mesmo espírito do CleanupOldRuns do Job 1 de
+                            // métricas): um arquivo travado/em uso não pode abortar a varredura toda.
+                            _logger.LogDebug(ex, "Falha ao remover ticket vencido do pathway IA: {Arquivo}", arquivo);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha ao varrer o diretório da store do pathway IA em {StorePath}", _storePath);
+            }
+
+            return new AiCandidateStoreCleanupResult(memoriaRemovida, arquivosRemovidos);
+        }
+
+        /// <summary>Instante-limite: o que foi escrito até aqui está vencido.</summary>
+        private DateTime ExpiracaoUtc() => _clock().UtcDateTime - _ttl;
 
         // Ticket já vem validado por LowCodeTransformationStore.TryParseTicket no controller — aqui
         // só canonicalizamos e conferimos o prefixo, mesma defesa em profundidade do store low-code.
@@ -117,5 +234,13 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 return null;
             }
         }
+    }
+
+    /// <summary>Resultado de uma varredura de limpeza da store do pathway IA (issue #51).</summary>
+    /// <param name="TicketsEmMemoria">Tickets vencidos removidos do cache em memória.</param>
+    /// <param name="ArquivosEmDisco">Arquivos de ticket vencidos removidos do disco.</param>
+    public record AiCandidateStoreCleanupResult(int TicketsEmMemoria, int ArquivosEmDisco)
+    {
+        public int Total => TicketsEmMemoria + ArquivosEmDisco;
     }
 }

--- a/Services/Transformation/Ai/AiCandidateStoreCleanupBackgroundService.cs
+++ b/Services/Transformation/Ai/AiCandidateStoreCleanupBackgroundService.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Transformation.Ai
+{
+    /// <summary>
+    /// Poda periódica dos tickets vencidos do <see cref="AiCandidateStore"/> — memória e disco
+    /// (issue #51: cada <c>execute-candidates</c> que dispara o pathway IA criava um ticket que
+    /// nunca era removido).
+    ///
+    /// <para><b>Por que BackgroundService e não varredura oportunista no Set/Get:</b> o Set/Get é
+    /// caminho de request (o front faz polling do status) e não pode pagar por
+    /// <c>EnumerateFiles</c> do diretório inteiro; além disso, varredura oportunista só roda quando
+    /// há tráfego — numa instância ociosa o lixo do dia anterior ficaria em disco indefinidamente.
+    /// O timer é previsível e independe de tráfego. O custo é um ciclo de vida novo, mas o projeto
+    /// já tem esse padrão (<c>CachePermanentWarmupBackgroundService</c>,
+    /// <c>LayoutValidationBackgroundService</c>). Como complemento O(1) e sem I/O, o próprio
+    /// <c>Get</c> descarta a entrada vencida da memória entre duas varreduras.</para>
+    /// </summary>
+    public class AiCandidateStoreCleanupBackgroundService : BackgroundService
+    {
+        private readonly ILogger<AiCandidateStoreCleanupBackgroundService> _logger;
+        private readonly AiCandidateStore _store;
+        private readonly TimeSpan _intervalo;
+
+        public AiCandidateStoreCleanupBackgroundService(
+            ILogger<AiCandidateStoreCleanupBackgroundService> logger,
+            AiCandidateStore store,
+            IOptions<AiTransformationCandidateOptions> options)
+        {
+            _logger = logger;
+            _store = store;
+
+            var minutos = options.Value.CleanupIntervalMinutes;
+            _intervalo = TimeSpan.FromMinutes(
+                minutos > 0 ? minutos : AiTransformationCandidateOptions.DefaultCleanupIntervalMinutes);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Cede a thread de startup imediatamente (RemoveExpired é I/O síncrono) e evita
+            // concorrer com o warm-up de cache nos primeiros segundos de vida da API.
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            _logger.LogInformation(
+                "Limpeza da store do pathway IA ativa (TTL {TtlHoras}h, varredura a cada {IntervaloMinutos}min)",
+                _store.Ttl.TotalHours, _intervalo.TotalMinutes);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                // Primeira varredura já no start: o TTL é absoluto por escrita, então o que sobrou
+                // de execuções anteriores da API entra vencido e é podado sem esperar um ciclo.
+                try
+                {
+                    var resultado = _store.RemoveExpired();
+                    if (resultado.Total > 0)
+                    {
+                        _logger.LogInformation(
+                            "Limpeza da store do pathway IA removeu {TicketsEmMemoria} ticket(s) da memória e {ArquivosEmDisco} arquivo(s) do disco",
+                            resultado.TicketsEmMemoria, resultado.ArquivosEmDisco);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Degrade: limpeza é manutenção — nunca pode derrubar o host nem interromper o
+                    // loop (dotnet-standards.md §Resiliência / §Background work).
+                    _logger.LogWarning(ex, "Falha na varredura de limpeza da store do pathway IA");
+                }
+
+                try
+                {
+                    await Task.Delay(_intervalo, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break; // Host parando.
+                }
+            }
+        }
+    }
+}

--- a/Services/Transformation/Ai/AiTransformationCandidateOptions.cs
+++ b/Services/Transformation/Ai/AiTransformationCandidateOptions.cs
@@ -8,6 +8,18 @@ namespace LayoutParserApi.Services.Transformation.Ai
     /// </summary>
     public class AiTransformationCandidateOptions
     {
+        /// <summary>
+        /// Retenção default de um ticket na store (issue #51). Escolha de 72h: o job em si morre em
+        /// no máximo <see cref="SanityTimeoutMinutes"/> (45min), então nenhum ticket vivo é atingido;
+        /// o que sobra é valor de diagnóstico ("por que o job de ontem falhou?"), e 3 dias cobrem a
+        /// janela de um ticket criado na sexta à noite e triado na segunda de manhã. Acima disso é
+        /// auditoria de longo prazo — papel do log estruturado (Serilog), não desta store.
+        /// </summary>
+        public const int DefaultTicketTtlHours = 72;
+
+        /// <summary>Intervalo default entre varreduras de limpeza (issue #51).</summary>
+        public const int DefaultCleanupIntervalMinutes = 60;
+
         /// <summary>Máximo de iterações do loop gerar → aplicar → diff → validar → corrigir.</summary>
         public int MaxIterations { get; set; } = 3;
 
@@ -20,5 +32,20 @@ namespace LayoutParserApi.Services.Transformation.Ai
 
         /// <summary>Onde persistir o job por ticket (padrão: MLData/AiTransformationCandidates).</summary>
         public string? StorePath { get; set; }
+
+        /// <summary>
+        /// TTL do ticket na store, em horas (issue #51 — sem isso a store crescia indefinidamente
+        /// em memória E em disco). Vale para as duas camadas e é <b>absoluto a partir da última
+        /// escrita</b>, não deslizante por leitura: polling de status não mantém um ticket vivo
+        /// para sempre. Valor &lt;= 0 cai no default (<see cref="DefaultTicketTtlHours"/>), mesma
+        /// convenção de <see cref="MaxIterations"/>/<see cref="SanityTimeoutMinutes"/>.
+        /// </summary>
+        public int TicketTtlHours { get; set; } = DefaultTicketTtlHours;
+
+        /// <summary>
+        /// Intervalo entre varreduras do <c>AiCandidateStoreCleanupBackgroundService</c>, em minutos.
+        /// Valor &lt;= 0 cai no default (<see cref="DefaultCleanupIntervalMinutes"/>).
+        /// </summary>
+        public int CleanupIntervalMinutes { get; set; } = DefaultCleanupIntervalMinutes;
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -26,6 +26,12 @@
     "Model": "deepseek-coder:6.7b",
     "DiagnosisTimeoutSeconds": 60
   },
+  "AiTransformationCandidate": {
+    "MaxIterations": 3,
+    "SanityTimeoutMinutes": 45,
+    "TicketTtlHours": 72,
+    "CleanupIntervalMinutes": 60
+  },
   "RAG": {
     "ExamplesPath": "Exemplos",
     "RulesPath": "Data/Rules"

--- a/docs/architecture/auditoria-gates-bugs-2026-08-14.md
+++ b/docs/architecture/auditoria-gates-bugs-2026-08-14.md
@@ -1,0 +1,230 @@
+# Auditoria de gates, bugs e débito técnico — 2026-08-14
+
+Missão `review-arch` (`@lp-architect`). Escopo: repositório inteiro (código, CI/CD, docs de
+arquitetura, memórias de agente). Objetivo: achar coisas **novas** — o que já virou issue
+(#30–#67, todas fechadas em `gh issue list`) não é repetido aqui, exceto quando a issue foi
+fechada citando uma correção que **não cobre o que a issue descrevia** (achados #1 e #2 abaixo).
+
+Metodologia: leitura dos índices de memória de todos os agentes, `gh issue list --state all`,
+leitura de `Program.cs`, dos 4 workflows (`ci-dev.yml`, `deploy.yml`, `merge-gate.yml`,
+`codeql.yml`), do `security-code-scan-baseline.json`, e busca dirigida por padrões de risco
+(`.Result`/`.Wait()`, `Task.Run` sem try/catch, DI não registrado) nos controllers e serviços.
+Cada achado tem evidência em arquivo:linha ou comando reproduzível.
+
+## Resumo executivo
+
+| Severidade | Qtd | Novos (não rastreados) |
+|---|---|---|
+| Crítico | 1 | 1 |
+| Alto | 2 | 2 |
+| Médio | 2 | 2 |
+| Baixo | 1 | 1 |
+
+Achado mais importante: uma correção já fechada como concluída (issue #33) **regrediu
+silenciosamente** e o endpoint voltou a quebrar em runtime — o teste de regressão que deveria
+proteger contra isso não exercita o `Program.cs` real, só uma cópia manual dele.
+
+---
+
+## 1. [CRÍTICO] `DataGenerationController` quebra em runtime — regressão da issue #33 (fechada)
+
+**O que aconteceu:** a issue #33 (fechada 2026-08-13, commit `6082834`) registrou
+`ISyntheticDataGeneratorService`, `IExcelDataProcessor`, `ILayoutAnalysisService` e as
+dependências do `TxtFileGeneratorFactory` no DI de `Program.cs`. Um commit posterior na mesma
+branch (`9e52791` "refactor: remove Pathway 1 legado", consolidado no merge `612a5a3
+"resolvendo conflito"`) **apagou o bloco inteiro** desses registros como dano colateral de uma
+resolução de conflito — a intenção era remover só `IMapperTransformationService` (Pathway 1),
+mas o bloco "Generation Services" que ficava logo abaixo dele foi junto.
+
+**Estado atual confirmado nesta sessão** (`HEAD` = `1dc58f2`, branch `develop`):
+```
+$ git diff 6082834 HEAD -- Program.cs   # mostra a remoção do bloco inteiro
+$ grep -n "ISyntheticDataGeneratorService\|IExcelDataProcessor\|ILayoutAnalysisService\|TxtFileGeneratorFactory" Program.cs
+(nenhum resultado)
+$ grep -n "ISyntheticDataGeneratorService" Controllers/DataGenerationController.cs
+23:        private readonly ISyntheticDataGeneratorService _dataGenerator;
+31:            ISyntheticDataGeneratorService dataGenerator,
+```
+O controller ainda injeta o serviço; o serviço não está mais registrado. Qualquer chamada a
+`DataGenerationController` volta a derrubar com `InvalidOperationException` de resolução de DI —
+exatamente o sintoma original da issue #33, agora sem issue aberta cobrindo.
+
+**Por que o quality gate não pegou isso:** `tests/LayoutParserApi.Tests/Controllers/
+DataGenerationControllerDiTests.cs` foi escrito para "travar a regressão sem precisar subir a
+aplicação inteira" — mas faz isso construindo um `ServiceCollection` **próprio**, com os
+registros **copiados manualmente** (linhas 33-40 do teste), em vez de carregar o `Program.cs`
+real. O teste continua verde porque testa a cópia, não o original — a suíte de testes (`dotnet
+test`, gate obrigatório em `ci-dev.yml`) não detecta a regressão porque nunca olhou para o
+`Program.cs` de verdade.
+
+**Impacto:** endpoint de geração de dados sintéticos (usado para fixtures/RAG fiscal — ver
+`docs/architecture/ia-fiscal-diagnosis-vision.md`) está morto em `develop` agora mesmo.
+
+**Recomendação (para `@lp-backend-dev`):**
+- Reintroduzir o bloco de registro em `Program.cs` (grupo "Generation Services").
+- Trocar (ou complementar) `DataGenerationControllerDiTests` por um teste que resolve o
+  controller a partir do `WebApplicationFactory`/`builder.Services` real (ou, no mínimo, um
+  teste de smoke que enumera todos os `[ApiController]` do assembly e garante que cada um
+  resolve via DI a partir do container de `Program.cs` — fecha esta classe inteira de bug de
+  uma vez, não só para este controller).
+
+**Rastreamento:** NOVO — issue #33 está fechada e não reflete o estado atual; precisa de issue
+nova (ou reabertura com nota da regressão).
+
+---
+
+## 2. [ALTO] `AiCandidateStore` — leak de memória/disco ainda presente; issue #51 fechada citando correção de outro subsistema
+
+**O que a issue #51 pedia:** TTL/limpeza para `Services/Transformation/Ai/AiCandidateStore.cs`
+— um `ConcurrentDictionary` em memória e arquivos em `MLData/AiTransformationCandidates/*.json`
+que crescem sem limite a cada ticket do pathway de IA em `execute-candidates` (issue #40).
+
+**O que foi fechado como correção:** o comentário de fechamento (2026-08-13) cita o commit
+`294ca22` — que adiciona `CleanupOldRuns`/`DefaultRetentionDays = 30` em
+`ai/XslSynth/Metrics/RunManifest.cs`. Esse é um componente **diferente**: `ai/XslSynth` é o
+projeto standalone de síntese/métricas do Job 1 (ver memória `xslsynth-trilha-a-overlap.md`),
+não o `AiCandidateStore` do pathway `execute-candidates` da API. Nomes parecidos (ambos lidam
+com "retenção"/"limpeza" de artefatos de IA), subsistemas distintos.
+
+**Confirmado nesta sessão:**
+```
+$ grep -n "TTL\|Retention\|Cleanup\|ConcurrentDictionary" Services/Transformation/Ai/AiCandidateStore.cs
+21:        private readonly ConcurrentDictionary<string, AiCandidateStatus> _memory = new();
+```
+Nenhuma lógica de expiração, nem em memória nem no `File.WriteAllText` (linha 61) que grava em
+disco. O leak descrito na issue #51 está integralmente presente no código hoje.
+
+**Impacto:** uso continuado do pathway `execute-candidates` (issue #40, já em produção) acumula
+tickets indefinidamente — memória do processo da API e disco em `MLData/
+AiTransformationCandidates/` crescem sem parar. Não é urgente (não derruba nada agora), mas é
+exatamente o tipo de achado que costuma ser descoberto tarde, com o processo já degradado.
+
+**Recomendação:** reabrir #51 ou abrir issue nova apontando explicitamente para
+`Services/Transformation/Ai/AiCandidateStore.cs`, com critério de aceite igual ao original.
+
+**Rastreamento:** issue existe (#51) mas está **fechada incorretamente** — tratar como NOVO para
+fins de decisão do dono.
+
+---
+
+## 3. [ALTO] Deploy de produção não roda a suíte de testes — e pode ser disparado sem PR
+
+**Gate que existe:** `ci-dev.yml` (dispara em push a `develop`/`feat/**`) roda `dotnet test`
+como gate obrigatório (linha "Testes (xUnit)") — teste vermelho aborta o deploy de dev.
+
+**Gate que NÃO existe:** `deploy.yml` (dispara em `push` a `main`/`master`, e via
+`workflow_dispatch`) builda e publica a API **sem nenhum step de teste**. Conferido lendo o
+arquivo inteiro: da checagem de `LayoutParserLib`/`LayoutParserDecrypt`/`LayoutParserApi` até o
+`Deploy to server (local)`, não há `dotnet test` em lugar nenhum.
+
+**Como isso compõe com a branch protection perdida:** `agent-authority.md` já documenta que a
+proteção nativa de branch foi perdida em 2026-08-12 (repos privados, plano free) e que o
+enforcement "master só recebe PR de develop" hoje é só o `merge-gate.yml`, que roda **apenas em
+evento `pull_request`** (`on: pull_request: branches: [master, main]`). Um `git push` direto a
+`master` (por qualquer conta com permissão de escrita, humana ou agente) **não dispara
+`merge-gate.yml`** — só dispara `deploy.yml`, que não testa nada. Ou seja: hoje é possível ir de
+um `git push origin master` a produção rodando, sem que nenhum teste automatizado tenha
+executado sobre aquele código.
+
+Isso não é o mesmo achado da issue #34 (TLS desligado, fechada) nem do registro de
+`agent-authority.md` (perda de enforcement — já documentado); é a composição dos dois com a
+ausência específica de teste em `deploy.yml`, que ainda não tinha sido apontada.
+
+**Recomendação:** adicionar um step `dotnet test` em `deploy.yml`, mesmo que redundante com
+`ci-dev.yml` na maioria dos fluxos (feature → develop → master) — ele é a única rede de segurança
+que sobra no caminho push-direto-a-master. Se o custo de repetir a suíte em todo deploy de
+produção for uma preocupação, ao menos gatear em `workflow_dispatch`/push fora do fluxo normal.
+
+**Rastreamento:** NOVO.
+
+---
+
+## 4. [MÉDIO] 27 achados de severidade alta do SecurityCodeScan aceitos em baseline sem issue de rastreamento
+
+**Evidência:** `security-code-scan-baseline.json` (raiz do repo), gerado 2026-08-13, lista 26
+achados `SCS0018` (path traversal) e 1 `SCS0016` (CSRF) espalhados por `DocumentController.cs`,
+`MetricsController.cs`, `ParseController.cs`, `AutomatedTransformationTestService.cs`,
+`LowCodeAutoTransformationService.cs`, `LowCodeTransformationStore.cs`,
+`TransformationLearningService.cs`, `TransformationValidatorService.cs`,
+`DocumentMLValidationService.cs`, `TransformationPipelineService.cs`, `XsdValidationService.cs`.
+O gate de CI (`ci-dev.yml`, step "Security Code Scan - gate por severidade") só bloqueia achados
+**fora** desse baseline — os 27 listados continuam aparecendo como warning, nunca bloqueiam.
+
+O próprio `_readme` do arquivo instrui: *"devem virar issue via @lp-pm para correção futura"*.
+Isso não foi feito — `gh issue list --state all` não tem nenhuma issue com "path traversal",
+"SCS0018" ou "SecurityCodeScan" no título. É debito técnico formalmente documentado no código,
+mas não no backlog rastreável.
+
+**Nota de risco:** a maioria dos SCS0018 é em caminhos de arquivo compostos a partir de
+`layoutName`/`mapperName`/GUIDs vindos de configuração ou banco (baixo risco de exploração
+direta por usuário final), mas dois merecem checagem prioritária por estarem em
+`Controllers/DocumentController.cs` e `Controllers/ParseController.cs` — mais próximos de input
+de requisição HTTP do que os demais (Services internos).
+
+**Recomendação:** `@lp-pm` formalizar como uma única issue "tech-debt" agregando os 27 achados
+(ou uma por arquivo, se preferir granularidade), citando o baseline como fonte. Isso também
+resolve o problema de fragilidade do baseline por número de linha (documentado no próprio
+`_readme`) — uma issue rastreável sobrevive a refactors que uma chave `arquivo:linha` não
+sobrevive.
+
+**Rastreamento:** NOVO.
+
+---
+
+## 5. [MÉDIO] `merge-gate.yml` e `deploy.yml` (produção) sem controle de concorrência entre si
+
+Achado menor de composição: `deploy.yml` já documenta (`concurrency: group: deploy-prod,
+cancel-in-progress: false`) que deploys concorrentes enfileiram para não interromper uma troca de
+binário no meio. Isso é correto para deploys entre si, mas não existe nenhum gate que impeça um
+segundo push a `master` (ex.: hotfix urgente) de entrar na fila **atrás** de um deploy que já
+está falhando/travado (o timeout do job é 60 min) — não há alerta de fila crescendo, só o log do
+Actions. Baixo risco na cadência atual (deploys pouco frequentes), mas vale registrar caso a
+cadência aumente.
+
+**Rastreamento:** NOVO, severidade baixa — incluído aqui só como nota, não recomendo abrir issue
+agora (esperar sinal real de fila).
+
+---
+
+## 6. [BAIXO] `RefreshLayoutCacheWithRetryAsync` trata layoutCount=0 como sucesso
+
+`Services/Database/CachePermanentWarmupBackgroundService.cs:110-115` — depois do retry com
+backoff (implementado corretamente para a issue #67, já fechada e verificada nesta sessão como
+de fato corrigida), se a query ao SQL responder com sucesso mas **zero linhas** (ex.: banco
+vazio, ou filtro errado silenciosamente), o código trata como sucesso (`_catalogState.
+SetResult(0)`) e o `/health/ready` fica `200 Healthy` com catálogo vazio — o cenário que o
+smoke test do `ci-dev.yml` tentava evitar ao trocar de "bate numa rota de negócio" para "bate em
+/health/ready" (comentário no próprio workflow, linha ~676). Não é o mesmo bug da #67 (aquele era
+conexão falhando; este é conexão OK com resultado vazio) — é uma lacuna adjacente.
+
+**Recomendação:** considerar `CatalogHealthCheck` como `Degraded` (não `Healthy`) quando
+`LayoutCount == 0` após warm-up bem-sucedido, para o smoke test de deploy pegar esse caso.
+
+**Rastreamento:** NOVO, baixa prioridade — vale nota, não bloqueia nada hoje.
+
+---
+
+## O que foi checado e está OK (não incluído como achado)
+
+- `Task.Run` fire-and-forget em `ParseController.cs`, `LowCodeAutoTransformationService.cs`,
+  `AiTransformationCandidateService.cs`: todos envolvidos em try/catch com log estruturado —
+  conforme padrão de `dotnet-standards.md`.
+- Usos de `.Result`/`.Wait()` em `DecryptionService.cs` e `LowCodeTransformationService.cs`: são
+  sobre `Task`s já concluídas (`await allTask` antes), não bloqueiam a thread — falso positivo do
+  grep bruto, confirmado por leitura de contexto.
+- `CachePermanentWarmupBackgroundService`: retry com backoff progressivo implementado
+  corretamente para a issue #67 (exceto a lacuna do achado #6 acima).
+- `RAGController`/`RAGService`: DI registrado corretamente (fix de 2026-07-21, confirmado ainda
+  presente em `Program.cs:437`).
+- Subsistemas de nuvem (Gemini/OpenAI): nenhuma referência viva a `GeminiAIService`/
+  `SemanticAIGenerator` em `Program.cs` ou `DataGenerationController.cs` — decommission
+  permanece efetivo no código (a pendência real é a revogação manual da chave, já rastreada em
+  `security.md`).
+
+## Próximo passo sugerido
+
+Achados #1 e #2 (crítico e alto) são acionáveis imediatamente por `@lp-backend-dev` — são fixes
+pequenos e localizados. Achado #3 é uma decisão de arquitetura de CI que cabe a `@lp-devops`.
+Achado #4 é trabalho de backlog puro para `@lp-pm`. Recomendo ao dono do projeto priorizar #1 e
+#2 primeiro (regressões silenciosas de fixes já pagos), depois decidir entre #3/#4 pelo esforço
+disponível.

--- a/tests/LayoutParserApi.Tests/Controllers/DataGenerationControllerDiTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/DataGenerationControllerDiTests.cs
@@ -3,10 +3,10 @@ using LayoutParserApi.Models.Entities;
 using LayoutParserApi.Models.Parsing;
 using LayoutParserApi.Models.Responses;
 using LayoutParserApi.Models.Structure;
-using LayoutParserApi.Services.Generation.Implementations;
-using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Generation;
 using LayoutParserApi.Services.Generation.TxtGenerator;
-using LayoutParserApi.Services.Generation.TxtGenerator.Parsers;
+using LayoutParserApi.Services.Generation.TxtGenerator.Enum;
+using LayoutParserApi.Services.Generation.TxtGenerator.Generators;
 using LayoutParserApi.Services.Interfaces;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -14,43 +14,132 @@ using Microsoft.Extensions.DependencyInjection;
 namespace LayoutParserApi.Tests.Controllers
 {
     /// <summary>
-    /// Issue #33: <see cref="ISyntheticDataGeneratorService"/>, <see cref="IExcelDataProcessor"/>,
-    /// <see cref="ILayoutAnalysisService"/> e <see cref="TxtFileGeneratorFactory"/> não estavam
-    /// registrados em <c>Program.cs</c> — qualquer chamada ao <see cref="DataGenerationController"/>
-    /// quebrava com <c>InvalidOperationException</c> do container de DI em runtime, mesmo com o
-    /// build passando (o erro só aparece na resolução, não na compilação). Este teste replica o
-    /// mesmo grupo "Generation Services" adicionado a <c>Program.cs</c> e garante que o container
-    /// resolve o controller sem lançar.
+    /// Trava a regressão de DI do grupo Generation (issue #33), que já aconteceu duas vezes.
+    ///
+    /// A primeira versão deste teste era VÁCUA: montava um <c>ServiceCollection</c> com os registros
+    /// COPIADOS do <c>Program.cs</c>, então continuava verde depois que um merge apagou o bloco real —
+    /// exatamente o cenário que ele deveria pegar. Aqui a composição é única
+    /// (<see cref="GenerationServiceCollectionExtensions.AddGenerationServices"/>, chamada pelo
+    /// <c>Program.cs</c> e por estes testes) e o par de garantias é:
+    ///
+    /// <list type="bullet">
+    ///   <item>apagar um registro DENTRO de <c>AddGenerationServices</c> quebra os testes de resolução;</item>
+    ///   <item>apagar a CHAMADA de <c>AddGenerationServices</c> no <c>Program.cs</c> quebra
+    ///         <see cref="Program_cs_chama_AddGenerationServices"/>.</item>
+    /// </list>
+    ///
+    /// Trade-off assumido: descartamos <c>WebApplicationFactory&lt;Program&gt;</c> (que exercitaria a
+    /// composition root de verdade e dispensaria o teste de call-site). Motivo: ela sobe o host real,
+    /// que lê o <c>appsettings.json</c> da API — cujo <c>Logging:File:Directory</c> aponta para o
+    /// diretório de log do SERVIDOR — tenta conectar no Redis e liga os <c>IHostedService</c> de
+    /// warm-up do catálogo (SQL). Seria um teste unitário dependente de infra externa e capaz de
+    /// escrever em diretório de produção, além de exigir pacote de teste novo
+    /// (<c>Microsoft.AspNetCore.Mvc.Testing</c>) e tornar <c>Program</c> público/parcial.
     /// </summary>
     public class DataGenerationControllerDiTests
     {
         [Fact]
-        public void Container_resolve_DataGenerationController_com_o_grupo_Generation_registrado()
+        public void AddGenerationServices_resolve_o_DataGenerationController()
         {
-            var services = new ServiceCollection();
-            services.AddLogging();
-
-            // Mesmo grupo "Generation Services" registrado em Program.cs.
-            services.AddScoped<ISyntheticDataGeneratorService, SyntheticDataGeneratorService>();
-            services.AddScoped<IExcelDataProcessor, ExcelDataProcessor>();
-            services.AddScoped<ILayoutAnalysisService, LayoutAnalysisService>();
-            services.AddScoped<XmlLayoutParser>();
-            services.AddScoped<ExcelRulesParser>();
-            services.AddScoped<LayoutParserApi.Services.Generation.TxtGenerator.Validators.LayoutValidator>();
-            services.AddScoped<TxtFileGeneratorFactory>();
-
-            // Única dependência do controller fora do grupo Generation — fake mínimo, o alvo
-            // deste teste é a resolução do container, não o comportamento de parsing.
-            services.AddScoped<ILayoutParserService, FakeLayoutParserService>();
-
-            services.AddScoped<DataGenerationController>();
-
-            using var provider = services.BuildServiceProvider();
+            using var provider = MontarProvider();
             using var scope = provider.CreateScope();
 
             var controller = scope.ServiceProvider.GetRequiredService<DataGenerationController>();
 
             Assert.NotNull(controller);
+        }
+
+        /// <summary>
+        /// O <see cref="TxtFileGeneratorFactory"/> recebe só o <c>IServiceProvider</c> e resolve
+        /// XmlLayoutParser/ExcelRulesParser/LayoutValidator dentro do <c>Create()</c> — resolver o
+        /// controller NÃO prova que essas dependências existem. Este teste fecha esse buraco:
+        /// exercita o factory nos dois modos de geração.
+        /// </summary>
+        [Theory]
+        [InlineData(GenerationMode.Deterministic)]
+        [InlineData(GenerationMode.Random)]
+        public void AddGenerationServices_permite_o_factory_criar_o_gerador(GenerationMode modo)
+        {
+            using var provider = MontarProvider();
+            using var scope = provider.CreateScope();
+
+            var factory = scope.ServiceProvider.GetRequiredService<TxtFileGeneratorFactory>();
+
+            var generatorService = factory.Create(modo);
+
+            Assert.NotNull(generatorService);
+        }
+
+        /// <summary>
+        /// Os geradores de valor são resolvidos por <c>GetService</c> (nullable) dentro do
+        /// <c>TxtFileGeneratorService</c>: sem registro, nada lança na criação — o campo fica null e
+        /// o estouro só aparece como NullReferenceException no meio da geração do arquivo. Por isso
+        /// a presença deles é assertada aqui, e não só o <c>Create()</c> acima.
+        /// </summary>
+        [Fact]
+        public void AddGenerationServices_registra_os_geradores_de_valor()
+        {
+            using var provider = MontarProvider();
+            using var scope = provider.CreateScope();
+
+            Assert.NotNull(scope.ServiceProvider.GetService<DeterministicGenerator>());
+            Assert.NotNull(scope.ServiceProvider.GetService<RandomGenerator>());
+        }
+
+        /// <summary>
+        /// Guarda de call-site: o teste acima só prova que o grupo Generation, SE registrado, resolve.
+        /// Quem garante que o <c>Program.cs</c> continua registrando é este — foi apagar essa chamada
+        /// que produziu a regressão. Sem lib de mock e sem subir o host, a verificação é sobre o
+        /// fonte real do <c>Program.cs</c> (linha ativa, comentário não conta).
+        /// </summary>
+        [Fact]
+        public void Program_cs_chama_AddGenerationServices()
+        {
+            string programCs = Path.Combine(LocalizarRaizDoRepo(), "Program.cs");
+
+            // Falha explícita (não "passa por omissão") se o fonte não for encontrado: um gate que
+            // não consegue olhar o alvo é um gate que mente — foi assim que a regressão passou.
+            Assert.True(File.Exists(programCs), $"Program.cs não encontrado para inspeção: {programCs}");
+
+            bool chamaOGrupo = File.ReadLines(programCs)
+                .Select(linha => linha.Trim())
+                .Any(linha => !linha.StartsWith("//", StringComparison.Ordinal)
+                              && linha.Contains("AddGenerationServices(", StringComparison.Ordinal));
+
+            Assert.True(chamaOGrupo,
+                "Program.cs não chama builder.Services.AddGenerationServices(): o grupo Generation " +
+                "voltou a ficar fora do DI e o DataGenerationController quebra em runtime (issue #33).");
+        }
+
+        /// <summary>
+        /// Mesma composição do <c>Program.cs</c> para o grupo Generation. Fora dele, só o mínimo:
+        /// logging e um fake do <see cref="ILayoutParserService"/> (o projeto não tem lib de mock —
+        /// fakes escritos à mão são o padrão da suíte).
+        /// </summary>
+        private static ServiceProvider MontarProvider()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddGenerationServices();
+
+            services.AddScoped<ILayoutParserService, FakeLayoutParserService>();
+            services.AddScoped<DataGenerationController>();
+
+            return services.BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// Sobe a partir do diretório de saída do teste até achar o .csproj da API — mesmo padrão já
+        /// usado em PositionalFormatRegressionTests.
+        /// </summary>
+        private static string LocalizarRaizDoRepo()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "LayoutParserApi.csproj")))
+                dir = dir.Parent;
+
+            return dir?.FullName ?? AppContext.BaseDirectory;
         }
 
         private sealed class FakeLayoutParserService : ILayoutParserService

--- a/tests/LayoutParserApi.Tests/Database/CachePermanentWarmupBackgroundServiceRetryTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/CachePermanentWarmupBackgroundServiceRetryTests.cs
@@ -107,6 +107,92 @@ namespace LayoutParserApi.Tests.Database
             await sut.StopAsync(CancellationToken.None);
         }
 
+        /// <summary>
+        /// Falha de LEITURA do catálogo não pode virar "catálogo vazio". CachedLayoutService/
+        /// LayoutDatabaseService engolem a exceção de SQL e devolvem <c>Success=false</c> — o catch
+        /// do retry nunca vê exceção nesse caminho. Antes isso virava <c>SetResult(0)</c>:
+        /// warm-up marcado como CONCLUÍDO no estado definitivo "Vazio", com o retry da issue #67
+        /// morto justamente no cenário que ele existe para cobrir (blip de SQL).
+        /// </summary>
+        [Fact]
+        public async Task Busca_sem_sucesso_nao_conclui_warmup_e_continua_aquecendo()
+        {
+            // Refresh não lança (exceção engolida lá dentro), mas a busca subsequente não tem sucesso.
+            var fakeLayoutService = new FakeCachedLayoutService(failuresBeforeSuccess: 0, successCount: 0, searchSuccess: false);
+            var fakeMapperService = new FakeCachedMapperService(failuresBeforeSuccess: 0);
+            var catalogState = new CatalogWarmupState();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ICachedLayoutService>(fakeLayoutService);
+            services.AddSingleton<ICachedMapperService>(fakeMapperService);
+            await using var provider = services.BuildServiceProvider();
+
+            var delayCalls = 0;
+            using var cts = new CancellationTokenSource();
+            Task NoDelay(TimeSpan _, CancellationToken __)
+            {
+                delayCalls++;
+                if (delayCalls >= 3) cts.Cancel(); // sem isso o loop (corretamente) tentaria para sempre
+                return Task.CompletedTask;
+            }
+
+            var sut = new CachePermanentWarmupBackgroundService(
+                provider,
+                NullLogger<CachePermanentWarmupBackgroundService>.Instance,
+                catalogState,
+                NoDelay);
+
+            await sut.StartAsync(cts.Token);
+            await WaitUntilAsync(() => cts.IsCancellationRequested && fakeLayoutService.RefreshAttempts >= 3, TimeSpan.FromSeconds(5));
+
+            Assert.False(catalogState.Completed);
+            Assert.Equal(CatalogWarmupStatus.Aquecendo, catalogState.Status);
+            Assert.Equal(-1, catalogState.LayoutCount); // nunca registrou 0 como conclusão
+            Assert.True(catalogState.FailedAttempts >= 3);
+            Assert.True(fakeLayoutService.RefreshAttempts >= 3); // continuou tentando
+
+            await sut.StopAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// O outro lado da moeda: busca BEM-SUCEDIDA devolvendo 0 layouts é conclusão de verdade
+        /// (o catálogo está mesmo vazio) → estado "Vazio", definitivo, sem retry infinito. Readiness
+        /// segue Unhealthy — é o sinal correto para o operador, não um Healthy mentiroso.
+        /// </summary>
+        [Fact]
+        public async Task Catalogo_realmente_vazio_conclui_como_vazio_definitivo()
+        {
+            var fakeLayoutService = new FakeCachedLayoutService(failuresBeforeSuccess: 0, successCount: 0);
+            var fakeMapperService = new FakeCachedMapperService(failuresBeforeSuccess: 0);
+            var catalogState = new CatalogWarmupState();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ICachedLayoutService>(fakeLayoutService);
+            services.AddSingleton<ICachedMapperService>(fakeMapperService);
+            await using var provider = services.BuildServiceProvider();
+
+            var delayCalls = 0;
+            Task NoDelay(TimeSpan _, CancellationToken __) { delayCalls++; return Task.CompletedTask; }
+
+            var sut = new CachePermanentWarmupBackgroundService(
+                provider,
+                NullLogger<CachePermanentWarmupBackgroundService>.Instance,
+                catalogState,
+                NoDelay);
+
+            using var cts = new CancellationTokenSource();
+            await sut.StartAsync(cts.Token);
+            await WaitUntilAsync(() => catalogState.Completed, TimeSpan.FromSeconds(5));
+
+            Assert.True(catalogState.Completed);
+            Assert.Equal(CatalogWarmupStatus.Vazio, catalogState.Status);
+            Assert.Equal(0, catalogState.LayoutCount);
+            Assert.Equal(1, fakeLayoutService.RefreshAttempts); // não fica retentando à toa
+            Assert.Equal(0, delayCalls);
+
+            await sut.StopAsync(cts.Token);
+        }
+
         private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
         {
             var deadline = DateTime.UtcNow + timeout;
@@ -121,12 +207,14 @@ namespace LayoutParserApi.Tests.Database
         {
             private readonly int _failuresBeforeSuccess;
             private readonly int _successCount;
+            private readonly bool _searchSuccess;
             public int RefreshAttempts { get; private set; }
 
-            public FakeCachedLayoutService(int failuresBeforeSuccess, int successCount)
+            public FakeCachedLayoutService(int failuresBeforeSuccess, int successCount, bool searchSuccess = true)
             {
                 _failuresBeforeSuccess = failuresBeforeSuccess;
                 _successCount = successCount;
+                _searchSuccess = searchSuccess;
             }
 
             public Task RefreshCacheFromDatabaseAsync()
@@ -141,7 +229,14 @@ namespace LayoutParserApi.Tests.Database
 
             public Task<LayoutSearchResponse> SearchLayoutsAsync(LayoutSearchRequest request)
             {
-                return Task.FromResult(new LayoutSearchResponse { Success = true, TotalFound = _successCount });
+                // searchSuccess=false simula o que o serviço real faz quando o SQL cai: ENGOLE a
+                // exceção e devolve Success=false (não propaga) — "não consegui ler", não "vazio".
+                return Task.FromResult(new LayoutSearchResponse
+                {
+                    Success = _searchSuccess,
+                    TotalFound = _searchSuccess ? _successCount : 0,
+                    ErrorMessage = _searchSuccess ? "" : "SQL indisponivel (simulado)"
+                });
             }
 
             public Task<LayoutRecord?> GetLayoutByIdAsync(int id) => Task.FromResult<LayoutRecord?>(null);

--- a/tests/LayoutParserApi.Tests/Health/ReadinessHealthCheckTests.cs
+++ b/tests/LayoutParserApi.Tests/Health/ReadinessHealthCheckTests.cs
@@ -13,26 +13,42 @@ namespace LayoutParserApi.Tests.Health
     /// </summary>
     public class ReadinessHealthCheckTests
     {
-        // ---- Catálogo: gate duro da readiness ---------------------------------------------------
+        // ---- Catálogo: gate duro da readiness, em TRÊS estados ----------------------------------
+        //
+        // (a) Aquecendo → Unhealthy, mas marcado transitório (o retry ainda pode recuperar).
+        // (b) Pronto (> 0 layouts) → Healthy — ÚNICO estado saudável.
+        // (c) Vazio (warm-up concluiu com 0) → Unhealthy definitivo. NUNCA Healthy: catálogo sem
+        //     layouts não serve requisição nenhuma, e um deploy não pode declarar sucesso com ele.
 
         [Fact]
-        public async Task Catalogo_vazio_apos_warmup_e_unhealthy()
+        public async Task Catalogo_vazio_apos_warmup_e_unhealthy_definitivo()
         {
             var state = new CatalogWarmupState();
-            state.SetResult(0);
+            state.SetResult(0); // warm-up CONCLUIU e o catálogo veio vazio
 
             var result = await new CatalogHealthCheck(state).CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Equal(nameof(CatalogWarmupStatus.Vazio), result.Data["estado"]);
+            Assert.Equal(false, result.Data["transitorio"]); // exige intervenção, não se resolve sozinho
+            Assert.Equal(0, result.Data["layoutCount"]);
         }
 
         [Fact]
-        public async Task Catalogo_ainda_nao_concluido_e_unhealthy()
+        public async Task Catalogo_ainda_nao_concluido_e_unhealthy_transitorio()
         {
-            // Warm-up não rodou (Completed=false) → instância não está pronta.
-            var result = await new CatalogHealthCheck(new CatalogWarmupState()).CheckHealthAsync(new HealthCheckContext());
+            // Warm-up não rodou/está em retry (Completed=false) → instância não está pronta, mas
+            // isso NÃO é falha definitiva: o backoff da issue #67 ainda pode recuperar sozinho.
+            var state = new CatalogWarmupState();
+            state.RegisterFailedAttempt("SqlException");
+
+            var result = await new CatalogHealthCheck(state).CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Equal(nameof(CatalogWarmupStatus.Aquecendo), result.Data["estado"]);
+            Assert.Equal(true, result.Data["transitorio"]);
+            Assert.Equal(1, result.Data["tentativasFalhas"]);
+            Assert.Contains("AQUECENDO", result.Description);
         }
 
         [Fact]
@@ -44,6 +60,30 @@ namespace LayoutParserApi.Tests.Health
             var result = await new CatalogHealthCheck(state).CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Equal(nameof(CatalogWarmupStatus.Pronto), result.Data["estado"]);
+            Assert.Equal(42, result.Data["layoutCount"]);
+        }
+
+        /// <summary>
+        /// Os dois estados NÃO saudáveis respondem o mesmo HTTP (503), então só o payload os separa.
+        /// Sem essa distinção o operador não sabe se espera (aquecendo) ou se age (vazio definitivo).
+        /// </summary>
+        [Fact]
+        public async Task Aquecendo_e_vazio_sao_ambos_unhealthy_mas_distinguiveis()
+        {
+            var aquecendo = new CatalogWarmupState();
+
+            var vazio = new CatalogWarmupState();
+            vazio.SetResult(0);
+
+            var rAquecendo = await new CatalogHealthCheck(aquecendo).CheckHealthAsync(new HealthCheckContext());
+            var rVazio = await new CatalogHealthCheck(vazio).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, rAquecendo.Status);
+            Assert.Equal(HealthStatus.Unhealthy, rVazio.Status);
+            Assert.NotEqual(rAquecendo.Data["estado"], rVazio.Data["estado"]);
+            Assert.NotEqual(rAquecendo.Data["transitorio"], rVazio.Data["transitorio"]);
+            Assert.NotEqual(rAquecendo.Description, rVazio.Description);
         }
 
         // ---- Dependências opcionais: Degraded, não Unhealthy ------------------------------------
@@ -100,6 +140,37 @@ namespace LayoutParserApi.Tests.Health
             var report = await svc.CheckHealthAsync(r => r.Tags.Contains("ready"));
 
             Assert.Equal(HealthStatus.Unhealthy, report.Status);
+        }
+
+        /// <summary>
+        /// Trava a decisão de NÃO reportar o warm-up em andamento como <c>Degraded</c>: Degraded
+        /// mapeia para <b>200</b> em /health/ready e o smoke test do deploy exige 200 estrito — a
+        /// instância seria declarada pronta com o catálogo ainda vazio, exatamente a classe de bug
+        /// que esta sonda fecha. Unhealthy (503) mantém o smoke test retentando, que é o correto:
+        /// o laço do deploy já trata 503 como "ainda não pronto", não como falha definitiva.
+        /// </summary>
+        [Fact]
+        public async Task Readiness_com_catalogo_aquecendo_agrega_unhealthy_e_nao_degraded()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            // Warm-up em andamento/retry: nunca chamou SetResult.
+            var state = new CatalogWarmupState();
+            state.RegisterFailedAttempt("SqlException");
+            services.AddSingleton(state);
+
+            services.AddHealthChecks()
+                .Add(new HealthCheckRegistration("catalog",
+                    sp => new CatalogHealthCheck(sp.GetRequiredService<CatalogWarmupState>()),
+                    HealthStatus.Unhealthy, new[] { "ready" }));
+
+            await using var provider = services.BuildServiceProvider();
+            var report = await provider.GetRequiredService<HealthCheckService>()
+                .CheckHealthAsync(r => r.Tags.Contains("ready"));
+
+            Assert.Equal(HealthStatus.Unhealthy, report.Status);
+            Assert.Equal(true, report.Entries["catalog"].Data["transitorio"]);
         }
 
         [Fact]

--- a/tests/LayoutParserApi.Tests/Infra/DeployWorkflowGateTests.cs
+++ b/tests/LayoutParserApi.Tests/Infra/DeployWorkflowGateTests.cs
@@ -1,0 +1,172 @@
+using System.Text.RegularExpressions;
+
+namespace LayoutParserApi.Tests.Infra
+{
+    /// <summary>
+    /// Guarda de regressão do quality gate do deploy de PRODUÇÃO (<c>.github/workflows/deploy.yml</c>).
+    ///
+    /// Contexto: até 2026-08-14 só o <c>ci-dev.yml</c> rodava <c>dotnet test</c> — produção buildava e
+    /// publicava sem nunca executar a suíte. O caminho que garantia o gate (feat → develop → master via
+    /// PR) deixou de ser obrigatório quando a branch protection nativa do GitHub foi perdida ao tornar os
+    /// repositórios privados (ver <c>.claude/rules/agent-authority.md</c>). Sem bloqueio técnico do
+    /// GitHub, o que impede a regressão é este teste.
+    ///
+    /// O que ele trava: (1) o deploy de produção executa a suíte de fato; (2) essa execução acontece
+    /// ANTES de qualquer step que escreva no host; (3) o gate não é tolerante a falha; (4) deploys
+    /// concorrentes continuam serializados. As asserções são textuais de propósito — o alvo é um YAML,
+    /// não código. Se o workflow for legitimamente reestruturado (ex.: a suíte virar um job separado com
+    /// <c>needs:</c>), este teste precisa ser atualizado junto: a mensagem de falha diz o porquê.
+    /// </summary>
+    public class DeployWorkflowGateTests
+    {
+        /// <summary>
+        /// Invocação REAL de <c>dotnet test</c> — início de linha, dentro de um bloco <c>run:</c>.
+        /// Menções em comentário (<c>`dotnet test`</c>, <c># dotnet test ...</c>) não casam de propósito:
+        /// um gate removido que deixou o comentário para trás não pode passar por gate existente.
+        /// </summary>
+        private static readonly Regex InvocacaoDeDotnetTest =
+            new(@"^[ \t]*dotnet test\b", RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Marcadores de "daqui em diante o workflow ESCREVE no host de produção". São trechos de
+        /// comando, não nomes de step: nome se renomeia sem mudar comportamento, comando não.
+        /// </summary>
+        private static readonly string[] MarcadoresDeEscritaEmProducao =
+        {
+            "LayoutParserLowCodeRunner.exe",                // publicação do runner na Bin do Sysmiddle
+            "HKLM:\\SYSTEM\\CurrentControlSet\\Services",   // Environment do serviço Windows
+            "Stop-Service"                                  // parada do serviço antes da cópia
+        };
+
+        [Fact]
+        public void Deploy_de_producao_executa_a_suite_de_testes()
+        {
+            var workflow = LerDeployYml();
+            if (workflow is null) return;
+
+            Assert.True(
+                InvocacaoDeDotnetTest.IsMatch(workflow),
+                "deploy.yml nao invoca 'dotnet test' em nenhum bloco run:. O deploy de PRODUCAO voltaria " +
+                "a publicar sem que a suite tenha rodado - e, sem branch protection, um push direto em " +
+                "master chegaria ao servidor sem nenhum teste automatizado.");
+        }
+
+        [Fact]
+        public void Gate_de_testes_vem_antes_de_qualquer_step_que_toca_producao()
+        {
+            var workflow = LerDeployYml();
+            if (workflow is null) return;
+
+            var invocacao = InvocacaoDeDotnetTest.Match(workflow);
+            Assert.True(invocacao.Success, "deploy.yml nao invoca 'dotnet test' em nenhum bloco run:.");
+
+            foreach (var marcador in MarcadoresDeEscritaEmProducao)
+            {
+                var posicaoDaEscrita = workflow.IndexOf(marcador, StringComparison.Ordinal);
+                if (posicaoDaEscrita < 0) continue; // step removido/renomeado: nada a comparar
+
+                Assert.True(
+                    invocacao.Index < posicaoDaEscrita,
+                    $"'dotnet test' aparece DEPOIS de '{marcador}' em deploy.yml. O gate precisa rodar " +
+                    "antes de qualquer escrita no host: este workflow nao tem swap atomico nem backup " +
+                    "dos binarios anteriores, entao abortar no meio deixa producao pela metade.");
+            }
+        }
+
+        [Fact]
+        public void Gate_de_testes_nao_e_tolerante_a_falha()
+        {
+            var workflow = LerDeployYml();
+            if (workflow is null) return;
+
+            var bloco = ExtrairStepQueRodaOsTestes(workflow);
+            Assert.NotNull(bloco);
+
+            // continue-on-error transformaria o gate em enfeite: teste vermelho e o deploy segue.
+            Assert.DoesNotContain("continue-on-error", bloco, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Deploys_de_producao_continuam_serializados()
+        {
+            var workflow = LerDeployYml();
+            if (workflow is null) return;
+
+            Assert.Contains("concurrency:", workflow, StringComparison.Ordinal);
+
+            // cancel-in-progress: false é deliberado — cancelar um deploy durante a troca de binários
+            // (Stop-Service → cópia → Start-Service) deixaria a instalação inconsistente.
+            Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
+        }
+
+        // ---- Apoio -------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Sobe a árvore de diretórios a partir do binário de teste até achar o workflow, e devolve o
+        /// conteúdo com as linhas de COMENTÁRIO neutralizadas (ver <see cref="SemComentarios"/>).
+        /// Retorna <c>null</c> quando o repositório não está por perto (execução a partir de um
+        /// diretório publicado, por exemplo) — nesse cenário o teste não tem o que afirmar, e falhar
+        /// seria um vermelho falso justamente dentro do gate que ele protege.
+        /// </summary>
+        private static string? LerDeployYml()
+        {
+            var diretorio = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (diretorio is not null)
+            {
+                var candidato = Path.Combine(diretorio.FullName, ".github", "workflows", "deploy.yml");
+                if (File.Exists(candidato))
+                {
+                    return SemComentarios(File.ReadAllText(candidato));
+                }
+
+                diretorio = diretorio.Parent;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Substitui cada linha de comentário (YAML ou PowerShell dentro do <c>run:</c>) por espaços de
+        /// mesmo comprimento — os índices do arquivo continuam valendo, mas comentário deixa de casar.
+        ///
+        /// Isto não é preciosismo: o deploy.yml é fortemente comentado, e menções como
+        /// "Stop-Service -> copia -> Start-Service" ou "cancel-in-progress: false de PROPOSITO"
+        /// aparecem em comentário ANTES do comportamento real. Sem neutralizá-las, o teste afirmaria
+        /// sobre prosa em vez de sobre o workflow — passaria com o gate deletado e o comentário intacto.
+        /// </summary>
+        private static string SemComentarios(string workflow)
+        {
+            var linhas = workflow.Split('\n');
+
+            for (var i = 0; i < linhas.Length; i++)
+            {
+                if (linhas[i].TrimStart().StartsWith('#'))
+                {
+                    linhas[i] = new string(' ', linhas[i].Length);
+                }
+            }
+
+            return string.Join('\n', linhas);
+        }
+
+        /// <summary>
+        /// Recorta o bloco YAML do step que roda a suíte (do <c>- name:</c> anterior ao próximo).
+        /// </summary>
+        private static string? ExtrairStepQueRodaOsTestes(string workflow)
+        {
+            const string inicioDeStep = "\n    - name:";
+
+            var invocacao = InvocacaoDeDotnetTest.Match(workflow);
+            if (!invocacao.Success) return null;
+
+            var inicio = workflow.LastIndexOf(inicioDeStep, invocacao.Index, StringComparison.Ordinal);
+            if (inicio < 0) return null;
+
+            var fim = workflow.IndexOf(inicioDeStep, invocacao.Index, StringComparison.Ordinal);
+            if (fim < 0) fim = workflow.Length;
+
+            return workflow[inicio..fim];
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
@@ -1,0 +1,169 @@
+using LayoutParserApi.Services.Transformation.Ai;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai
+{
+    /// <summary>
+    /// Issue #51 — a store do pathway IA não tinha nenhuma expiração: cada <c>execute-candidates</c>
+    /// que disparava o pathway criava um ticket que ficava para sempre em memória (<c>ConcurrentDictionary</c>)
+    /// e em disco (JSON por ticket). A issue chegou a ser fechada citando a retenção de <c>RunManifest.cs</c>,
+    /// que é outro subsistema (run dirs do Job 1 de métricas) e não tocava neste leak.
+    ///
+    /// <para>Os testes cobrem as DUAS camadas e usam relógio injetado — nada de <c>Task.Delay</c> real.</para>
+    /// </summary>
+    public class AiCandidateStoreTtlTests
+    {
+        [Fact]
+        public void Varredura_remove_ticket_vencido_de_memoria_e_disco_e_preserva_o_que_esta_no_ttl()
+        {
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+                var store = CriarStore(dir, () => agora, ttlHoras: 24);
+
+                store.Set("ticket-velho", new AiCandidateStatus { Status = AiCandidateStatus.StatusFailed });
+
+                // Envelhece o relógio além do TTL e grava um ticket novo já na "era" seguinte.
+                agora = agora.AddHours(25);
+                store.Set("ticket-novo", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
+
+                var arquivoVelho = Path.Combine(dir, "ticket-velho.json");
+                var arquivoNovo = Path.Combine(dir, "ticket-novo.json");
+                Assert.True(File.Exists(arquivoVelho), "o ticket vencido ainda deve existir em disco ANTES da varredura");
+
+                var resultado = store.RemoveExpired();
+
+                Assert.Equal(1, resultado.TicketsEmMemoria);
+                Assert.Equal(1, resultado.ArquivosEmDisco);
+
+                // Vencido: sumiu das duas camadas.
+                Assert.False(File.Exists(arquivoVelho));
+                Assert.Null(store.Get("ticket-velho"));
+
+                // Dentro do TTL: intocado nas duas camadas.
+                Assert.True(File.Exists(arquivoNovo));
+                Assert.Equal(AiCandidateStatus.StatusConverged, store.Get("ticket-novo")?.Status);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Get_nao_devolve_ticket_vencido_mesmo_antes_da_varredura()
+        {
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+                var store = CriarStore(dir, () => agora, ttlHoras: 24);
+
+                store.Set("ticket-poll", new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
+                Assert.NotNull(store.Get("ticket-poll"));
+
+                agora = agora.AddHours(25);
+                Assert.Null(store.Get("ticket-poll"));
+
+                // O Get já liberou a entrada da memória (O(1), sem I/O): à varredura seguinte
+                // sobra apenas o arquivo em disco.
+                var resultado = store.RemoveExpired();
+                Assert.Equal(0, resultado.TicketsEmMemoria);
+                Assert.Equal(1, resultado.ArquivosEmDisco);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Store_nova_nao_ressuscita_ticket_vencido_do_disco()
+        {
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+                var storeAntiga = CriarStore(dir, () => agora, ttlHoras: 24);
+                storeAntiga.Set("ticket-restart", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
+
+                agora = agora.AddHours(25);
+
+                // Simula restart da API: memória zerada, disco cheio. O TTL é absoluto a partir da
+                // escrita, então o ticket não pode voltar à vida só porque o processo reiniciou.
+                var storeNova = CriarStore(dir, () => agora, ttlHoras: 24);
+                Assert.Null(storeNova.Get("ticket-restart"));
+
+                var resultado = storeNova.RemoveExpired();
+                Assert.Equal(0, resultado.TicketsEmMemoria);
+                Assert.Equal(1, resultado.ArquivosEmDisco);
+                Assert.False(File.Exists(Path.Combine(dir, "ticket-restart.json")));
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Ttl_nao_configurado_ou_invalido_cai_no_default()
+        {
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var padrao = CriarStore(dir, () => DateTimeOffset.UtcNow, ttlHoras: AiTransformationCandidateOptions.DefaultTicketTtlHours);
+                var invalido = CriarStore(dir, () => DateTimeOffset.UtcNow, ttlHoras: 0);
+
+                Assert.Equal(TimeSpan.FromHours(72), padrao.Ttl);
+                Assert.Equal(padrao.Ttl, invalido.Ttl);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Store_e_servico_de_limpeza_sao_resolviveis_pelo_container()
+        {
+            // O relógio é parâmetro opcional do construtor (só os testes injetam) — este teste
+            // garante que isso não quebra o AddSingleton<AiCandidateStore>() do Program.cs.
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddLogging();
+                services.Configure<AiTransformationCandidateOptions>(o => o.StorePath = dir);
+                services.AddSingleton<AiCandidateStore>();
+                services.AddSingleton<AiCandidateStoreCleanupBackgroundService>();
+
+                using var provider = services.BuildServiceProvider();
+
+                var store = provider.GetRequiredService<AiCandidateStore>();
+                Assert.Equal(TimeSpan.FromHours(AiTransformationCandidateOptions.DefaultTicketTtlHours), store.Ttl);
+                Assert.NotNull(provider.GetRequiredService<AiCandidateStoreCleanupBackgroundService>());
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        private static AiCandidateStore CriarStore(string storePath, Func<DateTimeOffset> relogio, int ttlHoras)
+            => new(
+                NullLogger<AiCandidateStore>.Instance,
+                Options.Create(new AiTransformationCandidateOptions { StorePath = storePath, TicketTtlHours = ttlHoras }),
+                relogio);
+
+        private static string CriarDiretorioTemporario()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "lpapi-ai-ttl-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+    }
+}


### PR DESCRIPTION
Integra numa única branch as 4 correções derivadas da auditoria de arquitetura de 2026-08-14
(`docs/architecture/auditoria-gates-bugs-2026-08-14.md`, incluído nesta PR).

Cada achado foi corrigido em branch isolada, passou por **verificação adversarial do `@lp-qa`**
com **teste de mutação** (quebra-se deliberadamente a produção para provar que o teste novo
falha — nenhum dos testes adicionados é vácuo) e só então entrou aqui via `cherry-pick`,
**um commit por achado**, para facilitar revisão e reversão seletiva.

---

## 1. CRÍTICO — Regressão de DI no `DataGenerationController` (e o teste vácuo que a escondeu)

**O que era:** o `DataGenerationController` voltou a quebrar em runtime — regressão silenciosa da
issue #33, que estava fechada. Todo endpoint de geração de dados sintéticos falhava ao resolver o
controller.

**Causa raiz:** duas camadas.
1. O grupo de registros `Generation` sumiu do `Program.cs` (usings ficaram órfãos).
2. O teste de regressão que deveria ter pego isso montava um `ServiceCollection` **copiando à mão**
   os registros do `Program.cs`. Ele testava a cópia, não a composição real — passava verde com o
   `Program.cs` quebrado.

**O que mudou:**
- Novo `Services/Generation/GenerationServiceCollectionExtensions.cs` com `AddGenerationServices()`,
  registrando **9** serviços `Scoped` em três profundidades:
  - as 4 dependências diretas do construtor do controller;
  - as 3 que o `TxtFileGeneratorFactory` resolve por `GetRequiredService` **dentro do `Create()`**
    (incluindo o `LayoutValidator` de `Generation.TxtGenerator.Validators`, com nome totalmente
    qualificado — colide com `Parsing.Implementations.LayoutValidator`). Resolver o controller
    **não** prova que essas existem;
  - `DeterministicGenerator` e `RandomGenerator`, resolvidos por `GetService` **nullable** — sem
    registro nada lança, o campo fica `null` e vira `NullReferenceException` no meio da geração.
- `Program.cs` passa a chamar `builder.Services.AddGenerationServices()` — composição num ponto só.
- O teste foi reescrito para chamar **o mesmo** `AddGenerationServices()` que o `Program.cs` chama,
  mais uma guarda de call-site que lê o fonte do `Program.cs` (ignorando linhas comentadas) e falha
  se a chamada sumir ou o arquivo não for achado.

**Nota:** o item dos dois geradores de valor **nunca** existiu, nem no fix original da #33 (`6082834`
registrava 7 serviços, não 9). Esta correção vai além de restaurar: fecha também um bug latente de
NRE que o código carregava desde sempre.

Commits: `2cb85fe`, `da70973` · 1 teste antigo → 5 testes.

---

## 2. ALTO — `AiCandidateStore` sem TTL (leak de memória e disco)

**O que era:** issue #51 foi fechada citando um fix em subsistema **diferente**
(`ai/XslSynth/Metrics/RunManifest.cs`) — o leak seguia presente. Tickets do pathway de IA nunca
expiravam, nem em memória nem em disco.

**Causa raiz:** a store não guardava o instante da escrita, então não havia como expirar nada; e
não existia nenhum processo de poda.

**O que mudou:**
- TTL **absoluto por escrita** nas duas camadas. Em memória, o dicionário passa a guardar
  `StoredEntry(Status, StoredAtUtc)`; o carimbo vem de um relógio injetável
  (`Func<DateTimeOffset>? clock = null`, default `DateTimeOffset.UtcNow` — opcional para o
  `AddSingleton<AiCandidateStore>()` continuar sem factory).
- Em disco, a idade é o `LastWriteTimeUtc`, carimbado explicitamente no `Set` com o **mesmo**
  relógio, em `try/catch` próprio com `LogDebug` — falha de carimbo (antivírus segurando handle)
  não é reportada como "falha ao persistir".
- `Get` ganhou duas guardas: hit de memória vencido é removido O(1) e devolve `null`; no miss, o
  arquivo só é lido se estiver dentro do limite. TTL absoluto, não deslizante — ticket vencido não
  ressuscita após restart. **Nenhuma varredura de diretório entrou no caminho de request.**
- Novo `RemoveExpired()` poda as duas camadas: memória com `TryRemove(KeyValuePair)` condicional
  (não derruba entrada republicada por um `Set` concorrente) e disco best-effort por arquivo.
- Novo `AiCandidateStoreCleanupBackgroundService` (`AddHostedService`): cede a thread de startup,
  loop `RemoveExpired()` → `Task.Delay`, com `try/catch` em volta de tudo — **falha de limpeza nunca
  derruba o host nem interrompe o loop**; `OperationCanceledException` encerra limpo no shutdown.
- Config: `TicketTtlHours` (default 72) e `CleanupIntervalMinutes` (default 60), com a convenção já
  usada no projeto de "valor <= 0 cai no default". A seção no `appsettings.json` tem valores
  idênticos aos defaults do código (mudança neutra).

**Efeito colateral observável:** ticket com mais de 72h passa a responder `not_found` no
`GET .../ia-status`, em vez do status terminal.

Commit: `b924ea4` · +5 testes, todos com relógio injetado (nenhum `Thread.Sleep`/tempo de parede).

---

## 3. ALTO — Deploy de produção sem gate de teste

**O que era:** o `deploy.yml` publicava em produção sem rodar a suíte. Qualquer regressão passava
direto para o servidor.

**Causa raiz:** o workflow nunca teve step de teste — só build e publish.

**O que mudou:**
- Novo step **"Quality gate - suíte de testes (pré-produção)"** antes de tocar produção. Roda
  `dotnet test` no csproj **explícito** (nunca por inferência da solution), Release, com logger TRX.
- O veredito **não** sai do exit code: sai do TRX (`ResultSummary.Counters`). São **cinco** caminhos
  de aborto, todos `Write-Error` + `exit 1`: projeto de teste ausente, TRX não gerado, TRX sem
  `Counters`, `$testExit -ne 0 -or $failed -gt 0`, e `$total -le 0`.
- Remove o TRX antes de rodar — detalhe que importa em runner self-hosted com workspace persistente:
  um TRX rançoso de run anterior viraria falso verde.
- **Sem `continue-on-error` e sem input de bypass no `workflow_dispatch`.**
- O bloco `concurrency: deploy-prod` **já existia**; esta PR apenas documenta por que o grupo é
  constante em vez de derivado de `github.workflow`/`github.ref`. Não introduz serialização nova —
  passa a **travá-la por teste**.
- 4 testes que assertam sobre o próprio YAML, com um cuidado que vale citar: `SemComentarios()`
  neutraliza linhas de comentário antes de assertar, e a regex exige `dotnet test` em início de
  linha. Sem isso, o teste passaria com o gate deletado e o comentário intacto.

Commits: `1555fda`, `ee650bd` · +4 testes.

---

## 4. MÉDIO — Falha de leitura do SQL mascarada como "catálogo vazio", matando o retry da issue #67

> ### ⚠️ Correção de rota — o achado original estava mal rotulado
>
> Este item foi originalmente registrado na auditoria como *"`CatalogHealthCheck` considera catálogo
> vazio como saudável"*. A verificação do `@lp-qa` provou que **essa premissa não se reproduz**: o
> guard já existia, introduzido em `a01274a` (P1.3, 2026-08-11), em
> `Services/Health/ReadinessHealthChecks.cs:137-138`:
>
> ```csharp
> if (_state.LayoutCount <= 0)
>     return Task.FromResult(HealthCheckResult.Unhealthy("Catalogo de layouts VAZIO apos warm-up (SQL/decryptor fora?) — instancia nao esta pronta."));
> ```
>
> Com o catálogo vazio, o readiness **já reportava Unhealthy** antes desta PR. Nada a corrigir ali.
>
> O que o commit `d608539` corrige de fato é **outro bug, mais grave e não relatado no achado
> original** — descrito abaixo. O código está correto e foi verificado; o que estava errado era o
> rótulo. **A branch (`fix/catalog-health-catalogo-vazio`) permanece com o nome impreciso** — não foi
> renomeada de propósito, para não reescrever histórico já revisado. Guie-se por esta seção, não pelo
> nome da branch.

**O que era (o bug real):** em `Services/Database/CachePermanentWarmupBackgroundService.cs:111`, a linha

```csharp
layoutCount = todos.Success ? todos.TotalFound : 0;   // ← falha de SQL virava "zero layouts"
```

convertia **falha de leitura do SQL** em "catálogo vazio", seguia para `_catalogState.SetResult(0)`
(linha 114) e retornava. Efeito: o warm-up **declarava-se concluído** em cima de uma leitura que
nunca funcionou — e com isso **matava o retry com backoff da issue #67 exatamente no cenário que ele
existe para cobrir**: o blip transitório de SQL. Um blip de segundos deixava a instância
permanentemente sem catálogo, e o readiness não tinha como distinguir isso de um catálogo
legitimamente vazio.

**Causa raiz:** `CachedLayoutService.SearchLayoutsAsync` e `LayoutDatabaseService` **engolem** a
exceção de SQL e devolvem `Success=false` em vez de propagar. O `catch` do retry nunca via a falha
por esse caminho, e o ternário acima achatava `Success=false` e `TotalFound=0` no mesmo valor.

**O que mudou:**
- Novo enum `CatalogWarmupStatus { Aquecendo, Pronto, Vazio }` e `RegisterFailedAttempt(motivo)`,
  que incrementa contador (`Interlocked`) e guarda uma categoria curta da falha — deliberadamente
  **não** chama `SetResult`, então tentativa falha não "conclui" o warm-up.
- No `CachePermanentWarmupBackgroundService`, "não consegui ler" passa a ser separado de "está
  vazio": `Success == false` registra a falha, loga Warning e faz `continue` (**mantém o retry
  vivo**); só `Success == true` chama `SetResult`. Zero com busca bem-sucedida vira estado `Vazio`
  definitivo (log Error, sem retry infinito).
- `CatalogHealthCheck` reescrito em switch de três estados: `Pronto` → Healthy; `Vazio` → Unhealthy
  com `transitorio=false`; `Aquecendo` → Unhealthy com `transitorio=true`. Ambos os não-saudáveis
  carregam um dicionário `Data` (estado/layoutCount/transitorio/tentativasFalhas/ultimaFalha).
- O `ResponseWriter` de `/health/ready` passa a emitir `data`, para que os **dois** 503 (aquecendo
  vs. vazio) sejam distinguíveis sem parsear texto de descrição.

**O HTTP não muda para nenhum estado.** O que muda é que (a) o retry da #67 deixa de ser morto por
falha de leitura e (b) o operador passa a saber se espera ou se age.

Commit: `d608539` · +4 testes.

---

## 5. Documento da auditoria

`docs/architecture/auditoria-gates-bugs-2026-08-14.md` (230 linhas) — entregável do `@lp-architect`
que estava só numa branch de worktree e ainda não tinha chegado ao `develop`. Junto vem a memória
de agente correspondente (`.claude/agent-memory/lp-architect/audit-2026-08-14-di-regression.md`).

Commits: `a0e67dc`, `0250441`.

---

## Verificação na branch **integrada**

Isolado, cada fix passava. O risco real de uma integração é a interação — em especial `Program.cs`,
tocado tanto pelo fix de DI quanto pelo de health check. Resultado:

| Gate | Resultado |
|------|-----------|
| `git cherry-pick` (8 commits) | **0 conflitos** |
| `dotnet build -c Release` | **0 erros**, 618 warnings |
| `dotnet test -c Release` (suíte completa) | **336 passando, 0 falhas, 0 skipped** (~31 s) |

**Warnings:** 618 é exatamente o baseline pré-existente (SecurityCodeScan/nullable). Esta PR
**não adiciona nem remove** warning.

**Contagem de testes:** baseline 319 → 336 (+17). Fecha certinho: DI (1 teste antigo → 5 = +4),
TTL (+5), deploy gate (+4), catálogo (+4).

**Base:** branch cortada de `origin/develop` **atualizado** (`8316422`, já com os merges de
dependabot #80/#81), não da base em que as branches originais foram criadas (`7928ff7`). Os bumps
só tocam `.csproj`, sem sobreposição com estas correções.

---

## O que ficou de fora, e por quê

- **Nenhum achado aprovado ficou de fora.** Os 4 PASS do QA entraram, os 8 commits aplicaram limpo,
  nenhum cherry-pick precisou ser abortado.
- O QA não reportou nenhum achado "com ressalva" nem "sem verificação" nesta rodada.
- **Alterações não commitadas do `@lp-pm`** (`.claude/agent-memory/lp-pm/MEMORY.md` e
  `project_issues-fechadas-sem-fix-real.md`) estavam na árvore de trabalho e foram **deliberadamente
  deixadas de fora** — são trabalho em andamento de outro agente, não desta auditoria.
- Achados da auditoria **sem correção nesta PR** (documentados, não corrigidos): os 27 achados de
  SecurityCodeScan em baseline sem issue de rastreamento e as duas notas de baixa prioridade. Estão
  descritos no documento incluído; viram backlog via `@lp-pm`, não código aqui.

---

*PR aberta por `@lp-devops` (Gage). **Não mergear automaticamente** — o dono aprova e mergeia.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

