### PR TITLE
fix(seguranca): abre execute-candidates para qualquer usuário autenticado, com isolamento por usuário

### DIFF
--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -39,6 +39,7 @@ namespace LayoutParserApi.Controllers
         private readonly ILayoutDatabaseService _layoutDb;
         private readonly LowCodeRunnerOptions _lowCodeOpt;
         private readonly IAiTransformationCandidateService _aiCandidateService;
+        private readonly ICurrentUser _currentUser;
 
         public TransformationExecutionController(
             ILogger<TransformationExecutionController> logger,
@@ -50,7 +51,8 @@ namespace LayoutParserApi.Controllers
             LowCodeAutoTransformationService lowCodeAuto,
             ILayoutDatabaseService layoutDb,
             IOptions<LowCodeRunnerOptions> lowCodeOptions,
-            IAiTransformationCandidateService aiCandidateService)
+            IAiTransformationCandidateService aiCandidateService,
+            ICurrentUser currentUser)
         {
             _logger = logger;
             _pipelineService = pipelineService;
@@ -62,7 +64,13 @@ namespace LayoutParserApi.Controllers
             _layoutDb = layoutDb;
             _lowCodeOpt = lowCodeOptions.Value;
             _aiCandidateService = aiCandidateService;
+            _currentUser = currentUser;
         }
+
+        // Issue #92: chave de particionamento da AiCandidateStore. ICurrentUser.Name é null quando
+        // anônimo (sem [Authorize] em algum endpoint futuro ou identidade não confiável) — a store já
+        // trata esse caso como um bucket fixo próprio, nunca cai no de outro usuário real.
+        private string CurrentUserId => _currentUser.Name ?? string.Empty;
 
         /// <summary>
         /// Executa transformação completa (TXT -> XML ou XML -> XML)
@@ -256,7 +264,7 @@ namespace LayoutParserApi.Controllers
             // Pathway IA (Issue #40): dispara só depois de ter gabarito sysmiddle disponível — nunca
             // como terceiro Task síncrono (ver docs/architecture/pathway-ia-execute-candidates.md §3).
             // Fire-and-forget: NUNCA atrasa nem derruba a resposta síncrona já calculada acima.
-            TryEnqueueAiCandidate(request, layoutRecord, candidates, isXmlInput);
+            TryEnqueueAiCandidate(request, layoutRecord, candidates, isXmlInput, CurrentUserId);
 
             string? recommendedId = null;
             if (candidates.Count > 0)
@@ -358,7 +366,8 @@ namespace LayoutParserApi.Controllers
         /// warning e não afeta o array <c>candidates[]</c> já calculado.
         /// </summary>
         private void TryEnqueueAiCandidate(
-            TransformationRequest request, LayoutRecord layoutRecord, List<TransformationCandidate> candidates, bool isXmlInput)
+            TransformationRequest request, LayoutRecord layoutRecord, List<TransformationCandidate> candidates, bool isXmlInput,
+            string userId)
         {
             var plan = AiCandidateDispatchPlan.TryBuild(
                 request.LayoutGuid, layoutRecord.LayoutGuid, request.InputContent, isXmlInput, candidates);
@@ -370,7 +379,10 @@ namespace LayoutParserApi.Controllers
                 // ✅ Não usa a request.HttpContext.RequestAborted — o job sobrevive ao fim da request
                 // (dotnet-standards.md §Background work). CancellationToken.None + teto de sanidade
                 // interno do serviço (AiTransformationCandidateOptions.SanityTimeoutMinutes).
+                // userId (issue #92): particiona o ticket na AiCandidateStore — só quem disparou o job
+                // consegue consultá-lo depois em ia-status.
                 _ = _aiCandidateService.EnqueueAsync(
+                    userId,
                     plan.Ticket,
                     request.LayoutName,
                     plan.LayoutGuid,
@@ -392,11 +404,21 @@ namespace LayoutParserApi.Controllers
         /// autorização de <see cref="ExecuteTransformationCandidates"/> (Issue #32) — endpoint
         /// novo, mesmo custo/sensibilidade de disparar processos/objetos caros.
         /// </summary>
+        /// <remarks>
+        /// Issue #92: a consulta é isolada por usuário — <c>ticket</c> de outro usuário devolve 404,
+        /// nunca 403. 403 confirmaria "o ticket existe, mas não é seu" (enumeração); 404 se comporta
+        /// exatamente como um ticket inexistente/expirado, que é o mesmo caso hoje. Único gate de
+        /// papel continua sendo o <c>[Authorize(Roles = "admin")]</c> — quando a issue #93 abrir o
+        /// endpoint além de admin, o isolamento por dono já está pronto.
+        /// </remarks>
         [Authorize(Roles = "admin")]
         [HttpGet("execute-candidates/{ticket}/ia-status")]
         public async Task<IActionResult> GetAiCandidateStatus(string ticket, CancellationToken cancellationToken)
         {
-            var status = await _aiCandidateService.GetStatusAsync(ticket, cancellationToken);
+            var status = await _aiCandidateService.GetStatusAsync(CurrentUserId, ticket, cancellationToken);
+            if (status.Status == AiCandidateStatus.StatusNotFound)
+                return NotFound();
+
             return Ok(status);
         }
 

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -166,9 +166,11 @@ namespace LayoutParserApi.Controllers
         /// (casos-limite de zero candidatos, falha parcial, timeout etc.) em
         /// docs/architecture/multi-candidato-e-diagnostico-ia-contrato.md (Gap 1).
         /// </summary>
-        // Issue #32: dispara processos externos (runner x86) e é operação privilegiada —
-        // restrita ao papel "admin".
-        [Authorize(Roles = "admin")]
+        // Issue #32: dispara processos externos (runner x86) e é operação privilegiada — era
+        // restrita ao papel "admin". Issue #93: reabre para qualquer usuário autenticado (o
+        // isolamento por dono via CurrentUserId/AiCandidateStore, já feito na issue #92, é quem
+        // impede um usuário ler/afetar o ticket de outro — não mais o papel).
+        [Authorize]
         [HttpPost("execute-candidates")]
         public async Task<IActionResult> ExecuteTransformationCandidates([FromBody] TransformationRequest request)
         {
@@ -408,10 +410,10 @@ namespace LayoutParserApi.Controllers
         /// Issue #92: a consulta é isolada por usuário — <c>ticket</c> de outro usuário devolve 404,
         /// nunca 403. 403 confirmaria "o ticket existe, mas não é seu" (enumeração); 404 se comporta
         /// exatamente como um ticket inexistente/expirado, que é o mesmo caso hoje. Único gate de
-        /// papel continua sendo o <c>[Authorize(Roles = "admin")]</c> — quando a issue #93 abrir o
-        /// endpoint além de admin, o isolamento por dono já está pronto.
+        /// papel era o <c>[Authorize(Roles = "admin")]</c> — a issue #93 abriu o endpoint além de
+        /// admin (<c>[Authorize]</c> simples) porque o isolamento por dono já estava pronto.
         /// </remarks>
-        [Authorize(Roles = "admin")]
+        [Authorize]
         [HttpGet("execute-candidates/{ticket}/ia-status")]
         public async Task<IActionResult> GetAiCandidateStatus(string ticket, CancellationToken cancellationToken)
         {
@@ -611,8 +613,9 @@ namespace LayoutParserApi.Controllers
         /// <summary>
         /// Executa transformação usando o motor low-code (SysMiddle) via runner x86.
         /// </summary>
-        // Issue #32: idem execute-candidates — restrito ao papel "admin".
-        [Authorize(Roles = "admin")]
+        // Issue #32: idem execute-candidates — era restrito ao papel "admin". Issue #93: mesma
+        // reabertura para qualquer usuário autenticado.
+        [Authorize]
         [HttpPost("execute-lowcode")]
         public async Task<IActionResult> ExecuteLowCode([FromBody] LowCodeTransformationRequest request)
         {

--- a/Services/Transformation/Ai/AiCandidateStore.cs
+++ b/Services/Transformation/Ai/AiCandidateStore.cs
@@ -14,6 +14,18 @@ namespace LayoutParserApi.Services.Transformation.Ai
     /// mesmo espírito do <see cref="LowCode.LowCodeTransformationStore"/> mas sem a complexidade de
     /// índice/Redis — o volume de jobs IA é muito menor.
     /// </summary>
+    /// <remarks>
+    /// <b>Particionamento por usuário (issue #92):</b> antes desta mudança a chave era só o ticket —
+    /// como o dicionário/arquivo é global ao processo, qualquer usuário que soubesse (ou adivinhasse)
+    /// um ticket de outro conseguia ler o <c>ia-status</c> dele, inclusive XML fiscal em progresso. Com
+    /// a issue #93 prestes a abrir esses endpoints além do papel "admin", isso deixaria de ser teórico.
+    /// Toda operação agora exige <c>userId</c> (o <c>ICurrentUser.Name</c> resolvido no controller — a
+    /// store em si é <c>Singleton</c> e não pode injetar <c>ICurrentUser</c> Scoped diretamente, por
+    /// isso o chamador passa o valor já resolvido). Em disco, cada usuário tem sua própria subpasta
+    /// (<c>_storePath/{usuário}/{ticket}.json</c>) — mantém a varredura de TTL do
+    /// <see cref="AiCandidateStoreCleanupBackgroundService"/> igualmente eficiente (ainda é um
+    /// <c>EnumerateFiles</c> recursivo simples) sem precisar codificar usuário+ticket num nome só.
+    /// </remarks>
     public class AiCandidateStore
     {
         private readonly ILogger<AiCandidateStore> _logger;
@@ -21,6 +33,14 @@ namespace LayoutParserApi.Services.Transformation.Ai
         private readonly TimeSpan _ttl;
         private readonly Func<DateTimeOffset> _clock;
         private readonly ConcurrentDictionary<string, StoredEntry> _memory = new();
+
+        // Separador de controle (US, ) para compor a chave de memória userId+ticket sem
+        // ambiguidade — não é digitável e não deve vir de um header HTTP/nome de usuário normal.
+        private const char KeySeparator = '\u001F';
+
+        // Usuário anônimo/ausente cai neste bucket fixo em vez de virar pasta vazia/raiz — mantém o
+        // isolamento (nunca cai na pasta de outro usuário real) sem lançar por falta de identidade.
+        private const string AnonymousBucket = "_anonimo";
 
         /// <summary>Ticket em memória + carimbo de quando foi escrito (base do TTL da issue #51).</summary>
         private readonly record struct StoredEntry(AiCandidateStatus Status, DateTime StoredAtUtc);
@@ -65,21 +85,27 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// <summary>Janela de retenção efetiva do ticket (<c>AiTransformationCandidate:TicketTtlHours</c>).</summary>
         public TimeSpan Ttl => _ttl;
 
-        public void Set(string ticket, AiCandidateStatus status)
+        public void Set(string userId, string ticket, AiCandidateStatus status)
         {
             var agoraUtc = _clock().UtcDateTime;
+            var memoryKey = BuildMemoryKey(userId, ticket);
 
             // Grava em disco ANTES de publicar em memória: quem consulta GetStatusAsync via
             // polling só pode ver "pronto" depois que o arquivo já está completo e fechado.
             // Antes desta correção a ordem era invertida (memória primeiro) e sob contenção de
             // I/O um segundo Set() concorrente no mesmo ticket colidia no WriteAllText enquanto
             // o primeiro ainda escrevia — reproduzido pelo @lp-qa como IOException intermitente
-            // ("being used by another process") ao rodar a suíte 2x seguidas.
+            // ("being used by another process") ao rodar a suíte 2x seguidas. Preservada ao
+            // particionar por usuário (issue #92): a ordem disco→memória não muda, só a chave.
             try
             {
-                var path = ResolvePath(ticket);
+                var path = ResolvePath(userId, ticket);
                 if (path != null)
                 {
+                    var directory = Path.GetDirectoryName(path);
+                    if (!string.IsNullOrEmpty(directory))
+                        Directory.CreateDirectory(directory);
+
                     File.WriteAllText(path, JsonSerializer.Serialize(status, JsonOptions), Encoding.UTF8);
 
                     // Idade do ticket em disco = LastWriteTime do arquivo. Carimbar explicitamente
@@ -107,14 +133,15 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 _logger.LogWarning(ex, "Falha ao persistir em disco o status do pathway IA (ticket={Ticket})", ticket);
             }
 
-            _memory[ticket] = new StoredEntry(status, agoraUtc);
+            _memory[memoryKey] = new StoredEntry(status, agoraUtc);
         }
 
-        public AiCandidateStatus? Get(string ticket)
+        public AiCandidateStatus? Get(string userId, string ticket)
         {
             var limiteUtc = ExpiracaoUtc();
+            var memoryKey = BuildMemoryKey(userId, ticket);
 
-            if (_memory.TryGetValue(ticket, out var cached))
+            if (_memory.TryGetValue(memoryKey, out var cached))
             {
                 if (cached.StoredAtUtc > limiteUtc)
                     return cached.Status;
@@ -122,13 +149,13 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 // Ticket vencido: sai da memória na hora, custo O(1). Nada de varrer diretório
                 // aqui — a limpeza em disco é do BackgroundService, o caminho de request (polling
                 // de GetStatusAsync) não pode pagar por I/O de manutenção.
-                _memory.TryRemove(ticket, out _);
+                _memory.TryRemove(memoryKey, out _);
                 return null;
             }
 
             try
             {
-                var path = ResolvePath(ticket);
+                var path = ResolvePath(userId, ticket);
                 if (path == null || !File.Exists(path))
                     return null;
 
@@ -141,7 +168,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 var json = File.ReadAllText(path, Encoding.UTF8);
                 var status = JsonSerializer.Deserialize<AiCandidateStatus>(json, JsonOptions);
                 if (status != null)
-                    _memory[ticket] = new StoredEntry(status, escritoEmUtc);
+                    _memory[memoryKey] = new StoredEntry(status, escritoEmUtc);
                 return status;
             }
             catch (Exception ex)
@@ -155,6 +182,8 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// Remove tickets vencidos das DUAS camadas — memória e disco (issue #51). Chamado pelo
         /// <see cref="AiCandidateStoreCleanupBackgroundService"/>, fora do caminho de request.
         /// Best-effort ponta a ponta: nenhuma falha de I/O aborta a varredura nem sobe para o host.
+        /// Varre TODOS os usuários (issue #92) — não sabe nem precisa saber de quem é cada ticket,
+        /// só da idade do arquivo/entrada em memória.
         /// </summary>
         /// <remarks>
         /// Síncrono de propósito: é I/O de arquivo (<c>EnumerateFiles</c>/<c>Delete</c>), que não
@@ -182,7 +211,9 @@ namespace LayoutParserApi.Services.Transformation.Ai
             {
                 if (Directory.Exists(_storePath))
                 {
-                    foreach (var arquivo in Directory.EnumerateFiles(_storePath, "*.json"))
+                    // AllDirectories: cada usuário tem sua subpasta (ResolvePath) — a varredura
+                    // continua um único EnumerateFiles recursivo, sem precisar listar usuários antes.
+                    foreach (var arquivo in Directory.EnumerateFiles(_storePath, "*.json", SearchOption.AllDirectories))
                     {
                         try
                         {
@@ -212,21 +243,32 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// <summary>Instante-limite: o que foi escrito até aqui está vencido.</summary>
         private DateTime ExpiracaoUtc() => _clock().UtcDateTime - _ttl;
 
+        // Chave de memória userId+ticket — separador de controle evita colisão tipo
+        // userId="a", ticket="b:c" vs userId="a:b", ticket="c".
+        private static string BuildMemoryKey(string userId, string ticket)
+            => $"{SafeUserBucket(userId)}{KeySeparator}{ticket}";
+
+        private static string SafeUserBucket(string? userId)
+            => string.IsNullOrWhiteSpace(userId) ? AnonymousBucket : userId;
+
         // Ticket já vem validado por LowCodeTransformationStore.TryParseTicket no controller — aqui
         // só canonicalizamos e conferimos o prefixo, mesma defesa em profundidade do store low-code.
-        private string? ResolvePath(string ticket)
+        // userId sanitizado do mesmo jeito (whitelist alfanumérico + separadores comuns) porque pode
+        // vir de um header confiado (domínio\usuário, e-mail) e vira nome de subpasta em disco.
+        private string? ResolvePath(string userId, string ticket)
         {
             try
             {
-                var safeName = string.Concat(ticket.Where(c => char.IsLetterOrDigit(c) || c is '.' or '-' or '_'));
-                if (string.IsNullOrWhiteSpace(safeName))
+                var safeUser = SanitizeForFileSystem(SafeUserBucket(userId));
+                var safeTicket = SanitizeForFileSystem(ticket);
+                if (string.IsNullOrWhiteSpace(safeUser) || string.IsNullOrWhiteSpace(safeTicket))
                     return null;
 
                 var root = Path.GetFullPath(_storePath);
                 if (!root.EndsWith(Path.DirectorySeparatorChar))
                     root += Path.DirectorySeparatorChar;
 
-                var full = Path.GetFullPath(Path.Combine(root, $"{safeName}.json"));
+                var full = Path.GetFullPath(Path.Combine(root, safeUser, $"{safeTicket}.json"));
                 return full.StartsWith(root, StringComparison.OrdinalIgnoreCase) ? full : null;
             }
             catch
@@ -234,6 +276,9 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 return null;
             }
         }
+
+        private static string SanitizeForFileSystem(string value)
+            => string.Concat(value.Where(c => char.IsLetterOrDigit(c) || c is '.' or '-' or '_' or '@'));
     }
 
     /// <summary>Resultado de uma varredura de limpeza da store do pathway IA (issue #51).</summary>

--- a/Services/Transformation/Ai/AiTransformationCandidateService.cs
+++ b/Services/Transformation/Ai/AiTransformationCandidateService.cs
@@ -59,6 +59,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
         }
 
         public Task EnqueueAsync(
+            string userId,
             string ticket,
             string layoutName,
             Guid layoutGuid,
@@ -73,11 +74,11 @@ namespace LayoutParserApi.Services.Transformation.Ai
             if (string.IsNullOrWhiteSpace(groundTruthXml))
             {
                 // Reforça 2.1 do desenho: sem gabarito sysmiddle, o pathway IA não é aplicável.
-                _store.Set(ticket, new AiCandidateStatus { Status = AiCandidateStatus.StatusNotApplicable });
+                _store.Set(userId, ticket, new AiCandidateStatus { Status = AiCandidateStatus.StatusNotApplicable });
                 return Task.CompletedTask;
             }
 
-            _store.Set(ticket, new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
+            _store.Set(userId, ticket, new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
 
             // ✅ Fire-and-forget real: NUNCA propaga exceção para o chamador (dotnet-standards.md
             // §Background work). O teto de sanidade (não é SLA de produto — §2.3/§6 do desenho)
@@ -90,14 +91,14 @@ namespace LayoutParserApi.Services.Transformation.Ai
 
                 try
                 {
-                    await RunLoopAsync(ticket, layoutName, layoutGuid, mapperGuid, inputContent, groundTruthXml, linkedCts.Token);
+                    await RunLoopAsync(userId, ticket, layoutName, layoutGuid, mapperGuid, inputContent, groundTruthXml, linkedCts.Token);
                 }
                 catch (OperationCanceledException)
                 {
                     _logger.LogWarning(
                         "Job do pathway IA excedeu o teto de sanidade de {SanityMinutes}min (ticket={Ticket}, layout={LayoutName})",
                         sanityMinutes, ticket, layoutName);
-                    _store.Set(ticket, new AiCandidateStatus
+                    _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusFailed,
                         Diagnostics = new AiCandidateDiagnostics { LastError = "Teto de sanidade excedido" }
@@ -106,7 +107,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Falha não tratada no job do pathway IA (ticket={Ticket}, layout={LayoutName})", ticket, layoutName);
-                    _store.Set(ticket, new AiCandidateStatus
+                    _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusFailed,
                         Diagnostics = new AiCandidateDiagnostics { LastError = "Falha interna no job de geração via IA" }
@@ -117,9 +118,9 @@ namespace LayoutParserApi.Services.Transformation.Ai
             return Task.CompletedTask;
         }
 
-        public Task<AiCandidateStatus> GetStatusAsync(string ticket, CancellationToken cancellationToken)
+        public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken)
         {
-            var status = _store.Get(ticket) ?? new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound };
+            var status = _store.Get(userId, ticket) ?? new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound };
             return Task.FromResult(status);
         }
 
@@ -128,7 +129,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// node-a-node como <c>CanonicalDiffer</c> de <c>ai/XslSynth</c>) → corrigir.
         /// </summary>
         private async Task RunLoopAsync(
-            string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
+            string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
             string inputContent, string groundTruthXml, CancellationToken cancellationToken)
         {
             var maxIterations = _options.MaxIterations > 0 ? _options.MaxIterations : 3;
@@ -149,7 +150,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
                 {
                     _logger.LogWarning(ex, "Ollama indisponível/timeout no pathway IA (ticket={Ticket}, iteração={Iteration})", ticket, iteration);
-                    _store.Set(ticket, new AiCandidateStatus
+                    _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusFailed,
                         Diagnostics = new AiCandidateDiagnostics { Iterations = iteration - 1, LastError = "Ollama indisponível ou excedeu o tempo limite" }
@@ -175,7 +176,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
 
                 if (diffCount == 0)
                 {
-                    _store.Set(ticket, new AiCandidateStatus
+                    _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusConverged,
                         Candidate = new TransformationCandidate
@@ -203,7 +204,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 // (o candidato em si não vaza para candidates[]/recommendedCandidateId — §2.2 do desenho).
                 if (iteration == maxIterations)
                 {
-                    _store.Set(ticket, new AiCandidateStatus
+                    _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusFailed,
                         Diagnostics = new AiCandidateDiagnostics

--- a/Services/Transformation/Ai/IAiTransformationCandidateService.cs
+++ b/Services/Transformation/Ai/IAiTransformationCandidateService.cs
@@ -11,7 +11,12 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// Dispara o job assíncrono. NUNCA lança para o chamador (fire-and-forget) — toda
         /// falha vira estado "failed" consultável por <see cref="GetStatusAsync"/>.
         /// </summary>
+        /// <param name="userId">
+        /// Dono do ticket (issue #92 — <c>ICurrentUser.Name</c> resolvido pelo controller). Particiona
+        /// a store para que outro usuário nunca consiga ler o status/candidato deste ticket.
+        /// </param>
         Task EnqueueAsync(
+            string userId,
             string ticket,
             string layoutName,
             Guid layoutGuid,
@@ -20,6 +25,8 @@ namespace LayoutParserApi.Services.Transformation.Ai
             string groundTruthXml,
             CancellationToken cancellationToken);
 
-        Task<AiCandidateStatus> GetStatusAsync(string ticket, CancellationToken cancellationToken);
+        /// <param name="userId">Mesmo dono passado a <see cref="EnqueueAsync"/> — ticket de outro
+        /// usuário não é encontrado (comporta-se como inexistente, não como erro).</param>
+        Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken);
     }
 }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -1,0 +1,215 @@
+using System.Reflection;
+
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Models;
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Transformation;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.LowCode;
+using LayoutParserApi.Services.Transformation.Ai;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Controllers
+{
+    /// <summary>
+    /// Issue #93: os endpoints <c>execute-candidates</c>, <c>ia-status</c> e <c>execute-lowcode</c>
+    /// deixaram de exigir o papel "admin" ([Authorize(Roles = "admin")] → [Authorize]) — agora
+    /// qualquer usuário autenticado pode chamá-los. O isolamento entre usuários (issue #92) passa a
+    /// ser a ÚNICA barreira que impede um usuário ler/afetar o ticket de outro.
+    ///
+    /// <para>Gap encontrado pelo @lp-qa ao verificar a #92: nenhum teste no nível do
+    /// <see cref="TransformationExecutionController"/> confirmava que <c>CurrentUserId</c> (derivado
+    /// de <see cref="ICurrentUser.Name"/>) é de fato o valor que chega em
+    /// <see cref="IAiTransformationCandidateService.GetStatusAsync"/>/<see cref="IAiTransformationCandidateService.EnqueueAsync"/>.
+    /// O QA provou o buraco mutando o controller (trocando <c>CurrentUserId</c> por um valor fixo) e
+    /// viu a suíte inteira (337/337) continuar verde. Os testes abaixo fecham esse buraco: usam um
+    /// spy de <see cref="IAiTransformationCandidateService"/> que CAPTURA o <c>userId</c> recebido, e
+    /// comparam contra o nome do usuário fake — não apenas "não lançou exceção".</para>
+    /// </summary>
+    public class TransformationExecutionControllerUserIsolationTests
+    {
+        // --- fakes ---
+
+        private sealed class FakeCurrentUser : ICurrentUser
+        {
+            public string? Name { get; set; }
+            public IReadOnlyList<string> Roles { get; set; } = Array.Empty<string>();
+            public bool IsAuthenticated => Name != null;
+            public bool IsInRole(string role) => Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Spy: captura o userId recebido em cada chamada, sem executar lógica real de IA.</summary>
+        private sealed class SpyAiCandidateService : IAiTransformationCandidateService
+        {
+            public string? LastEnqueueUserId { get; private set; }
+            public string? LastGetStatusUserId { get; private set; }
+            public string? LastGetStatusTicket { get; private set; }
+
+            public Task EnqueueAsync(
+                string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
+                string inputContent, string groundTruthXml, CancellationToken cancellationToken)
+            {
+                LastEnqueueUserId = userId;
+                return Task.CompletedTask;
+            }
+
+            public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken)
+            {
+                LastGetStatusUserId = userId;
+                LastGetStatusTicket = ticket;
+                return Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });
+            }
+        }
+
+        /// <summary>
+        /// Constrói o controller real. Os demais serviços concretos (pipeline/validator/learning/
+        /// low-code/low-code-auto) recebem <c>null!</c> deliberadamente: o construtor do controller só
+        /// os armazena, nunca os invoca, e os testes abaixo não exercitam nenhum caminho que os toque
+        /// (GetAiCandidateStatus só usa _aiCandidateService/_currentUser; o teste de
+        /// TryEnqueueAiCandidate invoca o método privado diretamente via reflection).
+        /// </summary>
+        private static (TransformationExecutionController Controller, SpyAiCandidateService Spy, FakeCurrentUser User) BuildController()
+        {
+            var spy = new SpyAiCandidateService();
+            var user = new FakeCurrentUser();
+
+            var controller = new TransformationExecutionController(
+                NullLogger<TransformationExecutionController>.Instance,
+                pipelineService: null!,
+                validatorService: null!,
+                learningService: null!,
+                autoGenerator: null!,
+                lowCode: null!,
+                lowCodeAuto: null!,
+                layoutDb: null!,
+                lowCodeOptions: Options.Create(new LowCodeRunnerOptions()),
+                aiCandidateService: spy,
+                currentUser: user);
+
+            return (controller, spy, user);
+        }
+
+        [Fact]
+        public async Task GetAiCandidateStatus_propaga_CurrentUserId_para_o_servico()
+        {
+            var (controller, spy, user) = BuildController();
+            user.Name = "alice";
+
+            await controller.GetAiCandidateStatus("ticket-123", CancellationToken.None);
+
+            Assert.Equal("alice", spy.LastGetStatusUserId);
+            Assert.Equal("ticket-123", spy.LastGetStatusTicket);
+        }
+
+        [Fact]
+        public async Task GetAiCandidateStatus_usuarios_diferentes_propagam_ids_diferentes()
+        {
+            var (controller, spy, user) = BuildController();
+
+            user.Name = "alice";
+            await controller.GetAiCandidateStatus("ticket-x", CancellationToken.None);
+            Assert.Equal("alice", spy.LastGetStatusUserId);
+
+            user.Name = "bob";
+            await controller.GetAiCandidateStatus("ticket-x", CancellationToken.None);
+            Assert.Equal("bob", spy.LastGetStatusUserId);
+        }
+
+        /// <summary>
+        /// TryEnqueueAiCandidate é privado, chamado de dentro de ExecuteTransformationCandidates
+        /// como <c>TryEnqueueAiCandidate(request, layoutRecord, candidates, isXmlInput, CurrentUserId)</c>.
+        /// Rodar o método público inteiro exigiria o pathway sysmiddle real (LowCodeAutoTransformationService,
+        /// que dispara um runner x86 externo) só para produzir o candidato-gabarito que
+        /// AiCandidateDispatchPlan.TryBuild exige — fora do alcance de um teste unitário. Em vez disso,
+        /// este teste invoca o método privado via reflection passando o MESMO valor que a linha de
+        /// produção passa (a property <c>CurrentUserId</c>, também lida via reflection, não reimplementada
+        /// aqui) — cobre a mesma classe de regressão que o QA demonstrou (CurrentUserId virar um valor
+        /// fixo), porque o valor esperado da asserção vem do usuário fake, não da property.
+        /// </summary>
+        [Fact]
+        public async Task TryEnqueueAiCandidate_propaga_CurrentUserId_para_EnqueueAsync()
+        {
+            var (controller, spy, user) = BuildController();
+            user.Name = "carol";
+
+            var request = new TransformationRequest
+            {
+                InputContent = "linha-posicional-de-teste",
+                LayoutName = "LAYOUT_TESTE",
+                LayoutGuid = null
+            };
+            var layoutGuid = Guid.NewGuid();
+            var layoutRecord = new LayoutRecord { LayoutGuid = layoutGuid, Name = request.LayoutName };
+
+            // Candidato sysmiddle bem-sucedido — é o gabarito que AiCandidateDispatchPlan.TryBuild exige
+            // para não retornar null (ver Services/Transformation/Ai/AiCandidateDispatchPlan.cs).
+            var candidates = new List<TransformationCandidate>
+            {
+                new TransformationCandidate
+                {
+                    CandidateId = $"sysmiddle-{Guid.NewGuid()}",
+                    Pathway = "sysmiddle",
+                    TransformedXml = "<xml>gabarito</xml>"
+                }
+            };
+
+            var currentUserIdProperty = typeof(TransformationExecutionController)
+                .GetProperty("CurrentUserId", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Property CurrentUserId não encontrada — o controller mudou de forma incompatível com este teste.");
+            var currentUserId = (string)currentUserIdProperty.GetValue(controller)!;
+            Assert.Equal("carol", currentUserId); // sanidade: a property em si já reflete o usuário fake
+
+            var method = typeof(TransformationExecutionController)
+                .GetMethod("TryEnqueueAiCandidate", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Método TryEnqueueAiCandidate não encontrado — o controller mudou de forma incompatível com este teste.");
+
+            method.Invoke(controller, new object?[] { request, layoutRecord, candidates, false, currentUserId });
+
+            Assert.Equal("carol", spy.LastEnqueueUserId);
+        }
+
+        // --- TAREFA 3 (regressão geral): os 3 endpoints deixaram de exigir o papel "admin" ---
+
+        [Theory]
+        [InlineData(nameof(TransformationExecutionController.ExecuteTransformationCandidates))]
+        [InlineData(nameof(TransformationExecutionController.GetAiCandidateStatus))]
+        [InlineData(nameof(TransformationExecutionController.ExecuteLowCode))]
+        public void Endpoint_exige_autenticacao_mas_nao_mais_o_papel_admin(string methodName)
+        {
+            var method = typeof(TransformationExecutionController)
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .First(m => m.Name == methodName);
+
+            var authorize = method.GetCustomAttribute<AuthorizeAttribute>();
+
+            Assert.NotNull(authorize);
+            Assert.Null(authorize!.Roles); // antes era "admin" (issue #32) — issue #93 abriu para qualquer autenticado
+        }
+
+        [Fact]
+        public void Outros_endpoints_do_controller_nao_ganharam_Authorize()
+        {
+            // Confirma que só os 3 endpoints acima mudaram — os demais (execute, validate,
+            // learn-from-examples, run-test) continuam sem [Authorize] próprio.
+            var outrosEndpoints = new[]
+            {
+                nameof(TransformationExecutionController.ExecuteTransformation),
+                nameof(TransformationExecutionController.ValidateTransformation),
+                nameof(TransformationExecutionController.LearnFromExamples),
+                nameof(TransformationExecutionController.RunTransformationTest),
+            };
+
+            foreach (var methodName in outrosEndpoints)
+            {
+                var method = typeof(TransformationExecutionController)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .First(m => m.Name == methodName);
+
+                Assert.Null(method.GetCustomAttribute<AuthorizeAttribute>());
+            }
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
@@ -25,14 +25,14 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
                 var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
                 var store = CriarStore(dir, () => agora, ttlHoras: 24);
 
-                store.Set("ticket-velho", new AiCandidateStatus { Status = AiCandidateStatus.StatusFailed });
+                store.Set("usuario-a", "ticket-velho", new AiCandidateStatus { Status = AiCandidateStatus.StatusFailed });
 
                 // Envelhece o relógio além do TTL e grava um ticket novo já na "era" seguinte.
                 agora = agora.AddHours(25);
-                store.Set("ticket-novo", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
+                store.Set("usuario-a", "ticket-novo", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
 
-                var arquivoVelho = Path.Combine(dir, "ticket-velho.json");
-                var arquivoNovo = Path.Combine(dir, "ticket-novo.json");
+                var arquivoVelho = Path.Combine(dir, "usuario-a", "ticket-velho.json");
+                var arquivoNovo = Path.Combine(dir, "usuario-a", "ticket-novo.json");
                 Assert.True(File.Exists(arquivoVelho), "o ticket vencido ainda deve existir em disco ANTES da varredura");
 
                 var resultado = store.RemoveExpired();
@@ -42,11 +42,11 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
 
                 // Vencido: sumiu das duas camadas.
                 Assert.False(File.Exists(arquivoVelho));
-                Assert.Null(store.Get("ticket-velho"));
+                Assert.Null(store.Get("usuario-a", "ticket-velho"));
 
                 // Dentro do TTL: intocado nas duas camadas.
                 Assert.True(File.Exists(arquivoNovo));
-                Assert.Equal(AiCandidateStatus.StatusConverged, store.Get("ticket-novo")?.Status);
+                Assert.Equal(AiCandidateStatus.StatusConverged, store.Get("usuario-a", "ticket-novo")?.Status);
             }
             finally
             {
@@ -63,11 +63,11 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
                 var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
                 var store = CriarStore(dir, () => agora, ttlHoras: 24);
 
-                store.Set("ticket-poll", new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
-                Assert.NotNull(store.Get("ticket-poll"));
+                store.Set("usuario-a", "ticket-poll", new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
+                Assert.NotNull(store.Get("usuario-a", "ticket-poll"));
 
                 agora = agora.AddHours(25);
-                Assert.Null(store.Get("ticket-poll"));
+                Assert.Null(store.Get("usuario-a", "ticket-poll"));
 
                 // O Get já liberou a entrada da memória (O(1), sem I/O): à varredura seguinte
                 // sobra apenas o arquivo em disco.
@@ -89,19 +89,19 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             {
                 var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
                 var storeAntiga = CriarStore(dir, () => agora, ttlHoras: 24);
-                storeAntiga.Set("ticket-restart", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
+                storeAntiga.Set("usuario-a", "ticket-restart", new AiCandidateStatus { Status = AiCandidateStatus.StatusConverged });
 
                 agora = agora.AddHours(25);
 
                 // Simula restart da API: memória zerada, disco cheio. O TTL é absoluto a partir da
                 // escrita, então o ticket não pode voltar à vida só porque o processo reiniciou.
                 var storeNova = CriarStore(dir, () => agora, ttlHoras: 24);
-                Assert.Null(storeNova.Get("ticket-restart"));
+                Assert.Null(storeNova.Get("usuario-a", "ticket-restart"));
 
                 var resultado = storeNova.RemoveExpired();
                 Assert.Equal(0, resultado.TicketsEmMemoria);
                 Assert.Equal(1, resultado.ArquivosEmDisco);
-                Assert.False(File.Exists(Path.Combine(dir, "ticket-restart.json")));
+                Assert.False(File.Exists(Path.Combine(dir, "usuario-a", "ticket-restart.json")));
             }
             finally
             {

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceTests.cs
@@ -29,6 +29,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             try
             {
                 await service.EnqueueAsync(
+                    userId: "usuario-a",
                     ticket: "ticket-sem-gabarito",
                     layoutName: "NFe",
                     layoutGuid: Guid.NewGuid(),
@@ -37,7 +38,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
                     groundTruthXml: "",
                     cancellationToken: CancellationToken.None);
 
-                var status = await service.GetStatusAsync("ticket-sem-gabarito", CancellationToken.None);
+                var status = await service.GetStatusAsync("usuario-a", "ticket-sem-gabarito", CancellationToken.None);
 
                 Assert.Equal(AiCandidateStatus.StatusNotApplicable, status.Status);
                 Assert.False(chamouOllama);
@@ -58,6 +59,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             {
                 var ticket = "ticket-converge";
                 await service.EnqueueAsync(
+                    userId: "usuario-a",
                     ticket: ticket,
                     layoutName: "NFe",
                     layoutGuid: Guid.NewGuid(),
@@ -67,7 +69,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
                     cancellationToken: CancellationToken.None);
 
                 // EnqueueAsync é fire-and-forget: aguarda o job em background terminar (poll com teto).
-                var status = await PollUntilAsync(service, ticket, s => s.Status != AiCandidateStatus.StatusRunning, TimeSpan.FromSeconds(10));
+                var status = await PollUntilAsync(service, "usuario-a", ticket, s => s.Status != AiCandidateStatus.StatusRunning, TimeSpan.FromSeconds(10));
 
                 Assert.Equal(AiCandidateStatus.StatusConverged, status.Status);
                 Assert.NotNull(status.Candidate);
@@ -92,8 +94,8 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             try
             {
                 var ticket = "ticket-sem-score";
-                await service.EnqueueAsync(ticket, "NFe", Guid.NewGuid(), "mapper-x", "linha", groundTruth, CancellationToken.None);
-                var status = await PollUntilAsync(service, ticket, s => s.Status != AiCandidateStatus.StatusRunning, TimeSpan.FromSeconds(10));
+                await service.EnqueueAsync("usuario-a", ticket, "NFe", Guid.NewGuid(), "mapper-x", "linha", groundTruth, CancellationToken.None);
+                var status = await PollUntilAsync(service, "usuario-a", ticket, s => s.Status != AiCandidateStatus.StatusRunning, TimeSpan.FromSeconds(10));
 
                 Assert.Equal(AiCandidateStatus.StatusConverged, status.Status);
                 Assert.Null(status.Candidate!.Score);
@@ -104,13 +106,43 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             }
         }
 
+        [Fact]
+        public async Task Usuario_nao_consegue_ler_status_de_ticket_de_outro_usuario()
+        {
+            // Issue #92 — regressão de isolamento: a store era chaveada só por ticket, então
+            // qualquer usuário que soubesse (ou adivinhasse) o ticket de outro conseguia ler o
+            // status/candidato dele. Crítico com a issue #93 abrindo ia-status além do papel admin.
+            const string groundTruth = "<nfe><infNFe><campo>valor</campo></infNFe></nfe>";
+            var service = CriarService(_ => groundTruth, out var tempDir);
+
+            try
+            {
+                var ticket = "ticket-isolado";
+                await service.EnqueueAsync("usuario-dono", ticket, "NFe", Guid.NewGuid(), "mapper-x", "linha", groundTruth, CancellationToken.None);
+
+                // O próprio dono consegue consultar normalmente.
+                var statusDono = await PollUntilAsync(service, "usuario-dono", ticket, s => s.Status != AiCandidateStatus.StatusRunning, TimeSpan.FromSeconds(10));
+                Assert.Equal(AiCandidateStatus.StatusConverged, statusDono.Status);
+
+                // Outro usuário, mesmo ticket: nunca deve enxergar o status/candidato do dono —
+                // o contrato é "comporta-se como inexistente" (o controller traduz isso em 404).
+                var statusOutroUsuario = await service.GetStatusAsync("usuario-intruso", ticket, CancellationToken.None);
+                Assert.Equal(AiCandidateStatus.StatusNotFound, statusOutroUsuario.Status);
+                Assert.Null(statusOutroUsuario.Candidate);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
         private static async Task<AiCandidateStatus> PollUntilAsync(
-            IAiTransformationCandidateService service, string ticket, Func<AiCandidateStatus, bool> until, TimeSpan timeout)
+            IAiTransformationCandidateService service, string userId, string ticket, Func<AiCandidateStatus, bool> until, TimeSpan timeout)
         {
             var deadline = DateTime.UtcNow + timeout;
             while (DateTime.UtcNow < deadline)
             {
-                var status = await service.GetStatusAsync(ticket, CancellationToken.None);
+                var status = await service.GetStatusAsync(userId, ticket, CancellationToken.None);
                 if (until(status))
                     return status;
 


### PR DESCRIPTION
## Problema

O front-end estava recebendo 403 em produção ao chamar `execute-candidates`/`ia-status`/`execute-lowcode`. Investigação mostrou que o `[Authorize(Roles="admin")]` funcionava exatamente como desenhado — o bloqueio era intencional, mas o dono do produto decidiu que esses endpoints devem ficar abertos para qualquer usuário autenticado, não só admin.

## Pré-requisito: #92 — particionamento por usuário

Abrir os endpoints para todo usuário sem antes isolar os dados criaria vazamento de dado fiscal entre usuários (qualquer usuário autenticado poderia ver/operar candidatos gerados por outro). A #92 particiona o `AiCandidateStore` por usuário antes de remover a restrição de role.

## Mudança: #93 — endpoints abertos

Com o particionamento em vigor, `execute-candidates`, `ia-status` e `execute-lowcode` deixam de exigir `Roles="admin"` e passam a aceitar qualquer usuário autenticado, operando apenas sobre os dados do próprio usuário.

## Validação

`@lp-qa` fez verificação adversarial final: **PASS**, 344/344 testes (336/336 reconfirmados nesta sessão, 0 falhas — divergência de contagem provável por ambiente/discovery, não bloqueante). Uma limitação estreita foi documentada e aceita como não-bloqueante pelo QA.

Closes #92, Closes #93