### PR TITLE
fix(ci): substitui gitleaks-action pelo binario CLI (sem licenca de org)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -43,16 +43,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      # gitleaks-action e gratuito para repositorio publico (a org LayoutParser esta publica
-      # desde 2026-08-15 - ver .claude/rules/agent-authority.md). Sem licenca nova, mesmo
-      # espirito do SecurityCodeScan (SAST gratuito) ja usado em ci-dev.yml.
-      #
-      # Comportamento padrao em evento pull_request: escaneia os commits introduzidos pelo PR
-      # (o diff contra a base), nao o historico inteiro do repo - e exatamente o "diff do PR"
-      # pedido. Bloqueia o job (e portanto o merge, se marcado como required check) se achar
-      # padrao de segredo: connection string com senha, API key, token, chave privada etc.
+      # gitleaks/gitleaks-action@v2 (a Action oficial "wrapper") passou a exigir
+      # GITLEAKS_LICENSE para repositorios de ORGANIZACAO - so e gratuita para conta
+      # pessoal/individual, independente do repo ser publico ou privado. Mesma classe de
+      # problema resolvida hoje com o CodeQL (trocado por SecurityCodeScan, gratuito):
+      # aqui trocamos a Action pelo BINARIO gitleaks direto via CLI, que nao tem essa
+      # exigencia - e so o scanner open-source, sem telemetria/licenca nenhuma.
+      - name: Instalar gitleaks (binario oficial, sem licenca)
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION="8.21.2"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          chmod +x /tmp/gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      # Comportamento equivalente ao da Action: escaneia apenas os commits introduzidos
+      # pelo PR (diff contra a base), nao o historico inteiro do repo. Bloqueia o job (e
+      # portanto o merge, se marcado como required check) se achar padrao de segredo:
+      # connection string com senha, API key, token, chave privada etc. Usa o mesmo
+      # .gitleaks.toml (PR #123).
       - name: Gitleaks - scan do diff do PR
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          gitleaks detect \
+            --source . \
+            --log-opts="--no-merges --first-parent origin/${{ github.event.pull_request.base.ref }}..HEAD" \
+            --config .gitleaks.toml \
+            --redact \
+            --verbose


### PR DESCRIPTION
## Causa raiz

O workflow `.github/workflows/gitleaks.yml` (adicionado hoje via PR #123/#124) usava a Action
oficial `gitleaks/gitleaks-action@v2`, que exige `GITLEAKS_LICENSE` paga para repositorios de
**organizacao** (gratis so para conta pessoal/individual, independente de publico/privado).
Isso bloqueava o job com erro de licenca ausente — nao um vazamento real — e bloquearia toda
PR futura da org, ja que a exigencia e sempre a mesma. Encontrado ao investigar falha na PR #129.

Mesma classe de problema ja resolvida hoje com o CodeQL (trocado por SecurityCodeScan, gratuito).

## Fix

Troca a Action wrapper pelo **binario oficial do gitleaks** baixado via CLI (release do GitHub,
sem exigencia de licenca nenhuma — e so o scanner open-source). O job:

1. Baixa e instala o binario `gitleaks` (v8.21.2) no runner `ubuntu-latest`.
2. Roda `gitleaks detect --source . --config .gitleaks.toml` contra o diff do PR
   (`origin/<base>..HEAD`, equivalente ao comportamento padrao da Action antiga).
3. Mantem o mesmo `.gitleaks.toml` (PR #123) e o mesmo comportamento: falha o job (bloqueia
   merge) se achar segredo, passa se nao achar.

## Teste

- Sem ambiente local para rodar o workflow do GitHub Actions; validacao ocorre no proprio
  check da PR (`gitleaks-scan`) apos a criacao. Se falhar, ajusto antes de pedir merge.

**Nao mergear sem confirmacao do dono.**