### PR TITLE
fix: validacao de config LowCode/Ollama (readiness degrada, startup falha so quando cabivel)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -347,6 +347,11 @@ try
         .Add(new HealthCheckRegistration("lowcode-runner",
             sp => new LowCodeRunnerHealthCheck(sp.GetRequiredService<IOptions<LowCodeRunnerOptions>>()),
             HealthStatus.Unhealthy, new[] { "ready" }))
+        // ✅ A2 (gate #107/#108): Ollama:Url ausente/localhost é config órfã neste projeto — o Ollama
+        // real roda numa VM Linux separada. Degraded (200): diagnóstico via IA é opcional.
+        .Add(new HealthCheckRegistration("ollama-config",
+            sp => new OllamaConfigHealthCheck(sp.GetRequiredService<IOptions<OllamaOptions>>()),
+            HealthStatus.Unhealthy, new[] { "ready" }))
         .Add(new HealthCheckRegistration("catalog",
             sp => new CatalogHealthCheck(sp.GetRequiredService<CatalogWarmupState>()),
             HealthStatus.Unhealthy, new[] { "ready" }));
@@ -461,7 +466,30 @@ try
     // Ainda sem controller consumidor (isso é o item 6.2, Lia+Dex) - registrado desde
     // já seguindo o mesmo padrão dos itens 3.1/3.2 acima.
     builder.Services.AddScoped<CfopOperationCatalogService>();
-    builder.Services.Configure<LowCodeRunnerOptions>(builder.Configuration.GetSection("LowCode"));
+    // ✅ A1 (gate #107/#108): valida no ARRANQUE, não deixa o silêncio do binding chegar a produção.
+    // Causa raiz: `IOptions<LowCodeRunnerOptions>` cai nos defaults do C# sem erro nenhum quando a
+    // seção LowCode falta — AllowedPackageGuids vira lista vazia e a query SQL de mapper vira
+    // `IN (NULL)`, nunca batendo com nada. A regra é restrita de propósito: só falha quando a seção
+    // LowCode EXISTE e AllowedPackageGuids está vazia — um host sem low-code configurado (seção
+    // ausente) continua sendo um cenário válido (parse/catálogo servem sem transformação).
+    // ProjectId NÃO entra na validação: o diagnóstico mostrou que o default C# (2) coincide por
+    // acaso com o valor real do banco, então travar nele criaria uma regra rígida em cima de uma
+    // coincidência, não de um invariante real.
+    builder.Services.AddOptions<LowCodeRunnerOptions>()
+        .Bind(builder.Configuration.GetSection("LowCode"))
+        .Validate(opt =>
+        {
+            var lowCodeSection = builder.Configuration.GetSection("LowCode");
+            if (!lowCodeSection.Exists())
+                return true; // seção ausente: host sem low-code, cenário válido
+
+            return opt.AllowedPackageGuids is { Count: > 0 };
+        }, "LowCode:AllowedPackageGuids esta vazio, mas a secao LowCode esta presente na configuracao. " +
+           "Isso faz TODA busca de mapper falhar silenciosamente (query SQL vira IN (NULL)) sem erro " +
+           "visivel ate o usuario tentar transformar um documento. Configure a variavel de ambiente " +
+           "LowCode__AllowedPackageGuids__0 (e demais indices) com os PackageGuid permitidos deste host, " +
+           "ou remova a secao LowCode inteira se este host nao usa low-code.")
+        .ValidateOnStart();
     builder.Services.AddSingleton<LowCodeTransformationService>();
     // ✅ Store/índice das transformações low-code: Singleton porque é consumido pelos Singletons do
     // pathway (auto-transform) e não guarda estado por request. Redis é OPCIONAL — resolvido por

--- a/Services/Health/ReadinessHealthChecks.cs
+++ b/Services/Health/ReadinessHealthChecks.cs
@@ -1,5 +1,6 @@
 using LayoutParserApi.Services.Interfaces;
 using LayoutParserApi.Services.Transformation.LowCode;
+using LayoutParserApi.Services.XmlAnalysis;
 
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -107,7 +108,8 @@ namespace LayoutParserApi.Services.Health
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            var path = _options.Value.RunnerPath;
+            var options = _options.Value;
+            var path = options.RunnerPath;
 
             if (string.IsNullOrWhiteSpace(path))
                 return Task.FromResult(HealthCheckResult.Degraded("LowCode:RunnerPath nao configurado — transformacao low-code indisponivel."));
@@ -115,7 +117,46 @@ namespace LayoutParserApi.Services.Health
             if (!File.Exists(path))
                 return Task.FromResult(HealthCheckResult.Degraded($"LowCode:RunnerPath nao existe ({path}) — transformacao low-code indisponivel."));
 
+            // ✅ Gate #107/#108: AllowedPackageGuids vazio faz a query de mapper virar `IN (NULL)`,
+            // nunca batendo com nada — nenhum erro visível, só "mapper não encontrado" longe da causa.
+            // O startup (A1, ver Program.cs) já falha o boot quando a seção LowCode existe e o campo
+            // está vazio; esta sonda cobre o caso em que a validação de boot foi contornada (env var
+            // setada depois do bind, teste manual, etc.) — mesma severidade Degraded do resto deste
+            // health check: parse/catálogo seguem servindo, só a transformação low-code fica capenga.
+            if (options.AllowedPackageGuids is null || options.AllowedPackageGuids.Count == 0)
+                return Task.FromResult(HealthCheckResult.Degraded(
+                    "LowCode:AllowedPackageGuids vazio — nenhum mapper sera encontrado (query vira IN (NULL)); transformacao low-code indisponivel."));
+
             return Task.FromResult(HealthCheckResult.Healthy("Runner low-code encontrado."));
+        }
+    }
+
+    /// <summary>
+    /// Config órfã do Ollama: <c>Ollama:Url</c> ausente ou apontando para localhost/127.0.0.1 é sinal
+    /// forte de que a seção não foi configurada para este host — o Ollama real deste projeto roda numa
+    /// VM Linux separada, nunca no mesmo host da API (ver memória de <c>@lp-backend-dev</c>,
+    /// dev-ollama-vs-brnddappbld01-hardware). <b>Degraded</b>: diagnóstico via IA é funcionalidade
+    /// opcional (Gap 2) — parse/catálogo/transformação low-code seguem servindo sem ela.
+    /// </summary>
+    public sealed class OllamaConfigHealthCheck : IHealthCheck
+    {
+        private readonly IOptions<OllamaOptions> _options;
+
+        public OllamaConfigHealthCheck(IOptions<OllamaOptions> options) => _options = options;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            var url = _options.Value.Url;
+
+            if (string.IsNullOrWhiteSpace(url))
+                return Task.FromResult(HealthCheckResult.Degraded("Ollama:Url nao configurado — diagnostico via IA indisponivel."));
+
+            if (url.Contains("localhost", StringComparison.OrdinalIgnoreCase) ||
+                url.Contains("127.0.0.1", StringComparison.Ordinal))
+                return Task.FromResult(HealthCheckResult.Degraded(
+                    $"Ollama:Url aponta para localhost/127.0.0.1 ({url}) — sinal de config orfa: o Ollama real roda numa VM separada, nao no host da API."));
+
+            return Task.FromResult(HealthCheckResult.Healthy($"Ollama:Url configurado: {url}."));
         }
     }
 

--- a/tests/LayoutParserApi.Tests/Health/ReadinessHealthCheckTests.cs
+++ b/tests/LayoutParserApi.Tests/Health/ReadinessHealthCheckTests.cs
@@ -1,5 +1,6 @@
 using LayoutParserApi.Services.Health;
 using LayoutParserApi.Services.Transformation.LowCode;
+using LayoutParserApi.Services.XmlAnalysis;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -105,6 +106,82 @@ namespace LayoutParserApi.Tests.Health
             var result = await new LowCodeRunnerHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        /// <summary>
+        /// A2 (gate #107/#108): mesmo com RunnerPath válido, AllowedPackageGuids vazio é
+        /// Degraded — a query de mapper vira IN (NULL) e nenhuma transformação low-code funciona,
+        /// mas parse/catálogo seguem servindo (mesma severidade do resto deste health check).
+        /// </summary>
+        [Fact]
+        public async Task Runner_com_AllowedPackageGuids_vazio_e_degraded()
+        {
+            var options = Options.Create(new LowCodeRunnerOptions
+            {
+                RunnerPath = System.Reflection.Assembly.GetExecutingAssembly().Location, // arquivo que existe de verdade
+                AllowedPackageGuids = new List<string>()
+            });
+
+            var result = await new LowCodeRunnerHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("AllowedPackageGuids", result.Description);
+        }
+
+        [Fact]
+        public async Task Runner_com_AllowedPackageGuids_preenchido_e_healthy()
+        {
+            var options = Options.Create(new LowCodeRunnerOptions
+            {
+                RunnerPath = System.Reflection.Assembly.GetExecutingAssembly().Location,
+                AllowedPackageGuids = new List<string> { "11111111-1111-1111-1111-111111111111" }
+            });
+
+            var result = await new LowCodeRunnerHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+
+        // ---- Ollama: config órfã (Url ausente/localhost) é sinal forte neste projeto ------------
+
+        [Fact]
+        public async Task Ollama_com_url_localhost_e_degraded()
+        {
+            var options = Options.Create(new OllamaOptions { Url = "http://localhost:11434" });
+
+            var result = await new OllamaConfigHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        [Fact]
+        public async Task Ollama_com_url_127_0_0_1_e_degraded()
+        {
+            var options = Options.Create(new OllamaOptions { Url = "http://127.0.0.1:11434" });
+
+            var result = await new OllamaConfigHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        [Fact]
+        public async Task Ollama_com_url_vazia_e_degraded()
+        {
+            var options = Options.Create(new OllamaOptions { Url = "" });
+
+            var result = await new OllamaConfigHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        [Fact]
+        public async Task Ollama_com_url_de_vm_remota_e_healthy()
+        {
+            var options = Options.Create(new OllamaOptions { Url = "http://10.0.0.42:11434" });
+
+            var result = await new OllamaConfigHealthCheck(options).CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
 
         // ---- Agregação: dependência forçada a falhar → readiness responde 503 -------------------

--- a/tests/LayoutParserApi.Tests/Transformation/LowCodeRunnerOptionsValidationTests.cs
+++ b/tests/LayoutParserApi.Tests/Transformation/LowCodeRunnerOptionsValidationTests.cs
@@ -1,0 +1,108 @@
+using LayoutParserApi.Services.Transformation.LowCode;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Transformation
+{
+    /// <summary>
+    /// Trava a regra de validação de arranque (A1, gate #107/#108): a mesma composição
+    /// <c>AddOptions&lt;LowCodeRunnerOptions&gt;().Bind(...).Validate(...).ValidateOnStart()</c>
+    /// registrada em Program.cs, exercitada aqui isoladamente (sem subir o host inteiro).
+    ///
+    /// Causa raiz que a validação fecha: <c>IOptions&lt;LowCodeRunnerOptions&gt;</c> cai nos
+    /// defaults do C# sem erro nenhum quando a seção "LowCode" falta do appsettings/env vars —
+    /// AllowedPackageGuids vira lista vazia e a query SQL de mapper vira IN (NULL), nunca batendo
+    /// com nada. A regra é restrita de propósito: só falha quando a seção EXISTE e o campo está
+    /// vazio — host sem low-code configurado (seção ausente) continua válido.
+    /// </summary>
+    public class LowCodeRunnerOptionsValidationTests
+    {
+        private static ServiceProvider BuildProvider(IConfiguration configuration)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(configuration);
+
+            services.AddOptions<LowCodeRunnerOptions>()
+                .Bind(configuration.GetSection("LowCode"))
+                .Validate(opt =>
+                {
+                    var lowCodeSection = configuration.GetSection("LowCode");
+                    if (!lowCodeSection.Exists())
+                        return true;
+
+                    return opt.AllowedPackageGuids is { Count: > 0 };
+                }, "LowCode:AllowedPackageGuids esta vazio, mas a secao LowCode esta presente na configuracao.")
+                .ValidateOnStart();
+
+            return services.BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// (a) Seção "LowCode" presente + AllowedPackageGuids vazia → o arranque deve falhar.
+        /// É exatamente o cenário do gate #107/#108: config parcial que hoje sobe silenciosa.
+        /// </summary>
+        [Fact]
+        public void Startup_falha_quando_LowCode_presente_e_AllowedPackageGuids_vazio()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["LowCode:RunnerPath"] = @"C:\algum\caminho\runner.exe",
+                    ["LowCode:Package"] = "PKG123"
+                    // AllowedPackageGuids deliberadamente ausente → lista vazia após bind
+                })
+                .Build();
+
+            using var provider = BuildProvider(configuration);
+
+            var ex = Assert.Throws<OptionsValidationException>(
+                () => provider.GetRequiredService<IOptions<LowCodeRunnerOptions>>().Value);
+
+            Assert.Contains("AllowedPackageGuids", ex.Message);
+        }
+
+        /// <summary>
+        /// (b) Seção "LowCode" ausente por completo → NÃO deve falhar. Host sem low-code
+        /// configurado é um cenário válido (parse/catálogo servem sem transformação).
+        /// </summary>
+        [Fact]
+        public void Startup_nao_falha_quando_secao_LowCode_esta_totalmente_ausente()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["OutraSecao:Chave"] = "valor"
+                })
+                .Build();
+
+            using var provider = BuildProvider(configuration);
+
+            var options = provider.GetRequiredService<IOptions<LowCodeRunnerOptions>>().Value;
+
+            Assert.Empty(options.AllowedPackageGuids);
+        }
+
+        /// <summary>
+        /// Caso feliz: seção presente e AllowedPackageGuids preenchida → arranque segue normalmente.
+        /// </summary>
+        [Fact]
+        public void Startup_nao_falha_quando_AllowedPackageGuids_preenchido()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["LowCode:RunnerPath"] = @"C:\algum\caminho\runner.exe",
+                    ["LowCode:AllowedPackageGuids:0"] = "11111111-1111-1111-1111-111111111111"
+                })
+                .Build();
+
+            using var provider = BuildProvider(configuration);
+
+            var options = provider.GetRequiredService<IOptions<LowCodeRunnerOptions>>().Value;
+
+            Assert.Single(options.AllowedPackageGuids);
+        }
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa os itens A1+A2 da recomendacao de @lp-architect (issue #108), relacionados aos gates de config levantados na auditoria de arquitetura de #107/#108 (itens ja formalizados como PBIs no board pela @lp-pm).

- A1 - Program.cs: AddOptions<LowCodeRunnerOptions>().Validate(...).ValidateOnStart(). Startup falha ruidosamente apenas quando a secao LowCode esta presente e AllowedPackageGuids esta vazio - nao quando a secao inteira esta ausente (evita quebrar ambientes onde LowCode simplesmente nao e usado).
- A2 - Services/Health/ReadinessHealthChecks.cs: readiness agora reporta Degraded (nao Unhealthy) para o mesmo caso de AllowedPackageGuids vazio, e ganha um novo OllamaConfigHealthCheck para detectar Ollama:Url orfa (localhost/127.0.0.1) sem derrubar o processo.

## Comportamento

- Startup so falha no caso restrito descrito acima (config claramente incompleta).
- Health check degrada de forma visivel sem quebrar a resposta/readiness geral do servico - alinhado ao principio de resiliencia do projeto (dependencias externas/config incompleta nao derrubam o request principal).

## Validacao

- @lp-qa (Quinn) deu PASS no commit 81a23bc, incluindo validacao adversarial (mutation test que comprova que o teste novo pega a regressao).
- 353/353 testes, build limpo (dotnet build sem erros).

Base: master. Branch isolada, sem push direto em develop/master.