### PR TITLE
fix(ci): PRs para develop passam a rodar dotnet build/test

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,236 @@
+name: PR Validate (LayoutParserApi)
+
+# Gate de build/teste para PRs contra develop, de QUALQUER branch de origem.
+#
+# Por que este workflow existe separado do ci-dev.yml: ci-dev.yml, alem de compilar/testar,
+# TAMBEM FAZ DEPLOY (para/inicia o servico Windows nativo, sobrescreve os binarios em
+# DEPLOY_PATH_DEV, escreve o Environment do servico no registro). Rodar isso em todo
+# pull_request seria perigoso e sem sentido - uma PR ainda nao mergeada nao deve parar/reiniciar
+# o servico de dev nem escrever no destino do deploy. Este workflow cobre so o gate funcional
+# (build + testes), sem tocar em servico/deploy - resolve a issue #122 sem herdar o risco de
+# rodar deploy em pull_request.
+#
+# Roda no MESMO runner de dev (label 'dev-local') porque e a unica maquina com o .NET Framework
+# 4.8.1 necessario para compilar a LayoutParserLib/Decrypt - nao ha runner hospedado equivalente.
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+concurrency:
+  group: pr-validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: [self-hosted, windows, dev-local]
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout LayoutParserApi
+      uses: actions/checkout@v7
+      with:
+        path: LayoutParserApi
+
+    # Mesmo gate de encoding do ci-dev.yml - protege contra o defeito documentado la
+    # (acento/travessao em comentario de workflow quebra o parser do PowerShell 5.1 sem BOM).
+    - name: Validar encoding dos workflows (ASCII puro)
+      run: |
+        $ErrorActionPreference = "Stop"
+        $raiz = Join-Path $PWD.Path "LayoutParserApi\.github\workflows"
+        $problemas = 0
+
+        foreach ($wf in (Get-ChildItem $raiz -Filter *.yml -ErrorAction SilentlyContinue)) {
+          $linhas = Get-Content $wf.FullName
+          for ($i = 0; $i -lt $linhas.Count; $i++) {
+            $ruins = $linhas[$i].ToCharArray() | Where-Object { [int]$_ -gt 127 }
+            if ($ruins) {
+              $codigos = ($ruins | ForEach-Object { "U+{0:X4}" -f [int]$_ }) -join ' '
+              Write-Host "  $($wf.Name):$($i + 1)  $codigos"
+              Write-Host "      $($linhas[$i].Trim())"
+              $problemas++
+            }
+          }
+        }
+
+        if ($problemas -gt 0) {
+          Write-Error ("$problemas linha(s) com caractere nao-ASCII em workflow. " +
+            "O PowerShell do runner le o bloco run: como ANSI e isso QUEBRA o deploy de producao. " +
+            "Troque por equivalente ASCII (- em vez de travessao, [ATENCAO] em vez de emoji, sem acentos).")
+          exit 1
+        }
+
+        Write-Host "Workflows em ASCII puro - seguro para o PowerShell do runner."
+
+    - name: Checkout LayoutParserLib
+      uses: actions/checkout@v7
+      with:
+        repository: LayoutParser/LayoutParserLib
+        path: LayoutParserLib
+        token: ${{ secrets.GH_PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
+
+    - name: Checkout LayoutParserDecrypt
+      uses: actions/checkout@v7
+      with:
+        repository: LayoutParser/LayoutParserDecrypt
+        path: LayoutParserDecrypt
+        token: ${{ secrets.GH_PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Build LayoutParserLib (Debug, .NET Framework 4.8.1)
+      run: |
+        $LIB_PROJECT = Join-Path $PWD.Path "LayoutParserLib\LayoutParserLib.csproj"
+
+        if (-not (Test-Path $LIB_PROJECT)) {
+          Write-Error "Projeto nao encontrado: $LIB_PROJECT"
+          exit 1
+        }
+
+        dotnet build "$LIB_PROJECT" --configuration Debug
+
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Falha ao compilar LayoutParserLib"
+          exit 1
+        }
+
+        $LIB_DLL = Join-Path $PWD.Path "LayoutParserLib\bin\Debug\LayoutParserLib.dll"
+        if (-not (Test-Path $LIB_DLL)) {
+          Write-Error "LayoutParserLib.dll nao foi gerada em: $LIB_DLL"
+          exit 1
+        }
+
+        Write-Host "LayoutParserLib compilada (Debug): $LIB_DLL"
+
+    - name: Build LayoutParserApi (Release)
+      run: |
+        $API_PROJECT = Join-Path $PWD.Path "LayoutParserApi\LayoutParserApi.csproj"
+
+        if (-not (Test-Path $API_PROJECT)) {
+          Write-Error "Projeto nao encontrado: $API_PROJECT"
+          exit 1
+        }
+
+        dotnet restore "$API_PROJECT"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Falha no restore do LayoutParserApi"
+          exit 1
+        }
+
+        $BUILD_LOG = Join-Path $PWD.Path "scs-build.log"
+        dotnet build "$API_PROJECT" --configuration Release --no-restore | Tee-Object -FilePath $BUILD_LOG
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Falha ao compilar LayoutParserApi"
+          exit 1
+        }
+
+        Write-Host "LayoutParserApi compilada com sucesso (Release)"
+
+    # Mesmo gate de SAST do ci-dev.yml (SecurityCodeScan, veredito por severidade com baseline).
+    - name: Security Code Scan - gate por severidade
+      run: |
+        $BUILD_LOG = Join-Path $PWD.Path "scs-build.log"
+
+        if (-not (Test-Path $BUILD_LOG)) {
+          Write-Warning "Log de build nao encontrado em $BUILD_LOG - pulando gate de SCS."
+          exit 0
+        }
+
+        $CODIGOS_ALTOS = @(
+          "SCS0002",
+          "SCS0003",
+          "SCS0007",
+          "SCS0016",
+          "SCS0018",
+          "SCS0026",
+          "SCS0028",
+          "SCS0029",
+          "SCS0031"
+        )
+
+        $BASELINE_FILE = Join-Path $PWD.Path "LayoutParserApi\security-code-scan-baseline.json"
+        $baselineKeys = New-Object System.Collections.Generic.HashSet[string]
+        if (Test-Path $BASELINE_FILE) {
+          $baselineJson = Get-Content $BASELINE_FILE -Raw | ConvertFrom-Json
+          foreach ($item in $baselineJson.findings) {
+            [void]$baselineKeys.Add("$($item.code):$($item.file):$($item.line)")
+          }
+          Write-Host "Baseline carregado: $($baselineKeys.Count) achado(s) conhecido(s) em $BASELINE_FILE"
+        } else {
+          Write-Warning "security-code-scan-baseline.json nao encontrado - todo achado alto sera tratado como novo."
+        }
+
+        $linhas = Get-Content $BUILD_LOG | Where-Object { $_ -match "warning SCS\d+" }
+        $totalPorCodigo = @{}
+        $achadosConhecidos = New-Object System.Collections.Generic.HashSet[string]
+        $achadosNovos = New-Object System.Collections.Generic.HashSet[string]
+
+        foreach ($linha in $linhas) {
+          if ($linha -match "warning (SCS\d+)") {
+            $codigo = $Matches[1]
+            if (-not $totalPorCodigo.ContainsKey($codigo)) { $totalPorCodigo[$codigo] = 0 }
+            $totalPorCodigo[$codigo]++
+
+            if ($CODIGOS_ALTOS -contains $codigo -and $linha -match '(?<file>[A-Za-z]:[^():]+\.cs)\((?<line>\d+),(?<col>\d+)\):') {
+              $relFile = $Matches.file -replace '\\', '/'
+              foreach ($marker in @('/Controllers/', '/Services/')) {
+                $idx = $relFile.IndexOf($marker)
+                if ($idx -ge 0) {
+                  $relFile = $relFile.Substring($idx + 1)
+                  break
+                }
+              }
+              $chave = "$($codigo):$($relFile):$($Matches.line)"
+              if ($baselineKeys.Contains($chave)) {
+                [void]$achadosConhecidos.Add($chave)
+              } else {
+                [void]$achadosNovos.Add($chave)
+              }
+            }
+          }
+        }
+
+        Write-Host "Achados do SecurityCodeScan por codigo:"
+        foreach ($codigo in $totalPorCodigo.Keys) {
+          Write-Host "  $codigo : $($totalPorCodigo[$codigo])"
+        }
+
+        if ($achadosConhecidos.Count -gt 0) {
+          Write-Host ""
+          Write-Host "Achados de severidade ALTA ja no baseline (nao bloqueiam - debito tecnico conhecido):"
+          $achadosConhecidos | Sort-Object | ForEach-Object { Write-Host "  $_" }
+        }
+
+        if ($achadosNovos.Count -gt 0) {
+          Write-Host ""
+          Write-Host "Achados de severidade ALTA NOVOS (bloqueiam o merge):"
+          $achadosNovos | Sort-Object | ForEach-Object { Write-Host "  $_" }
+          Write-Error "SecurityCodeScan encontrou $($achadosNovos.Count) achado(s) NOVO(S) de severidade alta/critica (fora do baseline). Corrija, ou se for falso-positivo/debito aceito conscientemente, adicione ao security-code-scan-baseline.json."
+          exit 1
+        }
+
+        Write-Host "Nenhum achado de severidade alta/critica NOVO - gate de SCS OK (baseline conhecido e warnings de menor severidade nao bloqueiam)."
+
+    # Quality gate de verdade da PR: teste vermelho BLOQUEIA o merge.
+    - name: Testes (xUnit)
+      run: |
+        $TEST_PROJECT = Join-Path $PWD.Path "LayoutParserApi\tests\LayoutParserApi.Tests\LayoutParserApi.Tests.csproj"
+
+        if (-not (Test-Path $TEST_PROJECT)) {
+          Write-Error "Projeto de testes nao encontrado: $TEST_PROJECT"
+          exit 1
+        }
+
+        dotnet test "$TEST_PROJECT" --configuration Release --logger "console;verbosity=minimal"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Testes falharam - PR bloqueada."
+          exit 1
+        }
+
+        Write-Host "Suite de testes verde."


### PR DESCRIPTION
## Problema
`ci-dev.yml` so dispara em `push`, nunca em `pull_request` - nenhuma PR para `develop`
rodava `dotnet build`/`dotnet test` antes do merge, so `gitleaks`. Ver issue #122.

## Solucao
Novo workflow dedicado `pr-validate.yml`, disparado em `pull_request` para `develop`.
Reaproveita os mesmos steps de build/SCS/teste do `ci-dev.yml`, mas **sem nenhum step de
deploy** (parar/iniciar servico, escrever DEPLOY_PATH_DEV) - reaproveitar o ci-dev.yml direto
via `on: [push, pull_request]` teria feito uma PR nao mergeada mexer no servico de dev, que
nao e seguro.

## Teste
Esta propria PR e a prova: `pr-validate.yml` deve aparecer rodando nos checks dela.

Resolve #122.