### PR TITLE
fix(security): sanear 47 alertas CodeQL de log-forging (cs/log-forging) + descartar 3 falso-positivos de exposure

### DIFF
--- a/Controllers/ParseController.cs
+++ b/Controllers/ParseController.cs
@@ -553,7 +553,7 @@ namespace LayoutParserApi.Controllers
                 if (!Directory.Exists(layoutDirectory))
                 {
                     Directory.CreateDirectory(layoutDirectory);
-                    _logger.LogInformation("Diretório criado: {Path}", layoutDirectory);
+                    _logger.LogInformation("Diretório criado: {Path}", Services.Logging.LogMessageSanitizer.Sanitize(layoutDirectory));
                 }
 
                 // Salvar com nome totalmente gerado pelo servidor.

--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -369,6 +369,10 @@ namespace LayoutParserApi.Controllers
             CancellationToken cancellationToken)
         {
             var result = new List<TransformationCandidate>();
+            // ✅ CodeQL cs/log-forging: LayoutName vem do request (usuário) e pode conter \r/\n —
+            // saneia UMA VEZ aqui e reusa nos logs deste método (o valor cru continua sendo usado
+            // fora dos logs — SearchTerm, ticket, EnqueueAsync — onde forjar log não se aplica).
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(request.LayoutName);
 
             // Sysmiddle/low-code espera texto posicional (TXT), não XML — não é uma falha do
             // pathway, é entrada fora de escopo (a IA não deveria disparar por causa disso).
@@ -376,7 +380,7 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogInformation(
                     "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} motivo=entrada XML fora do escopo do pathway sysmiddle",
-                    Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", request.LayoutName);
+                    Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", safeLayoutName);
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "sysmiddle",
@@ -390,6 +394,7 @@ namespace LayoutParserApi.Controllers
             try
             {
                 var resolvedLayoutGuid = LowCodeLayoutGuidResolver.Resolve(request.LayoutGuid, layoutRecord.LayoutGuid);
+                var safeResolvedLayoutGuid = Services.Logging.LogMessageSanitizer.Sanitize(resolvedLayoutGuid);
                 if (resolvedLayoutGuid == null)
                 {
                     var msg = $"Layout {request.LayoutName} sem LayoutGuid válido no request ou no catálogo — pathway sysmiddle não aplicável";
@@ -397,7 +402,7 @@ namespace LayoutParserApi.Controllers
                     failureKinds.Add(FailureKind.NotApplicable);
                     _logger.LogInformation(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=request.LayoutGuid/catalogo (nenhum resolvível)",
-                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", request.LayoutName);
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "not_applicable", safeLayoutName);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -429,7 +434,7 @@ namespace LayoutParserApi.Controllers
                     failureKinds.Add(FailureKind.NotApplicable);
                     _logger.LogInformation(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=catalogo (consulta a mapeadores low-code sem resultado)",
-                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "no_mapper", request.LayoutName, resolvedLayoutGuid);
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "not_applicable", "no_mapper", safeLayoutName, safeResolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -458,7 +463,7 @@ namespace LayoutParserApi.Controllers
                         {
                             _logger.LogWarning(
                                 "fieldMappings (issue #141): parse posicional compartilhado falhou para layout {LayoutName} — candidatos sysmiddle seguem sem fieldMappings. Erro={ErrorMessage}",
-                                request.LayoutName, sharedParsingResult.ErrorMessage);
+                                safeLayoutName, Services.Logging.LogMessageSanitizer.Sanitize(sharedParsingResult.ErrorMessage));
                             sharedParsingResult = null;
                         }
                     }
@@ -467,7 +472,7 @@ namespace LayoutParserApi.Controllers
                         // Nunca deixa a composição de fieldMappings afetar o XML já produzido pelo runner.
                         _logger.LogWarning(parseEx,
                             "fieldMappings (issue #141): exceção no parse posicional compartilhado para layout {LayoutName} — candidatos sysmiddle seguem sem fieldMappings",
-                            request.LayoutName);
+                            safeLayoutName);
                         sharedParsingResult = null;
                     }
                 }
@@ -513,7 +518,7 @@ namespace LayoutParserApi.Controllers
                 {
                     _logger.LogInformation(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} layoutGuid={LayoutGuid} candidatos={CandidateCount} fonte=mapeadores low-code do catalogo",
-                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "candidate_generated", request.LayoutName, resolvedLayoutGuid, result.Count);
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "candidate_generated", safeLayoutName, safeResolvedLayoutGuid, result.Count);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -528,7 +533,7 @@ namespace LayoutParserApi.Controllers
                     // falharam na execução — infra/runner, não gap de cobertura (§4.3 "runner_unavailable").
                     _logger.LogWarning(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=execução do runner (mapper existe, execução falhou)",
-                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "runner_unavailable", request.LayoutName, resolvedLayoutGuid);
+                        Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "runner_unavailable", safeLayoutName, safeResolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "sysmiddle",
@@ -542,7 +547,7 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogWarning(ex,
                     "Falha estrutural no pathway sysmiddle ao gerar candidatos para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
-                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "execution_error");
+                    safeLayoutName, Services.Logging.CorrelationContext.CurrentId, "sysmiddle", "failed", "execution_error");
                 // Saneado: exceção de I/O deste pathway carrega caminho de disco do servidor e este
                 // warning sai no payload 200 (mesmo defeito do §3.1 da spec, outro ponto de saída).
                 var sanitizedEx = LowCodeErrorSanitizer.ForWire(ex);
@@ -588,7 +593,7 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogWarning(ex,
                     "fieldMappings (issue #141): falha ao compor mapeamentos estruturais para candidato mapper={MapperGuid} do layout {LayoutName}",
-                    candidate.MapperGuid, layoutName);
+                    candidate.MapperGuid, Services.Logging.LogMessageSanitizer.Sanitize(layoutName));
                 warnings.Add($"Candidato {candidate.MapperGuid} (pathway sysmiddle): falha ao compor fieldMappings — ver log do servidor");
                 return null;
             }
@@ -617,6 +622,8 @@ namespace LayoutParserApi.Controllers
             // do job em background, junto com o resto do trabalho de EnqueueAsync/RunLoopAsync —
             // capturamos só o conteúdo bruto aqui (string), nada de IO/CPU síncrono.
             var layoutName = request.LayoutName;
+            // ✅ CodeQL cs/log-forging: valor saneado só para logging deste job em background.
+            var safeLayoutNameForLog = Services.Logging.LogMessageSanitizer.Sanitize(layoutName);
             var decryptedLayoutContent = layoutRecord.DecryptedContent;
             var inputContent = request.InputContent;
 
@@ -655,7 +662,7 @@ namespace LayoutParserApi.Controllers
                     {
                         _logger.LogDebug(parseEx,
                             "Pathway IA: parse posicional para ParsedFieldRootTreeBuilder falhou — motor novo degrada para o loop legado (layout={LayoutName})",
-                            layoutName);
+                            safeLayoutNameForLog);
                     }
                 }
 
@@ -678,7 +685,7 @@ namespace LayoutParserApi.Controllers
                 {
                     // EnqueueAsync não deveria lançar (contrato do serviço), mas isolamento total aqui
                     // também — nunca derrubar o job em background por causa da IA.
-                    _logger.LogWarning(ex, "Falha ao disparar o pathway IA para layout {LayoutName}", layoutName);
+                    _logger.LogWarning(ex, "Falha ao disparar o pathway IA para layout {LayoutName}", safeLayoutNameForLog);
                 }
             }, CancellationToken.None); // O próprio Task.Run não deve morrer com a request HTTP.
         }
@@ -698,6 +705,8 @@ namespace LayoutParserApi.Controllers
             ConcurrentBag<FailureKind> failureKinds, List<string> warnings,
             ConcurrentBag<Models.Transformation.PathwayDiagnostic> pathwayDiagnostics, string userId)
         {
+            // ✅ CodeQL cs/log-forging: saneado uma vez, reusado só nos logs deste método.
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(request.LayoutName);
             try
             {
                 if (failureKinds.Any(k => k == FailureKind.ExecutionInfraError))
@@ -717,7 +726,7 @@ namespace LayoutParserApi.Controllers
                     warnings.Add(msg);
                     _logger.LogInformation(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=request.LayoutGuid/catalogo (nenhum resolvível)",
-                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", request.LayoutName);
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", safeLayoutName);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -734,7 +743,7 @@ namespace LayoutParserApi.Controllers
                     warnings.Add(msg);
                     _logger.LogInformation(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=IAiFallbackSuppressionGate (cooldown ativo até {RetryAt})",
-                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", request.LayoutName, resolvedLayoutGuid, retryAt);
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "not_applicable", "not_applicable", safeLayoutName, resolvedLayoutGuid, retryAt);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -752,7 +761,7 @@ namespace LayoutParserApi.Controllers
                     warnings.Add(msg);
                     _logger.LogWarning(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} layoutGuid={LayoutGuid} fonte=LowCodeTransformationStore.BuildTicketFromContent (retornou null)",
-                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "configuration_error", request.LayoutName, resolvedLayoutGuid);
+                        Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "configuration_error", safeLayoutName, resolvedLayoutGuid);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "ai-fallback",
@@ -784,7 +793,7 @@ namespace LayoutParserApi.Controllers
                 // sentido de estar em processamento").
                 _logger.LogInformation(
                     "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} layoutGuid={LayoutGuid} ticket={Ticket} fonte=IAiTransformationCandidateService.EnqueueAsync (sem gabarito)",
-                    Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "candidate_generated", request.LayoutName, resolvedLayoutGuid, ticket);
+                    Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "candidate_generated", safeLayoutName, resolvedLayoutGuid, Services.Logging.LogMessageSanitizer.Sanitize(ticket));
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "ai-fallback",
@@ -797,7 +806,7 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogWarning(ex,
                     "Falha ao disparar o fallback automático de IA para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
-                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "execution_error");
+                    safeLayoutName, Services.Logging.CorrelationContext.CurrentId, "ai-fallback", "failed", "execution_error");
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
                     Pathway = "ai-fallback",
@@ -847,6 +856,8 @@ namespace LayoutParserApi.Controllers
             ConcurrentBag<Models.Transformation.PathwayDiagnostic> pathwayDiagnostics)
         {
             var result = new List<TransformationCandidate>();
+            // ✅ CodeQL cs/log-forging: saneado uma vez, reusado só nos logs deste método.
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(request.LayoutName);
 
             try
             {
@@ -881,7 +892,7 @@ namespace LayoutParserApi.Controllers
                     };
                     _logger.LogWarning(
                         "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code} layout={LayoutName} fonte=TransformationPipelineService.ErrorCode={ErrorCode}",
-                        Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", code, request.LayoutName, pipelineResult.ErrorCode);
+                        Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", code, safeLayoutName, pipelineResult.ErrorCode);
                     pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                     {
                         Pathway = "tcl-xsl",
@@ -908,7 +919,7 @@ namespace LayoutParserApi.Controllers
                     {
                         // Falha de validação não invalida o candidato em si (o XML transformado existe) —
                         // só fica sem o campo Validation preenchido.
-                        _logger.LogWarning(ex, "Falha ao validar candidato tcl-xsl para layout {LayoutName}", request.LayoutName);
+                        _logger.LogWarning(ex, "Falha ao validar candidato tcl-xsl para layout {LayoutName}", safeLayoutName);
                         // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
                         warnings.Add($"Validação do candidato tcl-xsl falhou: {LowCodeErrorSanitizer.ForWire(ex)}");
                     }
@@ -935,7 +946,7 @@ namespace LayoutParserApi.Controllers
 
                 _logger.LogInformation(
                     "PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} layout={LayoutName} tclPath={TclPath} xslPath={XslPath} fonte=TransformationPipelineService",
-                    Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "candidate_generated", request.LayoutName,
+                    Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "candidate_generated", safeLayoutName,
                     System.IO.Path.GetFileName(pipelineResult.TclPath), System.IO.Path.GetFileName(pipelineResult.XslPath));
                 pathwayDiagnostics.Add(new Models.Transformation.PathwayDiagnostic
                 {
@@ -949,7 +960,7 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogWarning(ex,
                     "Falha estrutural no pathway tcl-xsl ao gerar candidato para layout {LayoutName}. PathwayDiagnostic {CorrelationId}: pathway={Pathway} status={Status} code={Code}",
-                    request.LayoutName, Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", "execution_error");
+                    safeLayoutName, Services.Logging.CorrelationContext.CurrentId, "tcl-xsl", "failed", "execution_error");
                 // Saneado (§5 do diagnóstico-issue-86): mesmo padrão do sysmiddle (linha ~385).
                 var sanitizedTclXslEx = LowCodeErrorSanitizer.ForWire(ex);
                 warnings.Add($"Pathway tcl-xsl falhou: {sanitizedTclXslEx}");
@@ -1164,6 +1175,8 @@ namespace LayoutParserApi.Controllers
                 return BadRequest(new { success = false, error = "LayoutName e InputContent são obrigatórios" });
 
             var warnings = new List<string>();
+            // ✅ CodeQL cs/log-forging: saneado uma vez, reusado nos logs deste endpoint.
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(request.LayoutName);
 
             LayoutRecord? layoutRecord;
             try
@@ -1177,7 +1190,7 @@ namespace LayoutParserApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Falha de infraestrutura ao resolver layout {LayoutName} para field-mappings", request.LayoutName);
+                _logger.LogError(ex, "Falha de infraestrutura ao resolver layout {LayoutName} para field-mappings", safeLayoutName);
                 return StatusCode(500, new { success = false, error = "Falha de infraestrutura ao consultar o catálogo de layouts" });
             }
 
@@ -1230,7 +1243,7 @@ namespace LayoutParserApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Falha ao compor field mappings para layout {LayoutName}", request.LayoutName);
+                _logger.LogError(ex, "Falha ao compor field mappings para layout {LayoutName}", safeLayoutName);
                 warnings.Add("Falha ao compor mapeamentos estruturais — ver log do servidor");
                 return Ok(new { success = true, fieldMappings = Array.Empty<object>(), warnings });
             }

--- a/Program.cs
+++ b/Program.cs
@@ -772,6 +772,10 @@ try
         var correlationId = context.Request.Headers["X-Correlation-ID"].FirstOrDefault();
         if (string.IsNullOrWhiteSpace(correlationId))
             correlationId = Guid.NewGuid().ToString();
+        else
+            // ✅ CodeQL cs/log-forging: X-Correlation-ID vem do cliente e é ecoado em TODO log da
+            // request (LogContext abaixo) — saneia aqui uma única vez em vez de em cada call site.
+            correlationId = LayoutParserApi.Services.Logging.LogMessageSanitizer.Sanitize(correlationId, maxLength: 200);
 
         context.Response.Headers["X-Correlation-ID"] = correlationId;
         CorrelationContext.CurrentId = correlationId;

--- a/Services/Database/DecryptionService.cs
+++ b/Services/Database/DecryptionService.cs
@@ -205,12 +205,16 @@ namespace LayoutParserApi.Services.Database
 
             if (winner != allTask)
             {
+                // ✅ CodeQL cs/log-forging: correlationId pode ecoar o header X-Correlation-ID do
+                // cliente — já saneado uma vez no middleware (Program.cs), saneia de novo aqui por
+                // segurança (defesa em profundidade, este método também é chamável fora do pipeline HTTP).
+                var safeCorrelationId = Services.Logging.LogMessageSanitizer.Sanitize(correlationId);
                 _logger.LogError(
                     "Legacy decryptor excedeu o timeout de {TimeoutMs}ms (corr={CorrelationId}) — matando processo",
-                    TimeoutMs, correlationId);
+                    TimeoutMs, safeCorrelationId);
 
                 try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
-                catch (Exception killEx) { _logger.LogWarning(killEx, "Falha ao matar processo do decryptor (corr={CorrelationId})", correlationId); }
+                catch (Exception killEx) { _logger.LogWarning(killEx, "Falha ao matar processo do decryptor (corr={CorrelationId})", safeCorrelationId); }
 
                 // Best effort: janela curta para o kill liberar os streams antes de desistir.
                 try { await Task.WhenAny(allTask, Task.Delay(TimeSpan.FromSeconds(2))); } catch { }

--- a/Services/Database/SqlIdentityWorkspaceStore.cs
+++ b/Services/Database/SqlIdentityWorkspaceStore.cs
@@ -90,7 +90,7 @@ namespace LayoutParserApi.Services.Database
                     // INSERT. Não é erro — relê o UserId que já existe (idempotência sob concorrência,
                     // critério de aceite #3 do contrato cross-repo).
                     await tx.RollbackAsync(cancellationToken);
-                    _logger.LogInformation("Corrida de criação de identidade externa detectada (provider={Provider}); relendo UserId existente.", provider);
+                    _logger.LogInformation("Corrida de criação de identidade externa detectada (provider={Provider}); relendo UserId existente.", Services.Logging.LogMessageSanitizer.Sanitize(provider));
                 }
                 catch
                 {

--- a/Services/Identity/IdentityWorkspaceService.cs
+++ b/Services/Identity/IdentityWorkspaceService.cs
@@ -48,7 +48,8 @@ namespace LayoutParserApi.Services.Identity
             {
                 // Fail-closed: identidade externa não resolvida vira UserId null. O chamador (endpoint)
                 // nega acesso — nunca degrada para "segue sem filtro". Nunca logar subject.
-                _logger.LogWarning(ex, "Falha ao resolver identidade externa (provider={Provider}, tenant={Tenant}) — negando UserId (fail-closed).", provider, tenant);
+                _logger.LogWarning(ex, "Falha ao resolver identidade externa (provider={Provider}, tenant={Tenant}) — negando UserId (fail-closed).",
+                    Services.Logging.LogMessageSanitizer.Sanitize(provider), Services.Logging.LogMessageSanitizer.Sanitize(tenant));
                 return null;
             }
             finally

--- a/Services/Implementations/AuditLogger .cs
+++ b/Services/Implementations/AuditLogger .cs
@@ -14,7 +14,14 @@ namespace LayoutParserApi.Services.Implementations
 
         public void LogAudit(AuditLogEntry entry)
         {
-            _logger.LogInformation("AUDIT | UserId:{UserId} | RequestId:{RequestId} | Endpoint:{Endpoint} | Action:{Action} | Details:{Details}",entry.UserId, entry.RequestId, entry.Endpoint, entry.Action, entry.Details);
+            // ✅ CodeQL cs/log-forging: entry.* vem do request (endpoint/ação/detalhes do usuário) e
+            // este log também é fonte de auditoria — CRLF cru forjaria linhas de auditoria falsas.
+            _logger.LogInformation("AUDIT | UserId:{UserId} | RequestId:{RequestId} | Endpoint:{Endpoint} | Action:{Action} | Details:{Details}",
+                Services.Logging.LogMessageSanitizer.Sanitize(entry.UserId),
+                Services.Logging.LogMessageSanitizer.Sanitize(entry.RequestId),
+                Services.Logging.LogMessageSanitizer.Sanitize(entry.Endpoint),
+                Services.Logging.LogMessageSanitizer.Sanitize(entry.Action),
+                Services.Logging.LogMessageSanitizer.Sanitize(entry.Details));
         }
     }
 
@@ -29,10 +36,18 @@ namespace LayoutParserApi.Services.Implementations
 
         public void LogTechnical(LogEntry entry)
         {
+            // ✅ CodeQL cs/log-forging: mesmo motivo do AuditLogger acima — entry.* é derivado do request.
             if (entry.Level == "Error" && entry.Exception != null)
-                _logger.LogError(entry.Exception,"TECH | RequestId:{RequestId} | Endpoint:{Endpoint} | Message:{Message}",entry.RequestId, entry.Endpoint, entry.Message);
+                _logger.LogError(entry.Exception, "TECH | RequestId:{RequestId} | Endpoint:{Endpoint} | Message:{Message}",
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.RequestId),
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.Endpoint),
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.Message));
             else
-                _logger.LogInformation("TECH | Level:{Level} | RequestId:{RequestId} | Endpoint:{Endpoint} | Message:{Message}",entry.Level, entry.RequestId, entry.Endpoint, entry.Message);
+                _logger.LogInformation("TECH | Level:{Level} | RequestId:{RequestId} | Endpoint:{Endpoint} | Message:{Message}",
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.Level),
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.RequestId),
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.Endpoint),
+                    Services.Logging.LogMessageSanitizer.Sanitize(entry.Message));
         }
     }
 

--- a/Services/Testing/AutomatedTransformationTestService.cs
+++ b/Services/Testing/AutomatedTransformationTestService.cs
@@ -127,7 +127,7 @@ namespace LayoutParserApi.Services.Testing
                 {
                     _logger.LogWarning(
                         "Tentativa de acessar diretório de exemplos fora da base permitida: {ExamplesDirectory}",
-                        examplesDirectory);
+                        Services.Logging.LogMessageSanitizer.Sanitize(examplesDirectory));
                     result.Success = false;
                     result.Errors.Add("Diretório de exemplos fora da área permitida.");
                     return result;
@@ -244,7 +244,7 @@ namespace LayoutParserApi.Services.Testing
                     documentType = "NFe";
                     _logger.LogWarning(
                         "Não foi possível detectar o tipo de documento a partir do layout {LayoutName}; usando fallback {FallbackType}",
-                        layoutName, documentType);
+                        Services.Logging.LogMessageSanitizer.Sanitize(layoutName), documentType);
                 }
 
                 // Executar transformação

--- a/Services/Transformation/Ai/AiTransformationCandidateService.cs
+++ b/Services/Transformation/Ai/AiTransformationCandidateService.cs
@@ -165,7 +165,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "IXslSynthesizerService indisponível/falhou — degradando para o loop XML-direto legado (mapperGuid={MapperGuid})", mapperGuid);
+                _logger.LogDebug(ex, "IXslSynthesizerService indisponível/falhou — degradando para o loop XML-direto legado (mapperGuid={MapperGuid})", Services.Logging.LogMessageSanitizer.Sanitize(mapperGuid));
                 return null;
             }
         }
@@ -341,7 +341,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 }
                 catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
                 {
-                    _logger.LogWarning(ex, "Ollama indisponível/timeout no fallback IA (ticket={Ticket}, iteração={Iteration})", ticket, iteration);
+                    _logger.LogWarning(ex, "Ollama indisponível/timeout no fallback IA (ticket={Ticket}, iteração={Iteration})", Services.Logging.LogMessageSanitizer.Sanitize(ticket), iteration);
                     _store.Set(userId, ticket, new AiCandidateStatus
                     {
                         Status = AiCandidateStatus.StatusFailed,

--- a/Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs
+++ b/Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs
@@ -62,6 +62,10 @@ namespace LayoutParserApi.Services.Transformation.Ai
             CancellationToken cancellationToken,
             IReadOnlyList<ParsedField>? parsedFields = null)
         {
+            // ✅ CodeQL cs/log-forging: mapperGuid/layoutName vêm do request (ticket assíncrono de
+            // IA) e podem conter \r/\n — saneia uma vez, reusa só nos logs deste serviço.
+            var safeMapperGuid = Services.Logging.LogMessageSanitizer.Sanitize(mapperGuid);
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(layoutName);
             try
             {
                 var mapper = await ResolveMapperAsync(mapperGuid, cancellationToken);
@@ -88,13 +92,13 @@ namespace LayoutParserApi.Services.Transformation.Ai
                     {
                         _logger.LogWarning(
                             "ParsedFieldRootTreeBuilder recusou montar o ROOT (gate de qualidade) — {Motivo} (mapperGuid={MapperGuid})",
-                            built.Motivo, mapperGuid);
+                            built.Motivo, safeMapperGuid);
                         return Failed($"Não foi possível montar o XML de entrada a partir do parse posicional: {built.Motivo}");
                     }
 
                     _logger.LogInformation(
                         "ROOT construído via ParsedFieldRootTreeBuilder: {LinhasDistintas} tipo(s) de linha, {ComValor}/{Total} campo(s) com valor (mapperGuid={MapperGuid})",
-                        built.LinhasDistintas, built.CamposComValor, built.CamposFisicos, mapperGuid);
+                        built.LinhasDistintas, built.CamposComValor, built.CamposFisicos, safeMapperGuid);
                     input = built.Root;
                 }
                 else
@@ -107,7 +111,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                     {
                         // Sem ParsedFields e a entrada também não é XML bem-formado (TXT posicional
                         // cru) — nada com que construir o input do RepairOrchestrator.
-                        _logger.LogWarning(ex, "Entrada não é XML bem-formado e nenhum ParsedField foi informado — RepairOrchestrator não tem como montar o documento de entrada (mapperGuid={MapperGuid})", mapperGuid);
+                        _logger.LogWarning(ex, "Entrada não é XML bem-formado e nenhum ParsedField foi informado — RepairOrchestrator não tem como montar o documento de entrada (mapperGuid={MapperGuid})", safeMapperGuid);
                         return Failed("Entrada não é XML válido e nenhum ParsedField foi informado — RepairOrchestrator exige o documento já convertido (low-code) ou o resultado do parse posicional.");
                     }
                 }
@@ -115,7 +119,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 var xsdPath = ResolveXsdPath(groundTruthXml);
                 if (xsdPath is null)
                 {
-                    _logger.LogWarning("XSD não resolvido para o gabarito (mapperGuid={MapperGuid}) — validação XSD do loop sempre reportará inválido", mapperGuid);
+                    _logger.LogWarning("XSD não resolvido para o gabarito (mapperGuid={MapperGuid}) — validação XSD do loop sempre reportará inválido", safeMapperGuid);
                 }
 
                 var synthesizer = CreateOllamaSynthesizer();
@@ -154,7 +158,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
             {
                 // Resiliência (dotnet-standards.md): Ollama/RepairOrchestrator podem falhar —
                 // nunca propaga exceção não tratada pro chamador (fire-and-forget).
-                _logger.LogError(ex, "Falha não tratada na síntese de XSLT via RepairOrchestrator (mapperGuid={MapperGuid})", mapperGuid);
+                _logger.LogError(ex, "Falha não tratada na síntese de XSLT via RepairOrchestrator (mapperGuid={MapperGuid})", safeMapperGuid);
                 return Failed($"Falha interna na síntese de XSLT: {ex.Message}");
             }
         }
@@ -193,7 +197,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "MapeadorVO do mapper {MapperGuid} não é XML bem-formado", mapperGuid);
+                _logger.LogWarning(ex, "MapeadorVO do mapper {MapperGuid} não é XML bem-formado", Services.Logging.LogMessageSanitizer.Sanitize(mapperGuid));
                 return null;
             }
         }
@@ -202,22 +206,23 @@ namespace LayoutParserApi.Services.Transformation.Ai
         /// devolvido convergido ao chamador via <see cref="XslSynthesisResult"/>).</summary>
         private void TryPersistXslt(string? mapperName, string layoutName, string xslt)
         {
+            var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(layoutName);
             try
             {
                 if (string.IsNullOrWhiteSpace(mapperName))
                 {
-                    _logger.LogWarning("Não foi possível persistir o XSLT sintetizado — mapper sem Name (layout={LayoutName})", layoutName);
+                    _logger.LogWarning("Não foi possível persistir o XSLT sintetizado — mapper sem Name (layout={LayoutName})", safeLayoutName);
                     return;
                 }
 
                 Directory.CreateDirectory(_xslBasePath);
                 var path = Path.Combine(_xslBasePath, $"{mapperName}_{layoutName}.xsl");
                 File.WriteAllText(path, xslt);
-                _logger.LogInformation("XSLT sintetizado via RepairOrchestrator persistido em {Path}", path);
+                _logger.LogInformation("XSLT sintetizado via RepairOrchestrator persistido em {Path}", Services.Logging.LogMessageSanitizer.Sanitize(path));
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha ao persistir o XSLT sintetizado (layout={LayoutName})", layoutName);
+                _logger.LogWarning(ex, "Falha ao persistir o XSLT sintetizado (layout={LayoutName})", safeLayoutName);
             }
         }
 

--- a/Services/Transformation/TransformationValidatorService.cs
+++ b/Services/Transformation/TransformationValidatorService.cs
@@ -88,7 +88,7 @@ namespace LayoutParserApi.Services.Transformation
                     documentType = "NFe";
                     _logger.LogWarning(
                         "Não foi possível detectar o tipo de documento a partir do layout {LayoutName}; usando fallback {FallbackType}",
-                        layoutName, documentType);
+                        Services.Logging.LogMessageSanitizer.Sanitize(layoutName), documentType);
                 }
 
                 // Passo 2: Executar transformação completa

--- a/docs/architecture/triagem-codeql-69-alertas-2026-08-31.md
+++ b/docs/architecture/triagem-codeql-69-alertas-2026-08-31.md
@@ -1,0 +1,104 @@
+# Triagem CodeQL — 69 alertas (2026-08-31)
+
+Repositório ficou público de novo e o CodeQL nativo (default setup) rodou pela primeira vez,
+abrindo 69 alertas `medium`: 66 `cs/log-forging` (CWE-117) + 3 `cs/exposure-of-sensitive-information`
+(CWE-359).
+
+## Causa raiz — `cs/log-forging` (66 alertas)
+
+O projeto já segue o padrão de logging estruturado (`_logger.LogX("... {Param}", valor)`, nunca
+interpolação/concatenação) — **não é** o defeito que o CodeQL está sinalizando. O CodeQL flagra
+mesmo parâmetros estruturados quando o **valor em si** pode conter `\r`/`\n` e nunca é
+sanitizado antes de virar argumento de log: um valor vindo do request com uma quebra de linha
+crua forja uma linha de log falsa (2 origens confirmadas de risco real neste projeto, não
+teórico):
+
+1. **`X-Correlation-ID`** (header aceito do cliente, `Program.cs`) — ecoado em praticamente todo
+   log da API via `Services.Logging.CorrelationContext.CurrentId`/Serilog `LogContext`. Era o
+   maior raio de exposição: um único ponto vazando pra dezenas de call sites.
+2. **`LayoutName`/`LayoutGuid`/`mapperGuid`/`ticket`/mensagens de erro que ecoam nomes** — vêm do
+   corpo do request em `TransformationExecutionController`, `RepairOrchestratorXslSynthesizerService`,
+   `AiTransformationCandidateService`, etc.
+
+Já existia o helper certo para isso — `Services/Logging/LogMessageSanitizer.cs` (criado em
+2026-07-30 pela QA/Quinn depois de um incidente real: um stack trace colado num campo de
+observação injetou uma "geração fantasma" no painel de métricas de IA). `Sanitize(string?)`
+achata CRLF/LF/CR e trunca em 4000 chars por padrão. **REUSADO** em vez de recriar — decisão IDS.
+
+## Correção aplicada
+
+### 1) Fix de raiz único — `Program.cs` (middleware de CorrelationId)
+
+```csharp
+correlationId = LayoutParserApi.Services.Logging.LogMessageSanitizer.Sanitize(correlationId, maxLength: 200);
+```
+
+Saneia o `X-Correlation-ID` vindo do cliente **uma única vez**, na origem — cobre todo log que
+usa `CorrelationContext.CurrentId`/`LogContext` no resto da API, sem precisar tocar em cada call
+site individual que loga `{CorrelationId}`.
+
+### 2) Sanitização local nos demais pontos (47 linhas únicas flagadas em 10 arquivos)
+
+Padrão aplicado: declarar uma variável `safe*` saneada **uma vez por método** (não por log call)
+logo onde o valor tainted entra no escopo, e trocar só as referências usadas em `_logger.Log*`
+— o valor cru continua intacto em lógica de negócio (busca no catálogo, comparação, montagem de
+ticket, `EnqueueAsync`), onde forjar log não se aplica.
+
+| Arquivo | Alertas | O que foi saneado |
+|---|---|---|
+| `Controllers/TransformationExecutionController.cs` | 23 linhas únicas (41 alertas, dobrados por LayoutName+LayoutGuid no mesmo call) | `request.LayoutName`, `resolvedLayoutGuid`, `sharedParsingResult.ErrorMessage`, `layoutName` local, `ticket` |
+| `Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs` | 9 | `mapperGuid`, `layoutName` |
+| `Controllers/ParseController.cs` | 4 (3 são `correlationId`, cobertos pelo fix #1; 1 é `layoutDirectory`) | `layoutDirectory` (derivado de `layoutName` do form) |
+| `Services/Implementations/AuditLogger .cs` | 2 (mensagem cobre 2 métodos, 10 campos no total) | `AuditLogEntry`/`LogEntry` inteiros — é o próprio sink de auditoria, todo campo é do request |
+| `Services/Identity/IdentityWorkspaceService.cs` | 1 (2 params no mesmo call) | `provider`, `tenant` (claims OIDC) |
+| `Services/Database/SqlIdentityWorkspaceStore.cs` | 1 | `provider` |
+| `Services/Transformation/Ai/AiTransformationCandidateService.cs` | 2 | `mapperGuid`, `ticket` |
+| `Services/Transformation/TransformationValidatorService.cs` | 1 | `layoutName` |
+| `Services/Testing/AutomatedTransformationTestService.cs` | 2 | `examplesDirectory`, `layoutName` |
+| `Services/Database/DecryptionService.cs` | 2 | `correlationId` (defesa em profundidade — método também chamável fora do pipeline HTTP) |
+
+Nenhum contrato de endpoint mudou — a saneamento é só no que vai pro log, nunca no que volta na
+resposta HTTP.
+
+## Veredito — `cs/exposure-of-sensitive-information` (3 alertas)
+
+Todos os 3 apontam para o **mesmo método gerador**: `RandomGenerator.GenerateRandomEmail`
+(mensagem do CodeQL confirma: *"Private data returned by call to method GenerateRandomEmail is
+written to an external location"*), consumido por `TxtFileGeneratorService`
+(`Services/Generation/TxtGenerator/`) — o gerador de **dado sintético de teste** (issue de
+geração de TXT/NFe fabricado para o TCC), não um fluxo de dado real de cliente.
+
+| # | Local | Nível | Veredito |
+|---|---|---|---|
+| 8 | `Generators/RandomGenerator.cs:44` | Debug | **Falso positivo** — valor fabricado pelo próprio gerador aleatório |
+| 9 | `TxtFileGeneratorService.cs:93` | Warning | **Falso positivo** — mensagem de erro de validação de um TXT sintético já gerado |
+| 10 | `TxtFileGeneratorService.cs:187` | Debug | **Falso positivo** — valor de campo gerado sinteticamente na composição da linha |
+
+Critério de "sensível de verdade" usado (`.claude/rules/security.md`): dado real de cliente,
+segredo ou credencial. Aqui não há nenhum — é o próprio motor de geração de dados de teste
+(`RandomGenerator`) fabricando um e-mail para preencher um campo de layout, propositalmente
+falso. **Descartados** via API do GitHub (`dismissed_reason=false positive`), alertas #8, #9, #10.
+
+## Build/test
+
+```
+dotnet build   → 0 Errors (663 warnings pré-existentes, nenhum novo)
+dotnet test    → 482 passed, 0 failed
+```
+
+## Arquivos alterados
+
+- `Program.cs`
+- `Controllers/TransformationExecutionController.cs`
+- `Controllers/ParseController.cs`
+- `Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs`
+- `Services/Transformation/Ai/AiTransformationCandidateService.cs`
+- `Services/Implementations/AuditLogger .cs`
+- `Services/Identity/IdentityWorkspaceService.cs`
+- `Services/Database/SqlIdentityWorkspaceStore.cs`
+- `Services/Transformation/TransformationValidatorService.cs`
+- `Services/Testing/AutomatedTransformationTestService.cs`
+- `Services/Database/DecryptionService.cs`
+
+Nenhum arquivo novo criado — `LogMessageSanitizer` já existia e foi reusado (decisão IDS:
+REUSAR, não CRIAR).


### PR DESCRIPTION
## Resumo

Correção sistemática dos alertas CodeQL `cs/log-forging` (CWE-117) detectados no repositório,
reaproveitando o helper `LogMessageSanitizer` já existente no código (sem criar mecanismo novo).

- Saneamento de `\r`/`\n` em valores logados oriundos de entrada de requisição — principalmente
  `X-Correlation-ID` no middleware de correlação, cobrindo múltiplos call sites de log de uma vez.
- 3 alertas `cs/exposure-of-sensitive-information` descartados como falso positivo: os pontos
  sinalizados são geradores de dado sintético de teste, não dado real de cliente.

## Escopo

- Sem lógica de negócio nova, sem mudança de contrato de endpoint.
- Merge de `develop` incorporado nesta branch (Slices 1-4 fiscais) para manter o worktree
  atualizado antes do push; conflito trivial em `Program.cs` (registro de DI) resolvido mantendo
  ambos os blocos.

## Validação

- `dotnet build`: 0 erros.
- `dotnet test`: 492 + 59 testes verdes (LayoutParserApi.Tests + XslSynth.Core.Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)