### PR TITLE
chore(ci): Dependency Review + permissoes minimas + Action pinada

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -12,6 +12,13 @@ on:
       - 'feat/**'
   workflow_dispatch:
 
+# Minimo necessario: so faz checkout deste repo e de LayoutParserLib/LayoutParserDecrypt
+# (via GH_PAT_TOKEN, fora do escopo do GITHUB_TOKEN) - nenhum step comenta PR, cria release
+# ou escreve outro recurso do GitHub. GITHUB_TOKEN nao e usado no self-hosted runner alem
+# do proprio checkout.
+permissions:
+  contents: read
+
 # Um push novo na mesma branch cancela o run anterior ainda em andamento
 # (o runner de dev e unico - evita fila desnecessaria).
 concurrency:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency review
+
+# Bloqueia PR que introduz dependencia (NuGet/npm/etc.) com vulnerabilidade conhecida de
+# severidade alta ou critica. Cobre master E develop porque e o nosso fluxo real de PR
+# (feat/** -> develop -> master), nao so a branch de release.
+on:
+  pull_request:
+    branches: [ "master", "develop" ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          comment-summary-in-pr: always
+          fail-on-severity: high

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,12 @@ on:
       - '.github/workflows/ci-dev.yml'
   workflow_dispatch: # Permite executar manualmente
 
+# Minimo necessario: checkout deste repo + LayoutParserLib/LayoutParserDecrypt (via
+# GH_PAT_TOKEN, fora do escopo do GITHUB_TOKEN) - nenhum step comenta PR, cria release ou
+# escreve outro recurso do GitHub. GITHUB_TOKEN so participa do proprio checkout.
+permissions:
+  contents: read
+
 # Serializa deploys de producao. cancel-in-progress: false de PROPOSITO - cancelar um deploy
 # no meio (durante a troca de binario / Stop-Service -> copia -> Start-Service) deixaria a
 # instalacao pela metade. Runs concorrentes ENFILEIRAM; nenhum e abortado no meio do caminho.
@@ -77,7 +83,9 @@ jobs:
         dotnet-version: '10.0.x'
     
     - name: Setup MSBuild for .NET Framework
-      uses: microsoft/setup-msbuild@v1.3
+      # Pinado por SHA (tag mutavel proibida p/ Action de terceiro nao-imutavel - CodeQL
+      # actions/unpinned-tag). SHA corresponde a tag v1.3.
+      uses: microsoft/setup-msbuild@ede762b26a2de8d110bb5a3db4d7e0e080c0e917
     
     - name: Build LayoutParserLib (.NET Framework 4.8.1)
       run: |


### PR DESCRIPTION
## Summary
- Novo `.github/workflows/dependency-review.yml`: roda em PR contra `master`/`develop`, `fail-on-severity: high` (bloqueia, nao so comenta).
- `permissions: contents: read` explicito em `ci-dev.yml` e `deploy.yml` (CodeQL `actions/missing-workflow-permissions` #1 e #2) - nenhum step usa `GITHUB_TOKEN` alem do proprio checkout.
- `microsoft/setup-msbuild` pinado por SHA em `deploy.yml` (era `@v1.3`, tag mutavel - CodeQL `actions/unpinned-tag` #3), comentado com a tag que representa.

## Status dos alertas do CodeQL

| # | Regra | Situacao |
|---|-------|----------|
| #1 | `actions/missing-workflow-permissions` (ci-dev.yml:24) | Corrigido nesta PR |
| #2 | `actions/missing-workflow-permissions` (deploy.yml:45) | Corrigido nesta PR |
| #3 | `actions/unpinned-tag` (deploy.yml:80) | Corrigido nesta PR (pin por SHA) |
| #6 | `cs/command-line-injection` (DecryptionService.cs:149) | Ja corrigido no codigo (`ArgumentList`, PR #154) - alerta segue `open` porque o CodeQL nao rodou de novo apos o merge; nao dismissado manualmente, aguarda proximo scan |
| #7 | `cs/command-line-injection` (LowCodeTransformationService.cs:110) | Idem #6 |

## Test plan
- [x] `dotnet build LayoutParserApi.csproj --configuration Release` verde (0 erros)
- [x] Gate de encoding ASCII (mesmo do ci-dev.yml) validado manualmente nos 3 workflows tocados - sem byte > 127
- [ ] CI (`ci-dev.yml`) e o novo `dependency-review.yml` verdes nesta PR