### PR TITLE
fix(ai): aplica limite de tamanho na AiCandidateStore (issue #51, parte 2)

### DIFF
--- a/Services/Transformation/Ai/AiCandidateStore.cs
+++ b/Services/Transformation/Ai/AiCandidateStore.cs
@@ -31,8 +31,14 @@ namespace LayoutParserApi.Services.Transformation.Ai
         private readonly ILogger<AiCandidateStore> _logger;
         private readonly string _storePath;
         private readonly TimeSpan _ttl;
+        private readonly int _maxStoredTickets;
         private readonly Func<DateTimeOffset> _clock;
         private readonly ConcurrentDictionary<string, StoredEntry> _memory = new();
+
+        // Serializa a poda por limite de tamanho: Set() concorrente de tickets diferentes não
+        // precisa disputar I/O de enumeração/deleção ao mesmo tempo — best-effort, não é um lock
+        // de correção (perder uma corrida aqui só adia a poda para o próximo Set()).
+        private readonly object _sizeLimitGate = new();
 
         // Separador de controle (US, ) para compor a chave de memória userId+ticket sem
         // ambiguidade — não é digitável e não deve vir de um header HTTP/nome de usuário normal.
@@ -68,6 +74,8 @@ namespace LayoutParserApi.Services.Transformation.Ai
             _clock = clock ?? (() => DateTimeOffset.UtcNow);
             var ttlHoras = options.Value.TicketTtlHours;
             _ttl = TimeSpan.FromHours(ttlHoras > 0 ? ttlHoras : AiTransformationCandidateOptions.DefaultTicketTtlHours);
+            var maxTickets = options.Value.MaxStoredTickets;
+            _maxStoredTickets = maxTickets > 0 ? maxTickets : AiTransformationCandidateOptions.DefaultMaxStoredTickets;
             _storePath = options.Value.StorePath
                 ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "AiTransformationCandidates");
 
@@ -134,6 +142,73 @@ namespace LayoutParserApi.Services.Transformation.Ai
             }
 
             _memory[memoryKey] = new StoredEntry(status, agoraUtc);
+
+            EnforceSizeLimit();
+        }
+
+        /// <summary>
+        /// Poda os tickets mais antigos quando a store estoura <see cref="_maxStoredTickets"/>
+        /// (issue #51 — limite de tamanho, complementar ao TTL). Best-effort: qualquer falha de
+        /// I/O aqui é uma limpeza perdida, não um erro de escrita — o ticket que acabou de ser
+        /// gravado pelo <c>Set</c> já está persistido antes deste ponto.
+        /// </summary>
+        private void EnforceSizeLimit()
+        {
+            if (!Monitor.TryEnter(_sizeLimitGate))
+                return; // Outra thread já está podando; não vale a pena esperar no caminho de escrita.
+
+            try
+            {
+                if (!Directory.Exists(_storePath))
+                    return;
+
+                // Arquivo é a fonte de verdade da idade (mesmo critério do RemoveExpired): mais
+                // barato que manter um segundo índice em memória só para isso.
+                var arquivos = Directory.EnumerateFiles(_storePath, "*.json", SearchOption.AllDirectories)
+                    .Select(caminho =>
+                    {
+                        try { return (Caminho: caminho, EscritoEmUtc: File.GetLastWriteTimeUtc(caminho)); }
+                        catch { return (Caminho: caminho, EscritoEmUtc: DateTime.MaxValue); }
+                    })
+                    .OrderBy(item => item.EscritoEmUtc)
+                    .ToList();
+
+                var excedente = arquivos.Count - _maxStoredTickets;
+                if (excedente <= 0)
+                    return;
+
+                foreach (var (caminho, _) in arquivos.Take(excedente))
+                {
+                    try
+                    {
+                        // userId/ticket vêm da própria estrutura de pasta (ResolvePath): subpasta =
+                        // usuário, nome do arquivo sem extensão = ticket — reconstrói a chave de
+                        // memória sem precisar guardar um índice à parte.
+                        var ticket = Path.GetFileNameWithoutExtension(caminho);
+                        var userId = Path.GetFileName(Path.GetDirectoryName(caminho)) ?? AnonymousBucket;
+
+                        File.Delete(caminho);
+                        _memory.TryRemove(BuildMemoryKey(userId, ticket), out _);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Falha ao podar ticket excedente do pathway IA (limite={Limite}): {Arquivo}",
+                            _maxStoredTickets, caminho);
+                    }
+                }
+
+                _logger.LogInformation(
+                    "Limite de tamanho da store do pathway IA excedido — {Removidos} ticket(s) mais antigo(s) removido(s) (limite={Limite})",
+                    excedente, _maxStoredTickets);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha ao aplicar o limite de tamanho da store do pathway IA");
+            }
+            finally
+            {
+                Monitor.Exit(_sizeLimitGate);
+            }
         }
 
         public AiCandidateStatus? Get(string userId, string ticket)

--- a/Services/Transformation/Ai/AiTransformationCandidateOptions.cs
+++ b/Services/Transformation/Ai/AiTransformationCandidateOptions.cs
@@ -48,6 +48,21 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// </summary>
         public int CleanupIntervalMinutes { get; set; } = DefaultCleanupIntervalMinutes;
 
+        /// <summary>Teto default de tickets retidos na store (issue #51 — parte "limite de tamanho").</summary>
+        public const int DefaultMaxStoredTickets = 500;
+
+        /// <summary>
+        /// Limite global (todos os usuários somados) de tickets simultâneos na store — segunda
+        /// metade da issue #51: TTL sozinho não protege contra um pico de volume que ainda não
+        /// venceu (ex.: um usuário disparando <c>execute-candidates</c> em loop). Ao estourar, o
+        /// <see cref="AiCandidateStore"/> descarta os tickets mais antigos (por
+        /// <c>LastWriteTimeUtc</c> em disco) até voltar ao limite — mesmo espírito best-effort do
+        /// <c>RemoveExpired</c>, só que disparado no caminho de escrita (<c>Set</c>) em vez de
+        /// esperar o próximo ciclo do <c>AiCandidateStoreCleanupBackgroundService</c>. Valor
+        /// &lt;= 0 cai no default (<see cref="DefaultMaxStoredTickets"/>).
+        /// </summary>
+        public int MaxStoredTickets { get; set; } = DefaultMaxStoredTickets;
+
         /// <summary>
         /// Fallback automático de IA (Estado A — "não encontrado/não modelado", ver
         /// docs/architecture/design-fallback-ia-automatico-2026-08-16.md §5): cooldown do

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiCandidateStoreTtlTests.cs
@@ -153,10 +153,68 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
             }
         }
 
-        private static AiCandidateStore CriarStore(string storePath, Func<DateTimeOffset> relogio, int ttlHoras)
+        [Fact]
+        public void Set_poda_tickets_mais_antigos_quando_excede_o_limite_de_tamanho()
+        {
+            // Issue #51 (segunda metade): TTL sozinho não protege um pico de tickets ainda dentro
+            // da janela — MaxStoredTickets é o teto duro, aplicado no caminho de escrita.
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var agora = new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+                var store = CriarStore(dir, () => agora, ttlHoras: 24, maxStoredTickets: 3);
+
+                for (var i = 0; i < 5; i++)
+                {
+                    store.Set("usuario-a", $"ticket-{i}", new AiCandidateStatus { Status = AiCandidateStatus.StatusRunning });
+                    agora = agora.AddMinutes(1); // Cada Set em instante distinto — desempata a poda por idade.
+                }
+
+                var arquivosRestantes = Directory.EnumerateFiles(dir, "*.json", SearchOption.AllDirectories).ToList();
+                Assert.Equal(3, arquivosRestantes.Count);
+
+                // Os dois mais antigos (ticket-0, ticket-1) foram podados; os três mais recentes sobrevivem.
+                Assert.Null(store.Get("usuario-a", "ticket-0"));
+                Assert.Null(store.Get("usuario-a", "ticket-1"));
+                Assert.NotNull(store.Get("usuario-a", "ticket-2"));
+                Assert.NotNull(store.Get("usuario-a", "ticket-3"));
+                Assert.NotNull(store.Get("usuario-a", "ticket-4"));
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void MaxStoredTickets_nao_configurado_ou_invalido_cai_no_default()
+        {
+            var dir = CriarDiretorioTemporario();
+            try
+            {
+                var padrao = CriarStore(dir, () => DateTimeOffset.UtcNow, ttlHoras: 24, maxStoredTickets: AiTransformationCandidateOptions.DefaultMaxStoredTickets);
+                var invalido = CriarStore(dir, () => DateTimeOffset.UtcNow, ttlHoras: 24, maxStoredTickets: 0);
+
+                // Nenhum ticket escrito ainda — só confere que o construtor não lança com o default
+                // nem com valor inválido (mesma convenção de TicketTtlHours).
+                Assert.NotNull(padrao);
+                Assert.NotNull(invalido);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        private static AiCandidateStore CriarStore(string storePath, Func<DateTimeOffset> relogio, int ttlHoras, int maxStoredTickets = 0)
             => new(
                 NullLogger<AiCandidateStore>.Instance,
-                Options.Create(new AiTransformationCandidateOptions { StorePath = storePath, TicketTtlHours = ttlHoras }),
+                Options.Create(new AiTransformationCandidateOptions
+                {
+                    StorePath = storePath,
+                    TicketTtlHours = ttlHoras,
+                    MaxStoredTickets = maxStoredTickets
+                }),
                 relogio);
 
         private static string CriarDiretorioTemporario()


### PR DESCRIPTION
## Resumo

Ao investigar a issue #51 (limite de tamanho do AiCandidateStore), foi confirmado que:
- TTL (issue #51, parte 1) e particionamento por usuario (issue #92) ja estavam implementados e ativos (PR #89 e #105).
- O gap real era o limite de tamanho: `MaxStoredTickets` em `AiTransformationCandidateOptions` (default 500) e a poda dos tickets mais antigos no caminho de escrita (`AiCandidateStore.Set` -> `EnforceSizeLimit`), best-effort e sem travar o request.

## Mudancas

- `Services/Transformation/Ai/AiCandidateStore.cs` — poda de tickets mais antigos ao exceder `MaxStoredTickets`.
- `Services/Transformation/Ai/AiTransformationCandidateOptions.cs` — nova opcao `MaxStoredTickets`.
- `Services/Transformation/Ai/AiCandidateStoreTtlTests.cs` — cobertura nova.

## Validacao

- Validado PASS por @lp-qa (Quinn), com mutation test confirmado.
- `dotnet build`: 374/374.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
