### PR TITLE
fix(swagger): serve Swagger sob /api/swagger, nao /swagger

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -806,9 +806,16 @@ try
     app.UseMiddleware<TrustedIdentityMiddleware>();
 
     // ✅ Swagger habilitado em todo ambiente (não só Development) — pedido explícito do dono
-    // para testar endpoints via Postman/Swagger UI direto em produção.
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    // para testar endpoints via Postman/Swagger UI direto em produção. Servido sob /api/swagger
+    // (não /swagger) de propósito: em produção o BFF/reverse proxy (LayoutParserReact/server)
+    // só encaminha /api/* para esta API — qualquer rota fora desse prefixo cai no catch-all do
+    // SPA React e devolve a página de erro 404 do front, não o Swagger.
+    app.UseSwagger(c => c.RouteTemplate = "api/swagger/{documentName}/swagger.json");
+    app.UseSwaggerUI(c =>
+    {
+        c.RoutePrefix = "api/swagger";
+        c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "LayoutParserApi v1");
+    });
 
     // Enable detailed error pages in development
     if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Problema

Em producao, apos o deploy do PR #254 (Swagger habilitado em todo ambiente), acessar `/swagger`
retornava a pagina de erro 404 do SPA front-end, nao o Swagger UI.

Causa: o BFF/reverse proxy (LayoutParserReact/server) so encaminha `/api/*` para esta API -
qualquer rota fora desse prefixo cai no catch-all do React, que mostra sua propria tela de erro.

## Correcao

Move o Swagger para `/api/swagger` (UI e `swagger.json`), dentro do prefixo ja roteado para a API.

## Teste

- `dotnet build` — 0 erros.
- Apos deploy, validar `https://layoutparser.duckdns.org/api/swagger` no navegador e
  `https://layoutparser.duckdns.org/api/swagger/v1/swagger.json` para import no Postman.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)