### PR TITLE
chore(security): hook de pre-commit anti-segredo + confirmacao de log…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,8 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Git hooks shell scripts must keep LF line endings (fail under CRLF on sh)
+###############################################################################
+.githooks/* text eol=lf

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,65 @@
+# Git hooks locais — LayoutParser API
+
+Este diretório contém hooks versionados (o `.git/hooks/` padrão não é versionável).
+Hoje existe um hook: **`pre-commit`**, que roda o [gitleaks](https://github.com/gitleaks/gitleaks)
+contra os arquivos staged e **bloqueia o commit** se encontrar padrão de segredo
+(connection string com senha, API key, etc.).
+
+Contexto: a senha do SQL Server já vazou uma vez para o `appsettings.json` comitado
+(regressão de 2026-07-18) porque alguém testou local com a senha no arquivo e o
+commit foi junto. Esse hook existe para pegar isso **antes** do commit, não depois.
+Ver [`.claude/rules/security.md`](../.claude/rules/security.md) para o histórico completo.
+
+## Instalação (uma vez por clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Isso faz o git usar `.githooks/` em vez de `.git/hooks/` — cada dev configura
+uma vez no seu clone; não é algo que o repositório força automaticamente.
+
+## Instalar o gitleaks
+
+O hook precisa do binário `gitleaks` no `PATH`. É um binário único, sem
+dependência de Python/Node.
+
+**Windows (via winget, recomendado neste time):**
+```powershell
+winget install gitleaks
+```
+
+**Windows (download manual):** baixe o `.zip` da [página de releases](https://github.com/gitleaks/gitleaks/releases)
+(`gitleaks_<versão>_windows_x64.zip`), extraia `gitleaks.exe` para uma pasta já
+no `PATH` (ex.: `C:\Users\<user>\bin\`, adicionando-a ao `PATH` se necessário).
+
+**Via Go (se já tiver o toolchain):**
+```bash
+go install github.com/gitleaks/gitleaks/v8@latest
+```
+
+Confirme a instalação:
+```bash
+gitleaks version
+```
+
+## Comportamento sem gitleaks instalado
+
+O hook é **fail-open**: se `gitleaks` não estiver no `PATH`, ele avisa no
+console mas **não bloqueia** o commit — para não travar quem ainda não instalou
+o binário. Isso é uma rede de segurança adicional ao step equivalente no CI
+(gerido pelo `@lp-devops`), que é quem efetivamente impede merge de segredo
+mesmo se o hook local não rodar.
+
+## Config do projeto
+
+As regras customizadas (além do conjunto padrão do gitleaks) ficam em
+[`.gitleaks.toml`](../.gitleaks.toml) na raiz do repo — inclui uma regra
+específica para connection string de SQL Server com senha embutida.
+
+## Testar manualmente
+
+```bash
+git add .
+gitleaks protect --staged --config=.gitleaks.toml
+```

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Hook de pre-commit — anti-reincidência de segredos (LayoutParser API).
+#
+# Motivo: a senha do SQL Server já vazou uma vez para o appsettings.json
+# comitado (regressão de 2026-07-18, ver .claude/rules/security.md) porque
+# alguém testou local com a senha no arquivo e o commit foi junto. Esse hook
+# roda o gitleaks contra o diff staged e BLOQUEIA o commit se achar padrão
+# de segredo (connection string com senha, API key, etc.).
+#
+# Instalação (uma vez por clone):
+#   git config core.hooksPath .githooks
+#
+# Requer o binário `gitleaks` no PATH. Ver .githooks/README.md para instalar.
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+    echo "⚠️  gitleaks não encontrado no PATH — commit NÃO foi verificado por segredos." >&2
+    echo "    Instale o gitleaks (ver .githooks/README.md) para reativar essa proteção." >&2
+    echo "    Prosseguindo sem bloquear (fail-open) para não travar quem ainda não instalou." >&2
+    exit 0
+fi
+
+# Usa o config do projeto (.gitleaks.toml) se existir na raiz do repo.
+repo_root=$(git rev-parse --show-toplevel)
+config_arg=""
+if [ -f "$repo_root/.gitleaks.toml" ]; then
+    config_arg="--config=$repo_root/.gitleaks.toml"
+fi
+
+gitleaks protect --staged --redact --no-banner $config_arg
+status=$?
+
+if [ $status -ne 0 ]; then
+    echo "" >&2
+    echo "🔴 gitleaks encontrou possível segredo nos arquivos staged. Commit BLOQUEADO." >&2
+    echo "   Remova o segredo (use dotnet user-secrets / variáveis de ambiente) antes de comitar." >&2
+    echo "   Ver .claude/rules/security.md para o contexto completo do incidente." >&2
+    exit 1
+fi
+
+exit 0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+title = "gitleaks config — LayoutParser API"
+
+# Estende o conjunto de regras padrão do gitleaks (segredos genéricos: AWS keys,
+# tokens de API conhecidos, private keys, etc.) e adiciona regras específicas
+# deste projeto — em especial a connection string do SQL Server com senha
+# embutida, que já vazou uma vez (regressão de 2026-07-18, ver
+# .claude/rules/security.md).
+[extend]
+useDefault = true
+
+[[rules]]
+id = "sqlserver-connection-string-with-password"
+description = "Connection string de SQL Server com senha em texto plano (Password=/Pwd=)"
+regex = '''(?i)(Server|Data Source)\s*=.*(Password|Pwd)\s*=\s*[^;"'\s]+'''
+tags = ["secret", "connection-string", "sql"]
+
+[[rules]]
+id = "generic-password-assignment"
+description = "Atribuição de senha em texto plano em appsettings/config (Password/Pwd/ApiKey com valor não vazio)"
+regex = '''(?i)"(Password|Pwd|ApiKey|Secret|ConnectionString)"\s*:\s*"[^"\s]{4,}"'''
+tags = ["secret", "config"]
+
+# appsettings*.json legítimos deste repo usam placeholders vazios ("") —
+# a regra acima só dispara com valor não vazio, então não conflita com eles.
+[allowlist]
+paths = [
+    '''\.githooks/pre-commit''',
+    '''\.gitleaks\.toml''',
+]

--- a/README.md
+++ b/README.md
@@ -305,6 +305,21 @@ docker run -p 5000:5000 \
 
 > **⚠️ Rotacionar é obrigatório mesmo após limpar a história:** qualquer clone feito antes da limpeza ainda contém os segredos. A limpeza reduz exposição futura; só a rotação invalida o que vazou.
 
+### 10.0 Hook de pre-commit anti-segredo
+
+Para evitar reincidência (a senha do SQL já vazou uma vez para o `appsettings.json`
+comitado — ver [`.claude/rules/security.md`](.claude/rules/security.md)), o repo tem
+um hook de pre-commit versionado em [`.githooks/`](.githooks/) que roda o
+[gitleaks](https://github.com/gitleaks/gitleaks) contra os arquivos staged e bloqueia
+o commit se achar padrão de segredo. **Configure uma vez por clone:**
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Instruções de instalação do binário `gitleaks` e detalhes do hook:
+[`.githooks/README.md`](.githooks/README.md).
+
 ### 10.1 Identidade e autenticação (BFF → API)
 
 **🇧🇷** A API **não autentica ninguém diretamente** — ela **confia** na identidade que chega de um


### PR DESCRIPTION
…ging seguro

Parte do plano da Aria (2026-08-15) para itens 3 e 4 da mitigacao da senha SQL nao-rotacionavel (credencial compartilhada org-wide, rotacao descartada):

- Item 3: varredura completa do repo por LogError/Warning/Debug/Trace que pudessem expor a connection string via ex.ToString(). Nenhuma ocorrencia encontrada; todos os pontos usam ex.Message ou passam a excecao ao logger estruturado (SqlException.Message nao inclui a senha). Nenhuma alteracao de codigo necessaria - achado confirma a avaliacao previa da Aria.

- Item 4 (parte local): hook de pre-commit versionado em .githooks/pre-commit rodando gitleaks --staged contra os arquivos staged, com regras customizadas em .gitleaks.toml (conexao SQL Server com senha embutida + atribuicao generica de senha/API key). Fail-open se o gitleaks nao estiver instalado, para nao travar quem ainda nao configurou. Instalacao documentada em .githooks/README.md e README.md (10.0).

Fora de escopo (fica com @lp-devops): step equivalente no CI e hardening da senha em repouso no host.