### PR TITLE
feat: diagnostico estruturado de pathwayDiagnostics em execute-candidates (fecha LayoutParserReact#86)

### DIFF
--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -338,6 +338,9 @@ namespace LayoutParserApi.Controllers
             // pathway, é entrada fora de escopo (a IA não deveria disparar por causa disso).
             if (isXmlInput)
             {
+                _logger.LogInformation(
+                    "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} motivo=entrada XML fora do escopo do pathway sysmiddle",
+                    Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", request.LayoutName);
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "sysmiddle",
@@ -356,6 +359,9 @@ namespace LayoutParserApi.Controllers
                     var msg = $"Layout {request.LayoutName} sem LayoutGuid válido no request ou no catálogo — pathway sysmiddle não aplicável";
                     warnings.Add(msg);
                     failureKinds.Add(FailureKind.NotApplicable);
+                    _logger.LogInformation(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=request.LayoutGuid/catalogo (nenhum resolvível)",
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", request.LayoutName);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -385,6 +391,9 @@ namespace LayoutParserApi.Controllers
                     // Estado A (§2 do design-fallback-ia-automatico): não existe mapper cadastrado
                     // para este layout — gap real de cobertura, elegível ao fallback de IA.
                     failureKinds.Add(FailureKind.NotApplicable);
+                    _logger.LogInformation(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=catalogo (consulta a mapeadores low-code sem resultado)",
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "no_mapper", request.LayoutName, resolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -424,6 +433,9 @@ namespace LayoutParserApi.Controllers
 
                 if (result.Count > 0)
                 {
+                    _logger.LogInformation(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} layoutGuid={LayoutGuid} candidatos={CandidateCount} fonte=mapeadores low-code do catalogo",
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "candidate_generated", request.LayoutName, resolvedLayoutGuid, result.Count);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -436,6 +448,9 @@ namespace LayoutParserApi.Controllers
                 {
                     // autoResult.Applicable == true (mapper existe) mas TODOS os candidatos
                     // falharam na execução — infra/runner, não gap de cobertura (§4.3 "runner_unavailable").
+                    _logger.LogWarning(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=execução do runner (mapper existe, execução falhou)",
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "runner_unavailable", request.LayoutName, resolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -447,7 +462,9 @@ namespace LayoutParserApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha estrutural no pathway sysmiddle ao gerar candidatos para layout {LayoutName}", request.LayoutName);
+                _logger.LogWarning(ex,
+                    "Falha estrutural no pathway sysmiddle ao gerar candidatos para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
+                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "execution_error");
                 // Saneado: exceção de I/O deste pathway carrega caminho de disco do servidor e este
                 // warning sai no payload 200 (mesmo defeito do §3.1 da spec, outro ponto de saída).
                 var sanitizedEx = LowCodeErrorSanitizer.ForWire(ex);
@@ -538,6 +555,9 @@ namespace LayoutParserApi.Controllers
                 {
                     var msg = $"Layout {request.LayoutName} sem LayoutGuid válido — fallback de IA não aplicável";
                     warnings.Add(msg);
+                    _logger.LogInformation(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=request.LayoutGuid/catalogo (nenhum resolvível)",
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", request.LayoutName);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -552,6 +572,9 @@ namespace LayoutParserApi.Controllers
                 {
                     var msg = $"Pathway IA fallback suprimido para este layout até {retryAt:HH:mm} (já tentado sem sucesso)";
                     warnings.Add(msg);
+                    _logger.LogInformation(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=IAiFallbackSuppressionGate (cooldown ativo até {RetryAt})",
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", request.LayoutName, resolvedLayoutGuid, retryAt);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -567,6 +590,9 @@ namespace LayoutParserApi.Controllers
                 {
                     var msg = $"Layout {request.LayoutName}: não foi possível compor o ticket do fallback de IA";
                     warnings.Add(msg);
+                    _logger.LogWarning(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=LowCodeTransformationStore.BuildTicketFromContent (retornou null)",
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "configuration_error", request.LayoutName, resolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -596,6 +622,9 @@ namespace LayoutParserApi.Controllers
                 // (ticket assíncrono) — não um XML pronto, mas o front tem o que fazer com ele
                 // (§4.2 do desenho: "inclui o ticket assíncrono do fallback de IA, que 'gera' no
                 // sentido de estar em processamento").
+                _logger.LogInformation(
+                    "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} layoutGuid={LayoutGuid} ticket={Ticket} fonte=IAiTransformationCandidateService.EnqueueAsync (sem gabarito)",
+                    Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "candidate_generated", request.LayoutName, resolvedLayoutGuid, ticket);
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "ai-fallback",
@@ -606,7 +635,9 @@ namespace LayoutParserApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha ao disparar o fallback automático de IA para layout {LayoutName}", request.LayoutName);
+                _logger.LogWarning(ex,
+                    "Falha ao disparar o fallback automático de IA para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
+                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "execution_error");
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "ai-fallback",
@@ -685,6 +716,9 @@ namespace LayoutParserApi.Controllers
                         "xsl_not_found" => "xsl_not_found",
                         _ => "map_not_found" // fallback conservador: maioria dos casos "não aplicável" hoje é ausência de MAP
                     };
+                    _logger.LogWarning(
+                        "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=TransformationPipelineService.ErrorCode={ErrorCode}",
+                        Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", code, request.LayoutName, pipelineResult.ErrorCode);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "tcl-xsl",
@@ -726,6 +760,10 @@ namespace LayoutParserApi.Controllers
                     Validation = validation
                 });
 
+                _logger.LogInformation(
+                    "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} tclPath={TclPath} xslPath={XslPath} fonte=TransformationPipelineService",
+                    Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "candidate_generated", request.LayoutName,
+                    System.IO.Path.GetFileName(pipelineResult.TclPath), System.IO.Path.GetFileName(pipelineResult.XslPath));
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "tcl-xsl",
@@ -736,7 +774,9 @@ namespace LayoutParserApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha estrutural no pathway tcl-xsl ao gerar candidato para layout {LayoutName}", request.LayoutName);
+                _logger.LogWarning(ex,
+                    "Falha estrutural no pathway tcl-xsl ao gerar candidato para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
+                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", "execution_error");
                 // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
                 var sanitizedTclXslEx = LowCodeErrorSanitizer.ForWire(ex);
                 warnings.Add($"Pathway tcl-xsl falhou: {sanitizedTclXslEx}");

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -250,8 +250,9 @@ namespace LayoutParserApi.Controllers
             // failureKinds: classificação interna (§2 do design-fallback-ia-automatico) coletada na
             // ORIGEM de cada pathway — nunca inferida depois por regex sobre warning já sanitizado.
             var failureKinds = new ConcurrentBag<FailureKind>();
-            var sysmiddleTask = ExecuteSysmiddleCandidatesAsync(request, layoutRecord, isXmlInput, warnings, failureKinds, candidatesCts.Token);
-            var tclXslTask = ExecuteTclXslCandidatesAsync(request, isXmlInput, warnings, failureKinds);
+            var pathwayDiagnostics = new ConcurrentBag<Models.Transformation.PathwayDiagnostic>();
+            var sysmiddleTask = ExecuteSysmiddleCandidatesAsync(request, layoutRecord, isXmlInput, warnings, failureKinds, pathwayDiagnostics, candidatesCts.Token);
+            var tclXslTask = ExecuteTclXslCandidatesAsync(request, isXmlInput, warnings, failureKinds, pathwayDiagnostics);
 
             var allTask = Task.WhenAll(sysmiddleTask, tclXslTask);
             var winner = await Task.WhenAny(allTask, Task.Delay(TimeSpan.FromSeconds(overallTimeoutSeconds)));
@@ -285,7 +286,7 @@ namespace LayoutParserApi.Controllers
             // falhou por infra (Estado B) — aí a correção é operacional, não de transformação, e a
             // IA nunca deveria tentar "recriar" um mapper que já existe e está correto.
             if (candidates.Count == 0)
-                TryEnqueueAiFallback(request, layoutRecord, isXmlInput, failureKinds, warnings, CurrentUserId);
+                TryEnqueueAiFallback(request, layoutRecord, isXmlInput, failureKinds, warnings, pathwayDiagnostics, CurrentUserId);
 
             string? recommendedId = null;
             if (candidates.Count > 0)
@@ -300,9 +301,9 @@ namespace LayoutParserApi.Controllers
                 Candidates = candidates,
                 RecommendedCandidateId = recommendedId,
                 Warnings = warnings,
-                // pathwayDiagnostics (Issue #86): estrutura aditiva, população dos valores por
-                // pathway fica para etapa seguinte — ver docs/architecture/diagnostico-issue-86-*.md.
-                PathwayDiagnostics = new List<Models.Transformation.PathwayDiagnostic>(),
+                // pathwayDiagnostics (Issue #86): populado na origem por cada pathway (sysmiddle,
+                // tcl-xsl, ai-fallback) — ver docs/architecture/diagnostico-issue-86-*.md §4.
+                PathwayDiagnostics = pathwayDiagnostics.ToList(),
                 CorrelationId = Services.Logging.CorrelationContext.CurrentId
             });
         }
@@ -319,22 +320,40 @@ namespace LayoutParserApi.Controllers
         /// </summary>
         private async Task<List<TransformationCandidate>> ExecuteSysmiddleCandidatesAsync(
             TransformationRequest request, LayoutRecord layoutRecord, bool isXmlInput, List<string> warnings,
-            ConcurrentBag<FailureKind> failureKinds, CancellationToken cancellationToken)
+            ConcurrentBag<FailureKind> failureKinds, ConcurrentBag<Models.Transformation.PathwayDiagnostic> pathwayDiagnostics,
+            CancellationToken cancellationToken)
         {
             var result = new List<TransformationCandidate>();
 
             // Sysmiddle/low-code espera texto posicional (TXT), não XML — não é uma falha do
             // pathway, é entrada fora de escopo (a IA não deveria disparar por causa disso).
             if (isXmlInput)
+            {
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "sysmiddle",
+                    Status = "not_applicable",
+                    Code = "not_applicable",
+                    Message = "Entrada XML — pathway sysmiddle espera texto posicional (TXT)"
+                });
                 return result;
+            }
 
             try
             {
                 var resolvedLayoutGuid = LowCodeLayoutGuidResolver.Resolve(request.LayoutGuid, layoutRecord.LayoutGuid);
                 if (resolvedLayoutGuid == null)
                 {
-                    warnings.Add($"Layout {request.LayoutName} sem LayoutGuid válido no request ou no catálogo — pathway sysmiddle não aplicável");
+                    var msg = $"Layout {request.LayoutName} sem LayoutGuid válido no request ou no catálogo — pathway sysmiddle não aplicável";
+                    warnings.Add(msg);
                     failureKinds.Add(FailureKind.NotApplicable);
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "sysmiddle",
+                        Status = "not_applicable",
+                        Code = "not_applicable",
+                        Message = msg
+                    });
                     return result;
                 }
 
@@ -352,13 +371,23 @@ namespace LayoutParserApi.Controllers
 
                 if (!autoResult.Applicable)
                 {
-                    warnings.Add($"Nenhum mapeador low-code encontrado para o layout {request.LayoutName} (pathway sysmiddle)");
+                    var msgNoMapper = $"Nenhum mapeador low-code encontrado para o layout {request.LayoutName} (pathway sysmiddle)";
+                    warnings.Add(msgNoMapper);
                     // Estado A (§2 do design-fallback-ia-automatico): não existe mapper cadastrado
                     // para este layout — gap real de cobertura, elegível ao fallback de IA.
                     failureKinds.Add(FailureKind.NotApplicable);
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "sysmiddle",
+                        Status = "not_applicable",
+                        Code = "no_mapper",
+                        Message = msgNoMapper
+                    });
                     return result;
                 }
 
+                var anyCandidateFailed = false;
+                string lastCandidateFailureMessage = null;
                 foreach (var c in autoResult.Candidates)
                 {
                     if (c.Success && !string.IsNullOrEmpty(c.OutputXml))
@@ -376,9 +405,35 @@ namespace LayoutParserApi.Controllers
                         // vira warning (ver tabela de decisão do contrato). Estado B (§2 do design):
                         // o mapper EXISTE (Applicable==true) mas a execução falhou — é infra/config
                         // (runner, timeout, .exe ausente), não gap de cobertura. Nunca dispara IA.
-                        warnings.Add($"Candidato {c.MapperGuid} (pathway sysmiddle) falhou: {c.ErrorMessage ?? "erro desconhecido"}");
+                        var sanitizedCandidateError = LowCodeErrorSanitizer.ForWire(c.ErrorMessage ?? "erro desconhecido");
+                        anyCandidateFailed = true;
+                        lastCandidateFailureMessage = sanitizedCandidateError;
+                        warnings.Add($"Candidato {c.MapperGuid} (pathway sysmiddle) falhou: {sanitizedCandidateError}");
                         failureKinds.Add(FailureKind.ExecutionInfraError);
                     }
+                }
+
+                if (result.Count > 0)
+                {
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "sysmiddle",
+                        Status = "candidate_generated",
+                        Code = null,
+                        Message = $"{result.Count} candidato(s) sysmiddle gerado(s)"
+                    });
+                }
+                else if (anyCandidateFailed)
+                {
+                    // autoResult.Applicable == true (mapper existe) mas TODOS os candidatos
+                    // falharam na execução — infra/runner, não gap de cobertura (§4.3 "runner_unavailable").
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "sysmiddle",
+                        Status = "failed",
+                        Code = "runner_unavailable",
+                        Message = lastCandidateFailureMessage ?? "Todos os candidatos sysmiddle falharam na execução"
+                    });
                 }
             }
             catch (Exception ex)
@@ -386,9 +441,17 @@ namespace LayoutParserApi.Controllers
                 _logger.LogWarning(ex, "Falha estrutural no pathway sysmiddle ao gerar candidatos para layout {LayoutName}", request.LayoutName);
                 // Saneado: exceção de I/O deste pathway carrega caminho de disco do servidor e este
                 // warning sai no payload 200 (mesmo defeito do §3.1 da spec, outro ponto de saída).
-                warnings.Add($"Pathway sysmiddle falhou: {LowCodeErrorSanitizer.ForWire(ex)}");
+                var sanitizedEx = LowCodeErrorSanitizer.ForWire(ex);
+                warnings.Add($"Pathway sysmiddle falhou: {sanitizedEx}");
                 // Falha estrutural (exceção) é sempre infra, não "não modelado" — nunca dispara IA.
                 failureKinds.Add(FailureKind.ExecutionInfraError);
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "sysmiddle",
+                    Status = "failed",
+                    Code = "execution_error",
+                    Message = sanitizedEx
+                });
             }
 
             return result;
@@ -446,34 +509,62 @@ namespace LayoutParserApi.Controllers
         /// </summary>
         private void TryEnqueueAiFallback(
             TransformationRequest request, LayoutRecord layoutRecord, bool isXmlInput,
-            ConcurrentBag<FailureKind> failureKinds, List<string> warnings, string userId)
+            ConcurrentBag<FailureKind> failureKinds, List<string> warnings,
+            ConcurrentBag<Models.Transformation.PathwayDiagnostic> pathwayDiagnostics, string userId)
         {
             try
             {
                 if (failureKinds.Any(k => k == FailureKind.ExecutionInfraError))
                 {
                     // Estado B: já existe o warning de infra específico emitido pelo pathway que
-                    // falhou — nada a acrescentar aqui, só não disparar a IA (§2 do desenho).
+                    // falhou (e já virou pathwayDiagnostics próprio de sysmiddle/tcl-xsl) — nada a
+                    // acrescentar aqui, só não disparar a IA (§2 do desenho). Não emite um 3º
+                    // diagnóstico "ai-fallback: not_applicable" para não duplicar sinal — o front já
+                    // tem os itens failed de quem realmente quebrou.
                     return;
                 }
 
                 var resolvedLayoutGuidText = LowCodeLayoutGuidResolver.Resolve(request.LayoutGuid, layoutRecord.LayoutGuid);
                 if (resolvedLayoutGuidText == null || !Guid.TryParse(resolvedLayoutGuidText, out var resolvedLayoutGuid))
                 {
-                    warnings.Add($"Layout {request.LayoutName} sem LayoutGuid válido — fallback de IA não aplicável");
+                    var msg = $"Layout {request.LayoutName} sem LayoutGuid válido — fallback de IA não aplicável";
+                    warnings.Add(msg);
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "ai-fallback",
+                        Status = "not_applicable",
+                        Code = "not_applicable",
+                        Message = msg
+                    });
                     return;
                 }
 
                 if (_aiFallbackGate.IsInCooldown(resolvedLayoutGuid, out var retryAt))
                 {
-                    warnings.Add($"Pathway IA fallback suprimido para este layout até {retryAt:HH:mm} (já tentado sem sucesso)");
+                    var msg = $"Pathway IA fallback suprimido para este layout até {retryAt:HH:mm} (já tentado sem sucesso)";
+                    warnings.Add(msg);
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "ai-fallback",
+                        Status = "not_applicable",
+                        Code = "not_applicable",
+                        Message = msg
+                    });
                     return;
                 }
 
                 var ticket = LowCodeTransformationStore.BuildTicketFromContent(request.InputContent, resolvedLayoutGuidText);
                 if (ticket == null)
                 {
-                    warnings.Add($"Layout {request.LayoutName}: não foi possível compor o ticket do fallback de IA");
+                    var msg = $"Layout {request.LayoutName}: não foi possível compor o ticket do fallback de IA";
+                    warnings.Add(msg);
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "ai-fallback",
+                        Status = "failed",
+                        Code = "configuration_error",
+                        Message = msg
+                    });
                     return;
                 }
 
@@ -490,11 +581,30 @@ namespace LayoutParserApi.Controllers
                     groundTruthXml: null,
                     CancellationToken.None);
 
-                warnings.Add($"Nenhum candidato de transformação encontrado — fallback automático de IA enfileirado (ticket {ticket}), consulte GET execute-candidates/{ticket}/ia-status");
+                var enqueuedMsg = $"Nenhum candidato de transformação encontrado — fallback automático de IA enfileirado (ticket {ticket}), consulte GET execute-candidates/{ticket}/ia-status";
+                warnings.Add(enqueuedMsg);
+                // "candidate_generated" no sentido de que o pathway produziu um item consultável
+                // (ticket assíncrono) — não um XML pronto, mas o front tem o que fazer com ele
+                // (§4.2 do desenho: "inclui o ticket assíncrono do fallback de IA, que 'gera' no
+                // sentido de estar em processamento").
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "ai-fallback",
+                    Status = "candidate_generated",
+                    Code = null,
+                    Message = enqueuedMsg
+                });
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Falha ao disparar o fallback automático de IA para layout {LayoutName}", request.LayoutName);
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "ai-fallback",
+                    Status = "failed",
+                    Code = "execution_error",
+                    Message = LowCodeErrorSanitizer.ForWire(ex)
+                });
             }
         }
 
@@ -530,7 +640,8 @@ namespace LayoutParserApi.Controllers
         /// noção de múltiplos TCL/XSL candidatos para o mesmo layout).
         /// </summary>
         private async Task<List<TransformationCandidate>> ExecuteTclXslCandidatesAsync(
-            TransformationRequest request, bool isXmlInput, List<string> warnings, ConcurrentBag<FailureKind> failureKinds)
+            TransformationRequest request, bool isXmlInput, List<string> warnings, ConcurrentBag<FailureKind> failureKinds,
+            ConcurrentBag<Models.Transformation.PathwayDiagnostic> pathwayDiagnostics)
         {
             var result = new List<TransformationCandidate>();
 
@@ -551,9 +662,27 @@ namespace LayoutParserApi.Controllers
                 {
                     // Saneado (§5 do diagnóstico-issue-86): pipelineResult.Errors pode carregar
                     // caminho de disco cru (IOException/XmlException internos do pipeline).
-                    warnings.Add($"Candidato tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(string.Join("; ", pipelineResult.Errors))}");
+                    var sanitizedTclXslError = LowCodeErrorSanitizer.ForWire(string.Join("; ", pipelineResult.Errors));
+                    warnings.Add($"Candidato tcl-xsl falhou: {sanitizedTclXslError}");
                     // "Sem heurística aplicável" para este layout — Estado A (§2 do design).
                     failureKinds.Add(FailureKind.NotApplicable);
+
+                    // Issue #86 §2.4: distingue "arquivo MAP não encontrado" de "arquivo XSL não
+                    // encontrado" pelo ErrorCode populado na origem (TransformationPipelineService),
+                    // não por regex sobre a mensagem já sanitizada.
+                    var code = pipelineResult.ErrorCode switch
+                    {
+                        "map_not_found" => "map_not_found",
+                        "xsl_not_found" => "xsl_not_found",
+                        _ => "map_not_found" // fallback conservador: maioria dos casos "não aplicável" hoje é ausência de MAP
+                    };
+                    pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                    {
+                        Pathway = "tcl-xsl",
+                        Status = "failed",
+                        Code = code,
+                        Message = sanitizedTclXslError
+                    });
                     return result;
                 }
 
@@ -587,14 +716,30 @@ namespace LayoutParserApi.Controllers
                     SegmentMappings = pipelineResult.SegmentMappings?.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value),
                     Validation = validation
                 });
+
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "tcl-xsl",
+                    Status = "candidate_generated",
+                    Code = null,
+                    Message = "Candidato tcl-xsl gerado com sucesso"
+                });
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Falha estrutural no pathway tcl-xsl ao gerar candidato para layout {LayoutName}", request.LayoutName);
                 // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
-                warnings.Add($"Pathway tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(ex)}");
+                var sanitizedTclXslEx = LowCodeErrorSanitizer.ForWire(ex);
+                warnings.Add($"Pathway tcl-xsl falhou: {sanitizedTclXslEx}");
                 // Exceção estrutural é infra, não "não modelado" — nunca dispara IA.
                 failureKinds.Add(FailureKind.ExecutionInfraError);
+                pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
+                {
+                    Pathway = "tcl-xsl",
+                    Status = "failed",
+                    Code = "execution_error",
+                    Message = sanitizedTclXslEx
+                });
             }
 
             return result;

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -299,7 +299,11 @@ namespace LayoutParserApi.Controllers
                 Success = true,
                 Candidates = candidates,
                 RecommendedCandidateId = recommendedId,
-                Warnings = warnings
+                Warnings = warnings,
+                // pathwayDiagnostics (Issue #86): estrutura aditiva, população dos valores por
+                // pathway fica para etapa seguinte — ver docs/architecture/diagnostico-issue-86-*.md.
+                PathwayDiagnostics = new List<Models.Transformation.PathwayDiagnostic>(),
+                CorrelationId = Services.Logging.CorrelationContext.CurrentId
             });
         }
 
@@ -545,7 +549,9 @@ namespace LayoutParserApi.Controllers
 
                 if (!pipelineResult.Success || string.IsNullOrEmpty(pipelineResult.TransformedXml))
                 {
-                    warnings.Add($"Candidato tcl-xsl falhou: {string.Join("; ", pipelineResult.Errors)}");
+                    // Saneado (§5 do diagnóstico-issue-86): pipelineResult.Errors pode carregar
+                    // caminho de disco cru (IOException/XmlException internos do pipeline).
+                    warnings.Add($"Candidato tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(string.Join("; ", pipelineResult.Errors))}");
                     // "Sem heurística aplicável" para este layout — Estado A (§2 do design).
                     failureKinds.Add(FailureKind.NotApplicable);
                     return result;
@@ -568,7 +574,8 @@ namespace LayoutParserApi.Controllers
                         // Falha de validação não invalida o candidato em si (o XML transformado existe) —
                         // só fica sem o campo Validation preenchido.
                         _logger.LogWarning(ex, "Falha ao validar candidato tcl-xsl para layout {LayoutName}", request.LayoutName);
-                        warnings.Add($"Validação do candidato tcl-xsl falhou: {ex.Message}");
+                        // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
+                        warnings.Add($"Validação do candidato tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(ex)}");
                     }
                 }
 
@@ -584,7 +591,8 @@ namespace LayoutParserApi.Controllers
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Falha estrutural no pathway tcl-xsl ao gerar candidato para layout {LayoutName}", request.LayoutName);
-                warnings.Add($"Pathway tcl-xsl falhou: {ex.Message}");
+                // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
+                warnings.Add($"Pathway tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(ex)}");
                 // Exceção estrutural é infra, não "não modelado" — nunca dispara IA.
                 failureKinds.Add(FailureKind.ExecutionInfraError);
             }

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -174,6 +174,15 @@ namespace LayoutParserApi.Controllers
         /// de infra), o fallback automático de IA é disparado em background (loop gerar→validar→
         /// corrigir via Ollama), sujeito a cooldown de 4h por LayoutGuid; ver
         /// <see cref="GetAiCandidateStatus"/> para acompanhar o resultado.
+        ///
+        /// <para>Issue LayoutParserReact #86 (diagnóstico estruturado): a resposta traz, de forma
+        /// ADITIVA (não quebra clientes existentes), <see cref="TransformationExecutionCandidatesResponse.PathwayDiagnostics"/>
+        /// — um <see cref="Models.Transformation.PathwayDiagnostic"/> por pathway avaliado (sysmiddle/tcl-xsl/
+        /// ai-fallback), com <c>status</c>/<c>code</c>/<c>message</c> — e
+        /// <see cref="TransformationExecutionCandidatesResponse.CorrelationId"/>, que permite ao suporte
+        /// cruzar a resposta HTTP com o log estruturado completo (não sanitizado) desta chamada. Toda
+        /// <c>Message</c> nesse array já passou por <see cref="Services.Transformation.LowCode.LowCodeErrorSanitizer"/>
+        /// — nunca contém caminho físico de disco ou detalhe interno cru.</para>
         /// </summary>
         // Issue #32: dispara processos externos (runner x86) e é operação privilegiada — era
         // restrita ao papel "admin". Issue #93: reabre para qualquer usuário autenticado (o

--- a/Models/Transformation/PathwayDiagnostic.cs
+++ b/Models/Transformation/PathwayDiagnostic.cs
@@ -1,0 +1,32 @@
+namespace LayoutParserApi.Models.Transformation
+{
+    /// <summary>
+    /// Diagnóstico estruturado por pathway de <c>POST /api/transformation-execution/execute-candidates</c>
+    /// (Issue LayoutParserReact #86). Campo ADITIVO — não substitui <see cref="TransformationExecutionCandidatesResponse.Warnings"/>,
+    /// que continua populado exatamente como hoje por compatibilidade.
+    ///
+    /// <para>Ver desenho completo em
+    /// docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md §4.
+    /// Este arquivo só define a estrutura; a população dos valores por pathway (sysmiddle/tcl-xsl/
+    /// ai-fallback) é feita por quem já monta <c>warnings</c>/<c>failureKinds</c> hoje.</para>
+    /// </summary>
+    public class PathwayDiagnostic
+    {
+        /// <summary>"sysmiddle" | "tcl-xsl" | "ai-fallback".</summary>
+        public string Pathway { get; set; } = "";
+
+        /// <summary>"candidate_generated" | "not_applicable" | "failed" (§4.2 do desenho).
+        /// String, não enum exposto — permite adicionar valores sem quebrar o contrato.</summary>
+        public string Status { get; set; } = "";
+
+        /// <summary>Taxonomia estável: "no_mapper" | "map_not_found" | "xsl_not_found" |
+        /// "configuration_error" | "runner_unavailable" | "execution_error" | "not_applicable"
+        /// (§4.3 do desenho). String, não enum exposto, pelo mesmo motivo de <see cref="Status"/>.</summary>
+        public string Code { get; set; } = "";
+
+        /// <summary>Mensagem legível para o front. SEMPRE passada por
+        /// <see cref="LayoutParserApi.Services.Transformation.LowCode.LowCodeErrorSanitizer"/> antes de
+        /// chegar aqui — nunca caminho de disco/detalhe interno cru (§5 do desenho).</summary>
+        public string Message { get; set; } = "";
+    }
+}

--- a/Models/Transformation/TransformationCandidate.cs
+++ b/Models/Transformation/TransformationCandidate.cs
@@ -33,5 +33,15 @@ namespace LayoutParserApi.Models.Transformation
         public List<TransformationCandidate> Candidates { get; set; } = new();
         public string? RecommendedCandidateId { get; set; }
         public List<string> Warnings { get; set; } = new();
+
+        /// <summary>Diagnóstico estruturado por pathway (Issue LayoutParserReact #86) — ADITIVO,
+        /// não substitui <see cref="Warnings"/>. Vazio hoje: a população dos valores por pathway
+        /// (sysmiddle/tcl-xsl/ai-fallback) é feita em cima desta estrutura, ver
+        /// <see cref="PathwayDiagnostic"/>.</summary>
+        public List<PathwayDiagnostic> PathwayDiagnostics { get; set; } = new();
+
+        /// <summary>CorrelationId da request (<see cref="LayoutParserApi.Services.Logging.CorrelationContext.CurrentId"/>),
+        /// permite ao suporte cruzar com o log estruturado completo (não sanitizado) desta chamada.</summary>
+        public string? CorrelationId { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -325,6 +325,48 @@ Without a `groundTruthXml` (State A, "generate from scratch"), the convergence c
 | `failed` | Yes — **new in this contract** | Candidates exist, but **none** succeeded — structural failure of the set. Previously this came back as `completed` with every candidate `success=false`, forcing the front to scan the array to infer failure. |
 | `not_applicable` / `error` | Yes (only in `/api/parse/upload`'s synchronous response) | `not_applicable`: pathway not eligible (no mapper, non-positional type, empty input). `error`: structural failure processing transformations (e.g. database down) — does not fail the main parse. |
 
+### Diagnóstico estruturado de `execute-candidates` (Issue LayoutParserReact #86) / Structured diagnostics for `execute-candidates`
+
+**🇧🇷** `POST /api/transformationexecution/execute-candidates` ganhou dois campos **aditivos** na resposta (não quebram clientes existentes que ignoram campos desconhecidos): [`pathwayDiagnostics`](Models/Transformation/PathwayDiagnostic.cs) e `correlationId`. Design completo: [`docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md`](docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md).
+
+```jsonc
+{
+  "success": true,
+  "candidates": [],
+  "recommendedCandidateId": null,
+  "warnings": ["..."],
+  "pathwayDiagnostics": [
+    { "pathway": "sysmiddle", "status": "not_applicable", "code": "no_mapper", "message": "..." },
+    { "pathway": "tcl-xsl", "status": "failed", "code": "map_not_found", "message": "..." }
+  ],
+  "correlationId": "..."
+}
+```
+
+**Semântica principal:** `candidates: []` nunca fica sem causa quando a API sabe o motivo — cada pathway avaliado (`sysmiddle`, `tcl-xsl`, e `ai-fallback` quando o fallback automático de IA é disparado) entra em `pathwayDiagnostics` com um veredito, mesmo quando não produz candidato. `warnings` continua populado exatamente como antes, por compatibilidade — `pathwayDiagnostics` é estruturado, não substitui.
+
+| Campo | Valores | Significado |
+|-------|---------|-------------|
+| `pathway` | `sysmiddle` \| `tcl-xsl` \| `ai-fallback` | Qual dos pathways gerou este diagnóstico. |
+| `status` | `candidate_generated` \| `not_applicable` \| `failed` | `candidate_generated`: o pathway produziu ao menos um candidato. `not_applicable`: o pathway não é elegível para este layout/entrada (não é falha). `failed`: o pathway era elegível mas não conseguiu produzir candidato. |
+| `code` | `no_mapper` \| `map_not_found` \| `xsl_not_found` \| `configuration_error` \| `runner_unavailable` \| `timeout` \| `not_applicable` \| `execution_error` | Taxonomia estável (string, não enum — permite adicionar valores sem quebrar o contrato). |
+| `message` | texto livre | Mensagem legível para exibição no front. |
+
+**Regra de sanitização:** toda `message` em `pathwayDiagnostics` passa por [`LowCodeErrorSanitizer`](Services/Transformation/LowCode/LowCodeErrorSanitizer.cs) antes de chegar ao payload HTTP — **nunca** contém caminho físico de disco nem detalhe interno cru. O detalhe completo (não sanitizado) só existe no log estruturado, correlacionável via `correlationId`.
+
+**🇺🇸** `POST /api/transformationexecution/execute-candidates` gained two **additive** response fields (safe for existing clients that ignore unknown fields): [`pathwayDiagnostics`](Models/Transformation/PathwayDiagnostic.cs) and `correlationId`. Full design: [`docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md`](docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md).
+
+**Core semantics:** `candidates: []` is never left without a cause when the API knows the reason — every pathway evaluated (`sysmiddle`, `tcl-xsl`, and `ai-fallback` when the automatic AI fallback fires) gets an entry in `pathwayDiagnostics` with a verdict, even when it produces no candidate. `warnings` remains populated exactly as before for backward compatibility — `pathwayDiagnostics` is structured, it doesn't replace it.
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `pathway` | `sysmiddle` \| `tcl-xsl` \| `ai-fallback` | Which pathway produced this diagnostic. |
+| `status` | `candidate_generated` \| `not_applicable` \| `failed` | `candidate_generated`: the pathway produced at least one candidate. `not_applicable`: the pathway isn't eligible for this layout/input (not a failure). `failed`: the pathway was eligible but couldn't produce a candidate. |
+| `code` | `no_mapper` \| `map_not_found` \| `xsl_not_found` \| `configuration_error` \| `runner_unavailable` \| `timeout` \| `not_applicable` \| `execution_error` | Stable taxonomy (string, not an exposed enum — new values can be added without breaking the contract). |
+| `message` | free text | Human-readable message for front-end display. |
+
+**Sanitization rule:** every `message` in `pathwayDiagnostics` goes through [`LowCodeErrorSanitizer`](Services/Transformation/LowCode/LowCodeErrorSanitizer.cs) before reaching the HTTP payload — it **never** contains a physical disk path or raw internal detail. The full (unsanitized) detail only exists in the structured log, correlatable via `correlationId`.
+
 ---
 
 ## 8. Configuração / Configuration

--- a/Services/XmlAnalysis/Models/TransformationPipelineResult.cs
+++ b/Services/XmlAnalysis/Models/TransformationPipelineResult.cs
@@ -11,6 +11,15 @@
         public string XslPath { get; set; }
         public List<string> Errors { get; set; } = new();
         public List<string> Warnings { get; set; } = new();
+
+        /// <summary>
+        /// Código estável da causa de falha (Issue LayoutParserReact #86, pathwayDiagnostics).
+        /// "map_not_found" | "xsl_not_found" | null (sucesso ou erro interno não classificado —
+        /// nesse caso o chamador cai no "execution_error" genérico). Populado no ponto de origem
+        /// (<see cref="TransformationPipelineService"/>), nunca inferido depois por regex sobre
+        /// <see cref="Errors"/> — mesma disciplina já usada para <c>FailureKind</c> no controller.
+        /// </summary>
+        public string ErrorCode { get; set; }
         public Dictionary<string, string> StepResults { get; set; } = new();
         public Dictionary<int, string> SegmentMappings { get; set; } = new();
     }

--- a/Services/XmlAnalysis/TransformationPipelineService.cs
+++ b/Services/XmlAnalysis/TransformationPipelineService.cs
@@ -110,6 +110,7 @@ namespace LayoutParserApi.Services.XmlAnalysis
                 if (string.IsNullOrEmpty(xslPath) || !File.Exists(xslPath))
                 {
                     result.Success = false;
+                    result.ErrorCode = "xsl_not_found";
                     result.Errors.Add($"Arquivo XSL não encontrado para transformação {sourceDocumentType} → {targetDocumentType}");
                     return result;
                 }
@@ -151,6 +152,7 @@ namespace LayoutParserApi.Services.XmlAnalysis
                 var mapContent = await LoadMappingFileAsync(layoutName);
                 if (mapContent == null)
                 {
+                    result.ErrorCode = "map_not_found";
                     result.Errors.Add($"Arquivo MAP não encontrado para layout: {layoutName}");
                     return null;
                 }
@@ -309,6 +311,7 @@ namespace LayoutParserApi.Services.XmlAnalysis
                 var xslPath = FindXslFile("Intermediate", targetDocumentType, layoutName);
                 if (string.IsNullOrEmpty(xslPath) || !File.Exists(xslPath))
                 {
+                    result.ErrorCode = "xsl_not_found";
                     result.Errors.Add($"Arquivo XSL não encontrado para transformação Intermediate → {targetDocumentType}");
                     return null;
                 }

--- a/security-code-scan-baseline.json
+++ b/security-code-scan-baseline.json
@@ -58,7 +58,7 @@
     { "code": "SCS0018", "file": "Services/Transformation/TransformationValidatorService.cs", "line": 232 },
     { "code": "SCS0018", "file": "Services/Validation/DocumentMLValidationService.cs", "line": 178 },
     { "code": "SCS0018", "file": "Services/Validation/DocumentMLValidationService.cs", "line": 206 },
-    { "code": "SCS0018", "file": "Services/XmlAnalysis/TransformationPipelineService.cs", "line": 390 },
+    { "code": "SCS0018", "file": "Services/XmlAnalysis/TransformationPipelineService.cs", "line": 393 },
     { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 221 },
     { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 235 },
     { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 340 }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -1,0 +1,266 @@
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Models;
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Transformation;
+using LayoutParserApi.Services.Database;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.Ai;
+using LayoutParserApi.Services.Transformation.LowCode;
+using LayoutParserApi.Services.XmlAnalysis;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Controllers
+{
+    /// <summary>
+    /// Issue LayoutParserReact #86: <c>POST execute-candidates</c> passa a devolver
+    /// <c>pathwayDiagnostics[]</c> populado (não mais sempre vazio) para os dois pathways síncronos
+    /// (sysmiddle, tcl-xsl). Reproduz, com documento/layout SINTÉTICOS (nunca dado real de cliente),
+    /// os dois cenários relatados na issue: "nenhum mapeador low-code" (sysmiddle) e "arquivo MAP não
+    /// encontrado" (tcl-xsl) — e confirma que cada pathway termina em exatamente 1 diagnóstico, nunca
+    /// silencioso.
+    ///
+    /// <para>Reaproveita o padrão de <c>TransformationPipelineServiceMapFileTests</c> (fixture mínima
+    /// de pastas TCL/XSL vazias) e de <c>LowCodeAutoTransformationCacheTests</c> (fake de
+    /// <see cref="MapperDatabaseService"/> devolvendo lista vazia — sem tocar runner/SQL real).</para>
+    /// </summary>
+    public class TransformationExecutionControllerPathwayDiagnosticsTests
+    {
+        private const string LayoutName = "LAY_SINTETICO_TESTE_ISSUE86";
+        private static readonly Guid LayoutGuid = Guid.Parse("00000000-0000-0000-0000-0000000000e8");
+
+        private sealed class FakeCurrentUser : ICurrentUser
+        {
+            public string? Name { get; set; } = "issue86-test-user";
+            public IReadOnlyList<string> Roles { get; set; } = Array.Empty<string>();
+            public bool IsAuthenticated => Name != null;
+            public bool IsInRole(string role) => Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class FakeLayoutDatabaseService : ILayoutDatabaseService
+        {
+            public Task<LayoutSearchResponse> SearchLayoutsAsync(LayoutSearchRequest request) =>
+                Task.FromResult(new LayoutSearchResponse
+                {
+                    Success = true,
+                    Layouts = new List<LayoutRecord> { new() { Name = LayoutName, LayoutGuid = LayoutGuid } }
+                });
+
+            public Task<LayoutRecord?> GetLayoutByIdAsync(int id) => Task.FromResult<LayoutRecord?>(null);
+        }
+
+        /// <summary>Mesmo papel do <c>MapperDbFalso</c> de <c>LowCodeAutoTransformationCacheTests</c>,
+        /// mas sempre devolvendo lista vazia — força <c>autoResult.Applicable == false</c> (Estado A,
+        /// "no_mapper") sem nunca tocar o runner x86 nem SQL real.</summary>
+        private sealed class MapperDbVazio : MapperDatabaseService
+        {
+            public MapperDbVazio(IConfiguration config) : base(NullLogger<MapperDatabaseService>.Instance, null!, config) { }
+
+            public override Task<List<Models.Entities.Mapper>> GetRankedMapperCandidatesForLayoutGuidAsync(
+                string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids)
+                => Task.FromResult(new List<Models.Entities.Mapper>());
+        }
+
+        private sealed class SpyAiCandidateService : IAiTransformationCandidateService
+        {
+            public int EnqueueCount { get; private set; }
+            public Task EnqueueAsync(string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
+                string inputContent, string? groundTruthXml, CancellationToken cancellationToken)
+            {
+                EnqueueCount++;
+                return Task.CompletedTask;
+            }
+
+            public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
+                Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });
+        }
+
+        private sealed class SpyAiFallbackSuppressionGate : IAiFallbackSuppressionGate
+        {
+            public bool IsInCooldown(Guid layoutGuid, out DateTimeOffset retryAt) { retryAt = default; return false; }
+            public void RegisterFailure(Guid layoutGuid, TimeSpan cooldown) { }
+            public void ClearCooldown(Guid layoutGuid) { }
+        }
+
+        /// <summary>
+        /// Constrói o controller real, com sysmiddle (<see cref="LowCodeAutoTransformationService"/>)
+        /// apontando para um <see cref="MapperDbVazio"/> (sem mapper cadastrado) e tcl-xsl
+        /// (<see cref="TransformationPipelineService"/>) apontando para uma pasta TCL temporária
+        /// vazia (sem <c>.tcl</c> para o layout) — reproduz os dois sintomas originais da issue #86
+        /// (candidates: [] + as duas mensagens de texto) com um payload 100% sintético.
+        /// </summary>
+        private static (TransformationExecutionController Controller, SpyAiCandidateService AiSpy, string TclDir) BuildController()
+        {
+            var raiz = Path.Combine(Path.GetTempPath(), "lp-tests", "execute-candidates-diag", Guid.NewGuid().ToString("N"));
+            var tclDir = Path.Combine(raiz, "tcl");
+            var xslDir = Path.Combine(raiz, "xsl");
+            Directory.CreateDirectory(tclDir);
+            Directory.CreateDirectory(xslDir);
+
+            var lowCodeConfig = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ML:LowCodeTransformationsPath"] = Path.Combine(raiz, "lowcode-store"),
+                    ["Logging:File:Directory"] = Path.Combine(raiz, "runner-logs")
+                })
+                .Build();
+
+            var lowCodeOptions = Options.Create(new LowCodeRunnerOptions
+            {
+                RunnerPath = "runner-inexistente.exe",
+                SysmiddleDir = Path.GetTempPath(),
+                GlobalFolder = Path.GetTempPath()
+            });
+
+            var store = new LowCodeTransformationStore(
+                NullLogger<LowCodeTransformationStore>.Instance, lowCodeConfig, lowCodeOptions, redis: null);
+
+            var mapperDb = new MapperDbVazio(lowCodeConfig);
+            var services = new ServiceCollection();
+            services.AddScoped<MapperDatabaseService>(_ => mapperDb);
+
+            // O runner (LowCodeTransformationService) nunca é chamado quando não há mapper — ver
+            // LowCodeAutoTransformationService.TransformAndPersistAsync (checa ranked.Count == 0 ANTES
+            // de tocar o runner). null! é seguro aqui pelo mesmo motivo documentado em
+            // TransformationExecutionControllerUserIsolationTests.BuildController.
+            var lowCodeAuto = new LowCodeAutoTransformationService(
+                NullLogger<LowCodeAutoTransformationService>.Instance,
+                services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+                null!,
+                store,
+                lowCodeOptions);
+
+            var pipelineConfig = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TransformationPipeline:TclPath"] = tclDir,
+                    ["TransformationPipeline:XslPath"] = xslDir,
+                })
+                .Build();
+            var pipelineService = new TransformationPipelineService(
+                NullLogger<TransformationPipelineService>.Instance, pipelineConfig);
+
+            var aiSpy = new SpyAiCandidateService();
+
+            var controller = new TransformationExecutionController(
+                NullLogger<TransformationExecutionController>.Instance,
+                pipelineService: pipelineService,
+                validatorService: null!,
+                learningService: null!,
+                autoGenerator: null!,
+                lowCode: null!,
+                lowCodeAuto: lowCodeAuto,
+                layoutDb: new FakeLayoutDatabaseService(),
+                lowCodeOptions: lowCodeOptions,
+                aiCandidateService: aiSpy,
+                aiFallbackGate: new SpyAiFallbackSuppressionGate(),
+                currentUser: new FakeCurrentUser());
+
+            return (controller, aiSpy, tclDir);
+        }
+
+        [Fact]
+        public async Task Sem_mapper_e_sem_tcl_pathwayDiagnostics_reporta_no_mapper_e_map_not_found()
+        {
+            var (controller, aiSpy, _) = BuildController();
+
+            var request = new TransformationRequest
+            {
+                InputContent = "000001DADOS POSICIONAIS SINTETICOS DE TESTE ISSUE86",
+                LayoutName = LayoutName,
+                LayoutGuid = LayoutGuid.ToString()
+            };
+
+            var actionResult = await controller.ExecuteTransformationCandidates(request);
+
+            var ok = Assert.IsType<OkObjectResult>(actionResult);
+            var response = Assert.IsType<TransformationExecutionCandidatesResponse>(ok.Value);
+
+            Assert.Empty(response.Candidates);
+            // CorrelationId pode ser null fora de um pipeline HTTP real (sem middleware de correlação
+            // no teste) — o contrato exige a PROPRIEDADE presente no shape (response.CorrelationId
+            // compila e existe), não um valor não-nulo neste cenário sem HttpContext.
+
+            // 3 diagnósticos: sysmiddle (no_mapper) + tcl-xsl (map_not_found) + ai-fallback
+            // (candidate_generated, ver asserção mais abaixo) — nenhum pathway fica silencioso.
+            Assert.Equal(3, response.PathwayDiagnostics.Count);
+
+            var sysmiddle = Assert.Single(response.PathwayDiagnostics, d => d.Pathway == "sysmiddle");
+            Assert.Equal("not_applicable", sysmiddle.Status);
+            Assert.Equal("no_mapper", sysmiddle.Code);
+            Assert.False(string.IsNullOrWhiteSpace(sysmiddle.Message));
+
+            var tclXsl = Assert.Single(response.PathwayDiagnostics, d => d.Pathway == "tcl-xsl");
+            Assert.Equal("failed", tclXsl.Status);
+            Assert.Equal("map_not_found", tclXsl.Code);
+            Assert.False(string.IsNullOrWhiteSpace(tclXsl.Message));
+
+            // Fallback de IA (Estado A: nenhum FailureKind.ExecutionInfraError, já que ambos os
+            // pathways síncronos reportaram not_applicable/failed com códigos de "não encontrado", não
+            // de infra) deve ter disparado — e ganha seu próprio 3º diagnóstico. Aqui o contrato do
+            // desenho (§4.3) classifica map_not_found/xsl_not_found como FailureKind.NotApplicable no
+            // controller, não ExecutionInfraError — então o fallback de IA continua elegível.
+            Assert.Equal(1, aiSpy.EnqueueCount);
+            var aiFallback = Assert.Single(response.PathwayDiagnostics, d => d.Pathway == "ai-fallback");
+            Assert.Equal("candidate_generated", aiFallback.Status);
+        }
+
+        [Fact]
+        public async Task Sem_mapper_e_sem_tcl_nenhuma_mensagem_vaza_caminho_de_disco()
+        {
+            var (controller, _, tclDir) = BuildController();
+
+            var request = new TransformationRequest
+            {
+                InputContent = "000001OUTRO DOCUMENTO SINTETICO DE TESTE",
+                LayoutName = LayoutName,
+                LayoutGuid = LayoutGuid.ToString()
+            };
+
+            var actionResult = await controller.ExecuteTransformationCandidates(request);
+            var ok = Assert.IsType<OkObjectResult>(actionResult);
+            var response = Assert.IsType<TransformationExecutionCandidatesResponse>(ok.Value);
+
+            foreach (var diag in response.PathwayDiagnostics)
+            {
+                Assert.DoesNotContain(@"C:\", diag.Message ?? "", StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain(tclDir, diag.Message ?? "", StringComparison.OrdinalIgnoreCase);
+            }
+            foreach (var warning in response.Warnings)
+            {
+                Assert.DoesNotContain(@"C:\", warning, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain(tclDir, warning, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public async Task Xsl_ausente_apos_tcl_resolvido_reporta_xsl_not_found()
+        {
+            var (controller, _, tclDir) = BuildController();
+
+            // Cria o .tcl (fixture mínima já usada em TransformationPipelineServiceMapFileTests) sem
+            // criar nenhum .xsl correspondente — força o caminho "MAP resolvido, XSL não encontrado".
+            var mapXml = "<MAP><LINE identifier=\"HEADER\" name=\"HEADER\"><FIELD name=\"data\" length=\"8\"/></LINE></MAP>";
+            await File.WriteAllTextAsync(Path.Combine(tclDir, $"{LayoutName}.tcl"), mapXml);
+
+            var request = new TransformationRequest
+            {
+                InputContent = "20260827SINTETICO",
+                LayoutName = LayoutName,
+                LayoutGuid = LayoutGuid.ToString()
+            };
+
+            var actionResult = await controller.ExecuteTransformationCandidates(request);
+            var ok = Assert.IsType<OkObjectResult>(actionResult);
+            var response = Assert.IsType<TransformationExecutionCandidatesResponse>(ok.Value);
+
+            var tclXsl = Assert.Single(response.PathwayDiagnostics, d => d.Pathway == "tcl-xsl");
+            Assert.Equal("failed", tclXsl.Status);
+            Assert.Equal("xsl_not_found", tclXsl.Code);
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -190,16 +190,18 @@ namespace LayoutParserApi.Tests.Controllers
         // TryEnqueueAiFallback é privado — mesma técnica de reflection do teste acima, pelo mesmo
         // motivo (exercitar o pathway sysmiddle real fugiria do escopo de um teste unitário).
 
-        private static void InvokeTryEnqueueAiFallback(
+        private static List<PathwayDiagnostic> InvokeTryEnqueueAiFallback(
             TransformationExecutionController controller, TransformationRequest request, LayoutRecord layoutRecord,
             bool isXmlInput, IEnumerable<FailureKind> failureKinds, List<string> warnings, string userId)
         {
             var bag = new System.Collections.Concurrent.ConcurrentBag<FailureKind>(failureKinds);
+            var diagnostics = new System.Collections.Concurrent.ConcurrentBag<PathwayDiagnostic>();
             var method = typeof(TransformationExecutionController)
                 .GetMethod("TryEnqueueAiFallback", BindingFlags.NonPublic | BindingFlags.Instance)
                 ?? throw new InvalidOperationException("Método TryEnqueueAiFallback não encontrado — o controller mudou de forma incompatível com este teste.");
 
-            method.Invoke(controller, new object?[] { request, layoutRecord, isXmlInput, bag, warnings, userId });
+            method.Invoke(controller, new object?[] { request, layoutRecord, isXmlInput, bag, warnings, diagnostics, userId });
+            return diagnostics.ToList();
         }
 
         [Fact]
@@ -219,13 +221,16 @@ namespace LayoutParserApi.Tests.Controllers
             var warnings = new List<string>();
 
             // Estado A: nenhum pathway falhou por infra — só "não aplicável"/"sem heurística".
-            InvokeTryEnqueueAiFallback(
+            var diagnostics = InvokeTryEnqueueAiFallback(
                 controller, request, layoutRecord, isXmlInput: false,
                 failureKinds: new[] { FailureKind.NotApplicable, FailureKind.NotApplicable },
                 warnings, "dave");
 
             Assert.Equal("dave", spy.LastEnqueueUserId);
             Assert.Contains(warnings, w => w.Contains("fallback automático de IA enfileirado", StringComparison.OrdinalIgnoreCase));
+            var diag = Assert.Single(diagnostics);
+            Assert.Equal("ai-fallback", diag.Pathway);
+            Assert.Equal("candidate_generated", diag.Status);
         }
 
         [Fact]
@@ -246,14 +251,16 @@ namespace LayoutParserApi.Tests.Controllers
 
             // Estado B: pelo menos um pathway falhou por infra — mapper existe, IA não deve tentar
             // recriar algo que já é a fonte de verdade (regressão explícita do caso já diagnosticado
-            // em diagnostico-mapper-nao-encontrado-producao-2026-08-15.md).
-            InvokeTryEnqueueAiFallback(
+            // em diagnostico-mapper-nao-encontrado-producao-2026-08-15.md). Nenhum diagnóstico próprio
+            // de "ai-fallback" é emitido aqui — o item failed do pathway que quebrou já é o sinal.
+            var diagnostics = InvokeTryEnqueueAiFallback(
                 controller, request, layoutRecord, isXmlInput: false,
                 failureKinds: new[] { FailureKind.ExecutionInfraError, FailureKind.NotApplicable },
                 warnings, "erin");
 
             Assert.Null(spy.LastEnqueueUserId);
             Assert.DoesNotContain(warnings, w => w.Contains("fallback automático de IA enfileirado", StringComparison.OrdinalIgnoreCase));
+            Assert.Empty(diagnostics);
         }
 
         // --- TAREFA 3 (regressão geral): os 3 endpoints deixaram de exigir o papel "admin" ---


### PR DESCRIPTION
## Resumo

Referencia/resolve `LayoutParser/LayoutParserReact#86` (candidates vazio sem diagnóstico estruturado no `execute-candidates`).

### Causa raiz
O bug de "candidates vazio" propriamente dito já havia sido corrigido antes da issue ser aberta. O gap real era a **ausência de um contrato estruturado de diagnóstico**: quando um pathway (Pathway 1/Pathway 2) não produzia candidato, a API não expunha *por quê* de forma legível/correlacionável — só logs internos, sem retorno estruturado ao consumidor (BFF/front).

### Contrato novo
- `pathwayDiagnostics[]` no payload de resposta do `execute-candidates`, um item por pathway avaliado, com taxonomia de `status`/`code` (ex.: `not_applicable`, `failed`, sucesso).
- `correlationId` propagado ponta a ponta (resposta + logging estruturado), permitindo cruzar a resposta HTTP com os logs do servidor para o mesmo request.
- Logging estruturado (`ILogger`, mensagens com parâmetros nomeados) nos ramos `not_applicable`/`failed` de cada pathway, incluindo o `correlationId`.
- Fix de sanitização do fragmento `tcl-xsl` que atravessava os diagnósticos (evita quebra de contrato quando o conteúdo do XSLT/TCL contém caracteres problemáticos).

### Documentação
Diagnóstico completo do investigação em `docs/architecture/diagnostico-issue-86-diagnostico-estruturado-execute-candidates.md`, além de atualização de Swagger/README cobrindo o novo formato de resposta.

### Testes
- `dotnet build`: 0 erros (só warnings pré-existentes, SCS0005 etc.)
- `dotnet test`: 399 passando (388 + 11 XslSynth.Core.Tests), 4 falhas pré-existentes de path Windows×Linux (não relacionadas a esta mudança — `SafePathResolverTests`, `LowCodeRunnerArgsTests` x3)
- Novos testes desta branch: `TransformationExecutionControllerPathwayDiagnosticsTests` (cobrindo os novos ramos de diagnóstico estruturado)

## Test plan
- [x] `dotnet build` limpo
- [x] `dotnet test` sem regressão (mesmas 4 falhas pré-existentes de path)
- [ ] Revisão do dono antes de merge (merge NÃO será feito por este PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>