### PR TITLE
fix(ci): corrige fetch raso do gitleaks e allowlist de falso positivo

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -67,7 +67,16 @@ jobs:
       - name: Gitleaks - scan do diff do PR
         run: |
           set -euo pipefail
-          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          # BUG CORRIGIDO (2026-08-17, ver docs/architecture/triagem-gitleaks-segredos-historicos-2026-08-17.md):
+          # o checkout acima ja e fetch-depth: 0 (historico completo do PR), mas o
+          # `git fetch origin <base> --depth=1` que existia aqui criava um segundo fetch RASO
+          # do branch base, sem historico comum com o HEAD do checkout. Isso quebrava a
+          # resolucao do range `origin/<base>..HEAD` (merge-base nao encontrado), e o
+          # `gitleaks detect` caia no fallback de escanear o historico inteiro (110 commits)
+          # em vez de so o diff da PR - foi isso que bloqueou o merge de hoje com achados
+          # historicos ja tratados. Fix: sem --depth, o fetch aproveita o historico completo
+          # que o checkout ja trouxe e so atualiza a ref local origin/<base>.
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
           gitleaks detect \
             --source . \
             --log-opts="--no-merges --first-parent origin/${{ github.event.pull_request.base.ref }}..HEAD" \

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -22,8 +22,20 @@ tags = ["secret", "config"]
 
 # appsettings*.json legítimos deste repo usam placeholders vazios ("") —
 # a regra acima só dispara com valor não vazio, então não conflita com eles.
+#
+# Falsos positivos confirmados na triagem de 2026-08-17
+# (docs/architecture/triagem-gitleaks-segredos-historicos-2026-08-17.md):
+# 1) o marcador ***SENHA_REMOVIDA*** usado pelo git filter-repo de 2026-08-15 para
+#    substituir o segredo real no histórico — é o próprio remédio, não o segredo.
+# 2) "localhost:6379" — connection string do Redis local, sem senha nenhuma.
+# Regexes restritas a esses 2 padrões específicos — não enfraquece
+# generic-password-assignment de forma ampla.
 [allowlist]
 paths = [
     '''\.githooks/pre-commit''',
     '''\.gitleaks\.toml''',
+]
+regexes = [
+    '''\*\*\*SENHA_REMOVIDA\*\*\*''',
+    '''localhost:6379''',
 ]


### PR DESCRIPTION
## Resumo
- `gitleaks.yml`: o `git fetch origin "<base>" --depth=1` degenerava a resolução do range `origin/<base>..HEAD`, fazendo o gitleaks escanear o histórico inteiro (110 commits) em vez do diff da PR. Trocado para fetch sem `--depth`, reaproveitando o histórico completo já trazido pelo checkout.
- `.gitleaks.toml`: allowlist restrita para 2 falsos positivos confirmados (`***SENHA_REMOVIDA***`, marcador do filter-repo de 2026-08-15; `localhost:6379`, Redis sem senha).

Origem: docs/architecture/triagem-gitleaks-segredos-historicos-2026-08-17.md

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>