### PR TITLE
feat(ci): notifica falha de deploy de producao por e-mail

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -217,6 +217,59 @@ Os segredos antigos **persistem nos commits anteriores** mesmo após este commit
 > sendo a ação que efetivamente invalida o segredo — a limpeza de histórico é complementar,
 > não substitui a revogação.
 
+## Alerta de deploy por e-mail (2026-08-18)
+
+Item 1 do raio-X de maturidade (`docs/architecture/specs-execucao-maturidade-2026-08-16.md`).
+Canal decidido pelo dono: **e-mail** (Teams/Slack ficaram de fora — pago). Implementado em
+`.github/workflows/deploy.yml`, usando a Action gratuita `dawidd6/action-send-mail@v3`, disparada
+em 2 pontos do job de deploy:
+
+1. Logo após o step **Smoke test de readiness (pos-deploy)** — dispara quando esse step falha
+   (`steps.smoke_test.outcome == 'failure'`), cobrindo os casos "ROLLBACK OK" e "ROLLBACK FALHOU".
+   O corpo do e-mail reaproveita o mesmo resumo que já vai pro `$GITHUB_STEP_SUMMARY`.
+2. No fim do job — fallback genérico para "DEPLOY ABORTADO" (falha antes do smoke test rodar,
+   ex.: build/publish quebrou). Só dispara se o smoke test **não** foi quem falhou, pra não
+   duplicar o e-mail do caso 1.
+
+**Provedor SMTP ainda não escolhido pelo dono.** Os dois steps checam `secrets.SMTP_SERVER != ''`
+na condição `if:` — enquanto os secrets abaixo não existirem, os steps são **pulados**
+silenciosamente (não fazem o workflow falhar). Nenhuma ação é necessária até o dono decidir o
+provedor.
+
+### Secrets a criar quando o provedor for escolhido
+
+Em GitHub → repo `LayoutParserApi` → **Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret | Descrição |
+|--------|-----------|
+| `SMTP_SERVER` | Host do servidor SMTP (ex.: `smtp.gmail.com`) |
+| `SMTP_PORT` | Porta (ex.: `587` para TLS) |
+| `SMTP_USERNAME` | Usuário/e-mail de envio |
+| `SMTP_PASSWORD` | Senha/senha de app (nunca a senha normal da conta, se o provedor suportar senha de app) |
+| `ALERT_EMAIL_TO` | Endereço de destino dos alertas (só o dono, um endereço) |
+
+### Passo a passo — Gmail + senha de app (opção mais acessível)
+
+1. Acessar [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords) com a
+   conta Google que vai enviar os alertas (exige verificação em 2 etapas ativada na conta).
+2. Gerar uma **senha de app** nova (ex.: nome "LayoutParserApi Deploy Alert") — copiar o valor de
+   16 caracteres exibido (só aparece uma vez).
+3. Criar os secrets no GitHub com:
+   - `SMTP_SERVER` = `smtp.gmail.com`
+   - `SMTP_PORT` = `587`
+   - `SMTP_USERNAME` = o e-mail Gmail usado para gerar a senha de app
+   - `SMTP_PASSWORD` = a senha de app gerada no passo 2 (não a senha normal da conta)
+   - `ALERT_EMAIL_TO` = e-mail do dono que deve receber os alertas
+4. Não é preciso redisparar nada manualmente — os steps já existentes no `deploy.yml` passam a
+   disparar automaticamente no próximo deploy que falhar o smoke test (ou abortar antes dele).
+5. Não há como validar o envio real sem um deploy que falhe de propósito — se quiser confirmar o
+   mecanismo, `workflow_dispatch` não cobre isso hoje (o gatilho é sempre push a `master`); o
+   caminho mais seguro é revisar a sintaxe do step e confiar no smoke test real do próximo deploy.
+
+Se o provedor escolhido não for Gmail (Outlook/Office 365, SendGrid etc.), os nomes dos 5 secrets
+continuam os mesmos — só os valores de `SMTP_SERVER`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`
+mudam conforme a documentação do provedor.
+
 ## CodeQL desativado — Dependabot mantido (2026-08-15)
 
 **Causa raiz do erro de CI** (`Advanced Security must be enabled...`): CodeQL *code scanning* em

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1089,6 +1089,7 @@ jobs:
     # O ApiKeyGateFilter foi REMOVIDO do codigo (2026-08-12, `feat/identidade-do-bff`) - a
     # defesa BFF->API passou a ser rede (bind em loopback), nao chave compartilhada.
     - name: Smoke test de readiness (pos-deploy)
+      id: smoke_test
       env:
         API_URL_PROD: ${{ vars.API_URL_PROD }}
       run: |
@@ -1232,9 +1233,57 @@ jobs:
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $resumoLinhas
           }
 
+          # -- Outputs para o step de notificacao por e-mail (abaixo) ---------------------
+          #
+          # Precisam ser escritos ANTES do exit 1: Add-Content em $env:GITHUB_OUTPUT persiste
+          # mesmo que o step termine com falha logo em seguida - e o unico jeito de repassar
+          # o resumo (multilinha) para um step subsequente sem reconstrui-lo do zero.
+          if ($env:GITHUB_OUTPUT) {
+            $assunto = if ($rollbackOk) { "ROLLBACK OK" } else { "ROLLBACK FALHOU" }
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "alert_status=$assunto"
+            $delimiter = "EOF_ALERT_BODY_$([guid]::NewGuid().ToString('N'))"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "alert_body<<$delimiter"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ($resumoLinhas -join "`n")
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ""
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "Run: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "Commit: $env:GITHUB_SHA (ref $env:GITHUB_REF)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value $delimiter
+          }
+
           exit 1
         }
         Write-Host "Deploy de producao validado: API servindo (readiness 200)."
+
+    # -- Alerta ativo por e-mail: smoke test falhou (rollback OK/FALHOU) -------------
+    #
+    # Item 1 do raio-X de maturidade (docs/architecture/specs-execucao-maturidade-2026-08-16.md).
+    # Canal escolhido pelo dono: e-mail (Teams/Slack ficaram de fora - pago). Provedor SMTP
+    # ainda NAO foi escolhido pelo dono - este step referencia os secrets esperados e PULA
+    # graciosamente (nao falha o workflow) enquanto eles nao existirem. Ver
+    # `.claude/rules/security.md` -> secao "Alerta de deploy por e-mail" para o passo a passo
+    # de como o dono cria os secrets quando decidir o provedor (ex.: Gmail + senha de app).
+    #
+    # Dispara so quando o step "Smoke test de readiness" FALHOU (steps.smoke_test.outcome ==
+    # 'failure') - cobre os 2 primeiros casos do raio-X: rollback executado com sucesso OU
+    # rollback tambem falhou/nao foi possivel (o texto exato vem em steps.smoke_test.outputs.alert_body).
+    - name: Notificar falha de deploy por e-mail (smoke test / rollback)
+      if: >-
+        always() && steps.smoke_test.outcome == 'failure' &&
+        steps.smoke_test.outputs.alert_body != '' && secrets.SMTP_SERVER != ''
+      continue-on-error: true
+      uses: dawidd6/action-send-mail@v3
+      with:
+        # Secrets ainda NAO preenchidos pelo dono (provedor SMTP em aberto). Enquanto
+        # secrets.SMTP_SERVER estiver vazio, a Action falha rapido - por isso o step inteiro
+        # tem continue-on-error: true acima: nao pode derrubar o workflow so por falta de config.
+        server_address: ${{ secrets.SMTP_SERVER }}
+        server_port: ${{ secrets.SMTP_PORT }}
+        username: ${{ secrets.SMTP_USERNAME }}
+        password: ${{ secrets.SMTP_PASSWORD }}
+        subject: "[LayoutParserApi] Deploy de producao FALHOU - ${{ steps.smoke_test.outputs.alert_status }}"
+        to: ${{ secrets.ALERT_EMAIL_TO }}
+        from: "LayoutParserApi Deploy <${{ secrets.SMTP_USERNAME }}>"
+        body: ${{ steps.smoke_test.outputs.alert_body }}
 
     # -- Diagnostico de pre-requisitos (NAO-FATAL) -----------------------------------
     #
@@ -1331,3 +1380,37 @@ jobs:
           Write-Warning "Diagnostico falhou (nao bloqueia o deploy): $($_.Exception.Message)"
         }
         exit 0
+
+    # -- Alerta ativo por e-mail: fallback generico (DEPLOY ABORTADO) -----------------
+    #
+    # Cobre o 3o caso do raio-X (menor prioridade): o job falhou ANTES do smoke test rodar
+    # (build/publish/backup quebrou, por exemplo) - nesse caso steps.smoke_test nem chegou a
+    # existir ou terminou com outcome 'skipped'/'cancelled', entao o step de e-mail acima
+    # (que exige outcome == 'failure') nao dispara. Este step e o catch-all: `if: failure()`
+    # cobre qualquer falha do job inteiro; a condicao `steps.smoke_test.outcome != 'failure'`
+    # evita e-mail DUPLICADO quando quem falhou foi o smoke test (esse caso ja foi notificado
+    # acima, com o resumo detalhado do rollback).
+    #
+    # Mesmos secrets do step anterior (ver `.claude/rules/security.md`). Enquanto
+    # secrets.SMTP_SERVER estiver vazio, este step tambem pula sem quebrar o workflow.
+    - name: Notificar falha de deploy por e-mail (fallback - deploy abortado antes do smoke test)
+      if: >-
+        failure() && steps.smoke_test.outcome != 'failure' && secrets.SMTP_SERVER != ''
+      continue-on-error: true
+      uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: ${{ secrets.SMTP_SERVER }}
+        server_port: ${{ secrets.SMTP_PORT }}
+        username: ${{ secrets.SMTP_USERNAME }}
+        password: ${{ secrets.SMTP_PASSWORD }}
+        subject: "[LayoutParserApi] Deploy de producao ABORTADO antes do smoke test"
+        to: ${{ secrets.ALERT_EMAIL_TO }}
+        from: "LayoutParserApi Deploy <${{ secrets.SMTP_USERNAME }}>"
+        body: |
+          O job de deploy de producao falhou ANTES do smoke test de readiness rodar
+          (provavel falha de build/publish/backup - ver o run para o step exato que falhou).
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Commit: ${{ github.sha }} (ref ${{ github.ref }})
+
+          Investigue a causa raiz antes de tentar um novo deploy.

--- a/docs/architecture/specs-execucao-maturidade-2026-08-16.md
+++ b/docs/architecture/specs-execucao-maturidade-2026-08-16.md
@@ -5,10 +5,16 @@ reconstruir contexto. Owner e passos concretos em cada uma.
 
 ---
 
-## 1. Alerta ativo de deploy quebrado
+## 1. Alerta ativo de deploy quebrado — IMPLEMENTADO (2026-08-18) ✅
 
 **Owner:** `@lp-devops`
 **Arquivo:** `.github/workflows/deploy.yml`
+
+Canal decidido pelo dono: **e-mail** (Opção B abaixo). Implementado via
+`dawidd6/action-send-mail@v3` em dois steps (smoke test/rollback + fallback "deploy abortado").
+Secrets (`SMTP_SERVER`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`/`ALERT_EMAIL_TO`) ainda não
+preenchidos pelo dono — os steps pulam graciosamente até lá. Passo a passo de configuração:
+`.claude/rules/security.md`, seção "Alerta de deploy por e-mail (2026-08-18)".
 
 A lógica de detecção já existe (linhas ~1075-1224): smoke test de readiness com
 retry/backoff em `/health/ready`, rollback automático do backup pré-deploy (PR #129),


### PR DESCRIPTION
## Summary
- Item 1 do raio-X de maturidade (`docs/architecture/specs-execucao-maturidade-2026-08-16.md`). Canal decidido pelo dono: e-mail.
- Adiciona 2 steps em `deploy.yml` usando `dawidd6/action-send-mail@v3`: um após o smoke test/rollback (ROLLBACK OK / ROLLBACK FALHOU), outro como fallback genérico (DEPLOY ABORTADO antes do smoke test).
- Reaproveita o resumo já montado para `$GITHUB_STEP_SUMMARY` como corpo do e-mail.
- Secrets SMTP (`SMTP_SERVER`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`/`ALERT_EMAIL_TO`) ainda não preenchidos pelo dono — os steps checam `secrets.SMTP_SERVER != ''` e pulam graciosamente sem quebrar o workflow enquanto isso.
- Documenta em `.claude/rules/security.md` o passo a passo de configuração (Gmail + senha de app, caso mais acessível).

## Test plan
- [x] YAML validado com `yaml.safe_load` (sintaxe OK).
- [ ] Não há como testar o envio real sem os secrets preenchidos e um deploy real que falhe — validação de runtime fica pro próximo deploy que disparar o smoke test/rollback, depois que o dono configurar o provedor SMTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)