### PR TITLE
docs(ci): atualiza comentario de causa raiz do warmup apos fix 2106075/d6532e3

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -702,18 +702,26 @@ jobs:
         # subindo). 503 NAO e sucesso e tambem NAO e falha definitiva: e "ainda nao pronto" - por
         # isso o laco RETENTA ate 200 ou esgotar. So 200 encerra com sucesso.
         #
-        # [ATENCAO] Causa raiz investigada em 2026-08-13 (run 31687154272): o warm-up do catalogo
-        # (CachePermanentWarmupBackgroundService) roda UMA UNICA VEZ apos o app subir - nao ha
-        # retry. Se o SQL estiver com um blip de rede TRANSITORIO exatamente nesse instante
-        # (confirmado no log do host: "SqlException... error: 40 - Nao foi possivel abrir uma
-        # conexao com o SQL Server", recuperado segundos depois), o catalogo fica marcado com 0
-        # layouts PARA SEMPRE (CatalogHealthCheck Unhealthy -> /health/ready 503 permanente) ate
-        # o servico ser reiniciado manualmente - mesmo com o SQL saudavel de novo. O laco de
-        # retentativas abaixo nao ajuda nesse caso porque a sonda em si e reexecutada, mas o
-        # ESTADO do warm-up (CatalogWarmupState) nunca e recalculado. Por isso: se a janela
-        # inicial esgotar, tenta UM restart do servico (reexecuta o warm-up do zero) antes de
-        # desistir. Corrigir a causa raiz de verdade (retry no warm-up em si) e codigo de negocio
-        # -> @lp-backend-dev; aqui so mitigamos no nivel de deploy.
+        # [ATUALIZADO 2026-08-21] Causa raiz original investigada em 2026-08-13 (run 31687154272):
+        # o warm-up do catalogo (CachePermanentWarmupBackgroundService) rodava UMA UNICA VEZ apos
+        # o app subir, sem retry - um blip TRANSITORIO de rede no SQL nesse instante deixava o
+        # catalogo marcado com 0 layouts PARA SEMPRE (CatalogHealthCheck Unhealthy -> 503
+        # permanente), mesmo com o SQL saudavel segundos depois. Corrigido em `develop` pelos
+        # commits 2106075 (fix(catalog-warmup): retry com backoff no warm-up do cache, issue #67)
+        # e d6532e3 (fix: classifica warm-up do catalogo em tres estados na readiness), PR #178 -
+        # CatalogHealthCheck/CachePermanentWarmupBackgroundService agora distinguem estado
+        # transitorio ("Aquecendo", recuperavel com retry/backoff progressivo dentro do proprio
+        # warm-up) de definitivo ("Vazio", decryptor quebrado/config invalida - nao adianta retry).
+        # O restart abaixo continua como rede de seguranca: mesmo com retry no warm-up, um SQL
+        # fora do ar por tempo MAIOR que a janela de retry ainda deixa o estado definitivo ate
+        # reiniciar o processo. [VALIDACAO PENDENTE 2026-08-21] runs de CI apos o merge do fix
+        # (ex.: 32433130012, headSha 7245825, ancestral confirmado de d6532e3) AINDA falharam com
+        # 503 persistente e "SqlException... error: 40" no host, mesmo apos o restart automatico -
+        # ou seja, o retry/backoff nao cobre uma indisponibilidade de SQL mais longa que a janela
+        # de tentativas. Isso pode ser um SQL genuinamente fora do ar (infra), nao um gap no fix -
+        # investigar o log do host antes de assumir regressao. Se a causa raiz aqui precisar de
+        # mudanca de codigo (ex.: janela de retry maior, ou distinguir "SQL fora" de "catalogo
+        # vazio" na mensagem) -> @lp-backend-dev; aqui so mitigamos no nivel de deploy.
         function Test-Readiness {
           param([int]$Tentativas, [int]$EsperaSegundos)
           $statusLocal = $null
@@ -756,7 +764,8 @@ jobs:
           Write-Warning ("Readiness nao ficou 200 na janela inicial (ultimo: " +
             $(if ($null -eq $status) { "sem resposta" } else { "HTTP $status" }) +
             "). Tentando UM restart do servico para reexecutar o warm-up do catalogo " +
-            "(mitigacao de blip transitorio de rede no SQL durante o warm-up unico) e retestando...")
+            "(rede de seguranca alem do retry/backoff ja embutido no warm-up - cobre SQL fora do ar " +
+            "por mais tempo que a janela de retry) e retestando...")
           Restart-Service -Name $serviceName -ErrorAction SilentlyContinue
           $svc = Get-Service -Name $serviceName
           $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(30))

--- a/docs/architecture/decisao-dsl-mapper-sysmiddle-2026-08-21.md
+++ b/docs/architecture/decisao-dsl-mapper-sysmiddle-2026-08-21.md
@@ -1,0 +1,71 @@
+# Decisão — mecanismo real da DSL do Mapper Sysmiddle (2026-08-21)
+
+> **PT-BR.** Fecha a pergunta aberta desde `dsl-mapper-roslyn-hypothesis-2026-08-16.md`.
+> Autoria: `@lp-architect`. Execução: `@lp-parser-llm`. Decompilação autorizada pelo dono
+> nesta sessão, via `ilspycmd`, sobre `tools/LowCodeRunner/Functions/*.dll` (binários já
+> versionados no repo como dependência de runtime, não baixados de fora).
+
+## 1. O que a DSL realmente é
+
+`SysMiddle.Map4Connect.Rule.dll` (não ofuscada, decompila com fidelidade total) contém a
+classe `RuleInterpretor` (`SysMiddle.Map4Connect.Rule.Service`). Ela é um **interpretador
+proprietário escrito à mão, line-based**, não um compilador para C#/IL e não usa Roslyn,
+CodeDom, nem nenhum motor de script de terceiro (nenhuma referência a
+`Microsoft.CodeAnalysis` em nenhuma DLL do conjunto — achado de 2026-08-16 permanece válido
+e agora está confirmado pelo código-fonte real, não só por ausência de evidência).
+
+Mecanismo, em resumo:
+- `Process()` recebe `RuleVO.ContentValue` (o texto bruto salvo no XML do mapper) e lê linha
+  a linha via `StringReader` (`GetLines`).
+- O texto precisa começar com o marcador literal `%beginRuleContent;` e terminar com
+  `%endRuleContent;` — sentinelas do próprio formato, não delimitadores de linguagem
+  genérica.
+- `GetBlocks`/`SetBlockChildren` constroem uma árvore de `CodeBlock` reconhecendo os tokens
+  literais `begin`/`end` como abertura/fechamento de bloco após uma linha `if(`/`else
+  if(`/`else` (dicionário `_validBlocks` com essas três formas hard-coded) — explica por que
+  a amostra usa `begin/end` em vez de `{ }`: é a sintaxe real, não uma etapa intermediária.
+- Comparações usam `=`/`!=` sobre `.ToString()` dos valores resolvidos (`resultCondition`),
+  não `==` de C# — confirma que `if(#.x = 44)` já é a gramática literal do motor, não uma
+  tradução prévia.
+- Funções (`GetLength()` etc., citadas em `ia-xslt-synthesis.md`) são despachadas por
+  `ExecuteRuleFunction`/`ExecuteGetValueFromContext`/`ExecuteGetDictionaryValuesFromElement`/
+  `ExecuteGetSumElementValuesFunction` — um dispatcher interno por nome de função conhecida,
+  não reflexão genérica sobre uma API pública.
+
+**Refuta definitivamente a hipótese de Roslyn** (2026-08-16) e fecha a hipótese (A) do gap
+de "Functions" levantado em `viabilidade-dlls-sysmiddle-para-rag.md` §4: são chamadas
+internas ao próprio `ContentValue`, resolvidas por um dispatcher fechado do motor — não um
+artefato externo separado a indexar.
+
+## 2. Decisão de arquitetura para o `RealMapperParser`
+
+**Não usar `Microsoft.CodeAnalysis.CSharp` nem qualquer parser de linguagem geral.**
+`RealMapperParser`/`DslBlockInterpreter` devem continuar como **parser dedicado da gramática
+Sysmiddle**, e agora podem ser desenhados com precisão em vez de heurística, porque a
+gramática real é pequena e fechada:
+
+1. **Tokenizer de linha**, não de caractere: cada linha relevante do `ContentValue` é uma
+   unidade (`StringReader.ReadLine()` + `Trim()`), igual ao original.
+2. **Sentinelas fixas**: reconhecer `%beginRuleContent;`/`%endRuleContent;` como delimitadores
+   obrigatórios do bloco de regra — descartar tudo fora deles.
+3. **Três formas de condicional, hard-coded**: `if(`, `else if(`, `else` — não generalizar
+   para uma gramática de expressão arbitrária. Blocos abrem com a linha seguinte iniciando em
+   `begin` e fecham em `end`.
+4. **Operador de igualdade é `=`/`!=` sobre string**, não `==`/`!=` de C# — ao gerar
+   XSLT/relatório de mapeamento, traduzir literalmente para o equivalente XPath (`=`/`!=`
+   já coincide, por sorte, com a sintaxe XSLT/XPath nativa).
+5. **Catálogo fechado de funções**: espelhar o dispatcher (`GetValueFromContext`,
+   `GetDictionaryValuesFromElement`, `GetSumElementValuesFunction`, + funções nomeadas via
+   `RuleFunctionVO`) como uma tabela conhecida de tradução DSL→XSLT/XPath, em vez de tentar
+   interpretar chamadas de função como se fossem extensíveis livremente.
+
+**Não commitar código decompilado no repo** (risco de licença — Sysmiddle Technology é
+fornecedor terceiro). Este documento descreve o mecanismo em prosa; a saída do `ilspycmd`
+usada nesta investigação ficou fora do controle de versão, em `.claude/tmp/ilspy_out/`
+(git-ignorado).
+
+## 3. Próximo passo
+
+`@lp-parser-llm` implementa/ajusta `RealMapperParser` conforme §2, com testes cobrindo os 3
+casos de condicional + o operador `=`/`!=` + pelo menos as 4 funções internas confirmadas
+acima antes de expandir para outras.

--- a/docs/architecture/varredura-gaps-quadro-vs-solicitado-2026-08-21.md
+++ b/docs/architecture/varredura-gaps-quadro-vs-solicitado-2026-08-21.md
@@ -1,0 +1,60 @@
+# Varredura — gaps entre o que foi decidido/descoberto e o quadro real (2026-08-21)
+
+> Autoria: `@lp-architect` (Aria). Missão `review-arch`. Não implementa, não abre issue —
+> mapeia gaps para `@lp-pm` formalizar.
+
+## Método
+
+1. `gh issue list --state open --limit 200` (25 issues abertas hoje, #88 até #174).
+2. `git log --since="15 days ago" -- docs/architecture/` (~50 commits de diagnóstico/decisão).
+3. Releitura dos índices de memória de todos os agentes (`.claude/agent-memory/*/MEMORY.md`).
+4. Busca cruzada por palavra-chave (`gh issue list --search ...`) para os temas de risco
+   conhecidos: readiness/deploy, hardening de senha, pre-commit hook, CodeQL, AiCandidateStore.
+
+## Segurança
+
+| Gap | Onde | Issue | Prioridade |
+|---|---|---|---|
+| Hardening da senha SQL em repouso (DPAPI/`ProtectedConfigurationBuilder`) — runbook pronto (`docs/architecture/runbook-hardening-senha-sql-em-repouso.md`), falta aplicar no host + handoff de código (`AddUserSecrets` fora de `IsDevelopment()`) | `security.md` checklist, item não marcado | **Nenhuma** | **Alto** — é a peça que falta pra fechar a remediação da senha SQL comprometida (rotação está descartada; histórico já foi limpo). Sem hardening em repouso, a senha continua legível em texto plano no `Environment` do serviço Windows por qualquer admin local. |
+| Hook de pre-commit local (`gitleaks`/`detect-secrets`) — metade do item "prevenir reincidência"; a metade de CI (`.github/workflows/gitleaks.yml`) já existe | `security.md` checklist | **Nenhuma** | Médio — rede de segurança já existe no CI; o hook local é defesa em profundidade, não bloqueante. |
+| `GET export/{id}` devolve `DecryptedContent` sem `[Authorize]` | achado 2026-08-15 | **#95 (aberta)** | Já rastreado — sem gap. |
+| CodeQL/GHAS removido do CI (decisão 2026-08-15) | `security.md` | — | Já executado (`308ea97`), sem gap. |
+| Revogação da chave Gemini | `security.md` | — | Concluída pelo dono em 2026-08-17, sem gap. |
+
+## Deploy/Infra
+
+| Gap | Onde | Issue | Prioridade |
+|---|---|---|---|
+| Config drift `appsettings.json` produção vs. repo — auditoria + deploy "congela" config do host | commit `bd15dca` e diagnósticos subsequentes | **#108 (aberta)**, com `#110`/`#112` como próximos passos B1/B2 | Já rastreado — sem gap. |
+| Diagnóstico "deploy abortado — readiness sem resposta" (2026-08-15, `40426fd`), correlacionado ao `ValidateOnStart` da PR #114 | `docs/architecture/diagnostico-deploy-abortado-readiness-2026-08-15.md` | **Nenhuma issue própria** — está descrito como hipótese líder num doc, não formalizado | **Alto** — é causa-raiz plausível de indisponibilidade de deploy em produção, mas só existe como narrativa de diagnóstico; sem issue, corre risco de reincidir sem rastreamento. Distinto de #67 (CLOSED, causa diferente: warmup single-run). |
+| `candidates: []` para LAY_CNHI (2026-08-20) | diagnóstico mais recente (`64a158a`) | Bloqueado em reprodução com `CorrelationId` real — não há ação de código pendente | Baixo — não é gap de rastreamento, é bloqueio legítimo aguardando dado do front. |
+
+## Contrato API/Front
+
+| Gap | Onde | Issue | Prioridade |
+|---|---|---|---|
+| PBI #128/Epic #126 (fieldMappings TXT↔XML) | plano de execução `a0fef11` | **#137-#141 abertas** (guarda-chuva #137 + fases #138/#139/#140/#141), #151 como Fase 4 | Já rastreado em profundidade — sem gap. |
+| `transformationsTicket` — instrumentar/documentar o "trava em 100%" do front | `docs/architecture` (achado 2026-08-15) | **#99 (aberta)** | Já rastreado — sem gap. |
+
+## Domínio parsing/IA
+
+| Gap | Onde | Issue | Prioridade |
+|---|---|---|---|
+| `AiCandidateStore` sem TTL/limite | achado `@lp-qa`, issue original | **#51 fechada, mas auditoria de 2026-08-14 (`audit-2026-08-14-di-regression.md`) registra que o leak segue presente no código** | **Alto** — issue fechada sem fix real aplicado; risco de crescimento indefinido de disco/memória em produção segue ativo, mas o board mostra "resolvido". Reabrir ou criar nova issue é decisão de `@lp-pm`. |
+| Particionamento de `AiCandidateStore` por usuário (pré-requisito de RBAC real, #97) | `rbac-scope-xml-generic-2026-08-14.md` | Coberto parcialmente por #92/#97 mas a dependência explícita ("abrir RBAC sem particionar cria vazamento entre usuários") não está no corpo de nenhuma issue | Médio — risco de segurança silencioso se #97 for implementada sem essa nota. |
+| Geração de mapeamento fiscal via two-step (layout + gabarito SEFAZ) | `session-artifacts-sharing-design.md` (2026-08-14) | **#103 (aberta)** | Já rastreado — sem gap. |
+| Hipótese Roslyn do dono contradita pela amostra real da DSL (2026-08-16) | `dsl-mapper-roslyn-hypothesis-2026-08-16.md` | Pergunta em aberto para o dono, sem issue — decisão de arquitetura ainda não tomada | Médio — bloqueia decisão sobre o parser da DSL do mapper; não é bug, é decisão pendente do dono, mas sem rastreamento formal ela pode se perder. |
+
+## Top gaps (resumo para ação)
+
+1. **`AiCandidateStore` — issue #51 fechada, leak real ainda presente no código** (confirmado por auditoria 2026-08-14). Risco: board mente sobre o estado real. **Alto.**
+2. **Hardening da senha SQL em repouso** — runbook pronto, nada aplicado, nenhuma issue. É a peça final da remediação de um segredo permanentemente comprometido. **Alto.**
+3. **Diagnóstico "readiness sem resposta" (correlação com PR #114/`ValidateOnStart`)** — causa-raiz plausível de indisponibilidade de deploy só existe como doc, sem issue. **Alto.**
+4. **Hook de pre-commit local (gitleaks)** — metade do item de "prevenir reincidência" de segredos, sem issue. **Médio.**
+5. **Dependência AiCandidateStore↔RBAC** — nota de risco enterrada em memória, não no corpo de #92/#97. **Médio.**
+6. **Decisão Roslyn vs. parser custom da DSL do mapper** — pergunta pendente ao dono, sem rastreamento. **Médio.**
+
+Todos os demais itens levantados nos últimos 15 dias de `docs/architecture/` (deploy, config
+drift, fieldMappings/sectionMappings, governança de mapeadores, sessão de usuário) já têm
+issue correspondente aberta e atualizada — o board está, no geral, bem sincronizado com o
+trabalho de diagnóstico recente.


### PR DESCRIPTION
## Contexto
O comentario em `ci-dev.yml` (linhas ~705-716) ainda descrevia a causa raiz antiga do 503 em `/health/ready` (warm-up sem retry, restart como unica mitigacao). O fix real ja foi mesclado em `develop` via PR #178 (commits `2106075`, `d6532e3`) - `CatalogHealthCheck`/`CachePermanentWarmupBackgroundService` agora distinguem "Aquecendo" (transitorio, retry/backoff) de "Vazio" (definitivo).

## O que mudou
- Comentario reescrito para descrever o mecanismo atual.
- Registrada uma observacao pendente: runs de CI **depois** do merge do fix (ex. `32433130012`, headSha `7245825`, confirmado ancestral de `d6532e3`) ainda falharam com 503 persistente + `SqlException error 40` no host, mesmo apos o restart automatico - ou seja, o retry/backoff nao cobre indisponibilidade de SQL mais longa que a janela de tentativas. Pode ser SQL genuinamente fora do ar (infra), nao um gap no fix - fica documentado para proxima investigacao.

Nao mexe em logica de negocio, so no comentario/mensagem de log do workflow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>