### PR TITLE
fix(identity): SQL Server dedicado para identidade/workspace + Swagger em todo ambiente

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -805,12 +805,15 @@ try
     // loopback ou sem header → identidade anônima, nunca exceção. Ver TrustedIdentityMiddleware.
     app.UseMiddleware<TrustedIdentityMiddleware>();
 
+    // ✅ Swagger habilitado em todo ambiente (não só Development) — pedido explícito do dono
+    // para testar endpoints via Postman/Swagger UI direto em produção.
+    app.UseSwagger();
+    app.UseSwaggerUI();
+
     // Enable detailed error pages in development
     if (app.Environment.IsDevelopment())
     {
         app.UseDeveloperExceptionPage();
-        app.UseSwagger();
-        app.UseSwaggerUI();
         Log.Information("Swagger UI enabled for development");
     }
     else


### PR DESCRIPTION
## Resumo

- **Migração do storage de identidade/workspace** (`Services/Database/SqlIdentityWorkspaceStore.cs`) do banco Sysmiddle compartilhado (`ConnectUS_Macgyver`) para um SQL Server dedicado num servidor Linux separado (172.25.32.5), usando config `IdentityDatabase:*` e tabelas com prefixo `tbLp*`. Corrige erro de produção (FK inválida, Error 1770) que deixava a identidade sempre fail-closed.
- **Ajuste dos workflows** `.github/workflows/ci-dev.yml` e `deploy.yml` para injetar as novas credenciais (`IdentityDatabase__Server/Database/UserId/Password`) no ambiente do serviço Windows, a partir dos secrets/variables `IDENTITY_DB_USERID`, `IDENTITY_DB_PASSWORD`, `IDENTITY_DB_SERVER`, `IDENTITY_DB_NAME` já criados no GitHub.
- **Habilitação do Swagger UI** (`Program.cs`) em todo ambiente (não só `Development`) — pedido explícito do dono, para testar endpoints via Postman/Swagger direto em produção (`layoutparser.duckdns.org/swagger`).

## Referências

- Base: `develop` (merge de `develop` já resolvido na branch, sem conflitos pendentes)

## Test plan

- [ ] `dotnet build` — validar CI
- [ ] Validar variables/secrets `IDENTITY_DB_*` já criados no GitHub antes do deploy
- [ ] Confirmar Swagger acessível em produção após deploy

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>