### PR TITLE
fix: exige papel operador no export de mapper e implementa resumo real de learning (#95, #174)

### DIFF
--- a/Controllers/MapperDatabaseController.cs
+++ b/Controllers/MapperDatabaseController.cs
@@ -120,8 +120,12 @@ namespace LayoutParserApi.Controllers
         /// </summary>
         /// <param name="id">ID interno (não confundir com <c>mapperGuid</c>).</param>
         /// <response code="200">Mapeador completo.</response>
+        /// <response code="403">Usuário sem o papel "operador" (issue #95).</response>
         /// <response code="404">ID inexistente.</response>
         /// <response code="500">Falha não catalogada.</response>
+        // Issue #95: devolve o XML Sysmiddle descriptografado por completo — mesmo padrão de
+        // role gate do RefreshCache (issue #32), papel "operador".
+        [Authorize(Roles = "operador")]
         [HttpGet("export/{id}")]
         public async Task<IActionResult> ExportMapper(int id)
         {

--- a/Controllers/MetricsController.cs
+++ b/Controllers/MetricsController.cs
@@ -119,8 +119,11 @@ namespace LayoutParserApi.Controllers
             }
         }
 
-        /// <summary>Resumo agregado de aprendizado entre todos os layouts. <b>Nota:</b> implementação hoje é um stub fixo (zeros) — o agregado real ainda não foi implementado.</summary>
-        /// <response code="200">Resumo (hoje sempre zerado — ver nota).</response>
+        /// <summary>
+        /// Resumo agregado de aprendizado entre todos os layouts — soma os modelos TCL/XSL já
+        /// persistidos em disco (<c>TransformationPipeline:LearningModelsPath</c>).
+        /// </summary>
+        /// <response code="200">Resumo agregado (zerado se nenhum layout foi treinado ainda, ou se a leitura falhar — degrade gracioso).</response>
         [HttpGet("learning/summary")]
         public async Task<IActionResult> GetLearningSummary()
         {
@@ -128,14 +131,17 @@ namespace LayoutParserApi.Controllers
             {
                 _logger.LogInformation("Buscando resumo de métricas de aprendizado");
 
-                // TODO: Implementar busca de todos os modelos aprendidos
-                // Por enquanto, retornar estrutura básica
+                var aggregate = await _learningService.GetLearningSummaryAsync();
+
                 var summary = new
                 {
-                    totalModels = 0,
-                    totalPatterns = 0,
-                    totalExamples = 0,
-                    averageConfidence = 0.0
+                    totalModels = aggregate.TotalModels,
+                    totalPatterns = aggregate.TotalPatterns,
+                    totalExamples = aggregate.TotalExamples,
+                    // Média simples entre TODOS os padrões de TODOS os modelos — não há uma métrica
+                    // de "confiança real" única no pipeline hoje, apenas a confiança por padrão já
+                    // calculada no treino individual (ver GetLearningMetrics).
+                    averageConfidence = aggregate.AverageConfidence
                 };
 
                 return Ok(summary);

--- a/Services/Transformation/Models/LearningSummary.cs
+++ b/Services/Transformation/Models/LearningSummary.cs
@@ -1,0 +1,23 @@
+namespace LayoutParserApi.Services.Transformation.Models
+{
+    /// <summary>
+    /// Resumo agregado dos modelos de aprendizado (TCL + XSL) já persistidos em disco,
+    /// entre todos os layouts — usado pelo endpoint <c>GET /api/metrics/learning/summary</c>.
+    /// </summary>
+    public class LearningSummary
+    {
+        /// <summary>Quantidade de arquivos de modelo aprendido (tcl_*.json + xsl_*.json) encontrados.</summary>
+        public int TotalModels { get; set; }
+
+        /// <summary>Soma de padrões aprendidos (<c>Patterns.Count</c>) entre todos os modelos.</summary>
+        public int TotalPatterns { get; set; }
+
+        /// <summary>Soma de <c>ExamplesCount</c> entre todos os modelos.</summary>
+        public int TotalExamples { get; set; }
+
+        /// <summary>
+        /// Média de confiança entre todos os padrões de todos os modelos (0 se nenhum padrão existir).
+        /// </summary>
+        public double AverageConfidence { get; set; }
+    }
+}

--- a/Services/Transformation/TransformationLearningService.cs
+++ b/Services/Transformation/TransformationLearningService.cs
@@ -814,6 +814,76 @@ namespace LayoutParserApi.Services.Transformation
         }
 
         /// <summary>
+        /// Agrega, entre TODOS os layouts já treinados, os modelos TCL/XSL persistidos em
+        /// <see cref="_learningModelsPath"/> — usado pelo dashboard de métricas (issue #174).
+        /// Falha de leitura de um arquivo individual não derruba o agregado (loga e pula).
+        /// </summary>
+        public async Task<LearningSummary> GetLearningSummaryAsync()
+        {
+            var summary = new LearningSummary();
+            var confidences = new List<double>();
+
+            try
+            {
+                if (!Directory.Exists(_learningModelsPath))
+                {
+                    _logger.LogWarning("Diretório de modelos de aprendizado não encontrado: {Path}", _learningModelsPath);
+                    return summary;
+                }
+
+                var tclFiles = Directory.GetFiles(_learningModelsPath, "tcl_*.json", SearchOption.TopDirectoryOnly);
+                var xslFiles = Directory.GetFiles(_learningModelsPath, "xsl_*.json", SearchOption.TopDirectoryOnly);
+
+                foreach (var file in tclFiles)
+                {
+                    try
+                    {
+                        var json = await File.ReadAllTextAsync(file);
+                        var model = System.Text.Json.JsonSerializer.Deserialize<LearnedTclModel>(json);
+                        if (model == null) continue;
+
+                        summary.TotalModels++;
+                        summary.TotalPatterns += model.Patterns.Count;
+                        summary.TotalExamples += model.ExamplesCount;
+                        confidences.AddRange(model.Patterns.Select(p => p.Confidence));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Erro ao carregar modelo TCL para o resumo agregado: {File}", file);
+                    }
+                }
+
+                foreach (var file in xslFiles)
+                {
+                    try
+                    {
+                        var json = await File.ReadAllTextAsync(file);
+                        var model = System.Text.Json.JsonSerializer.Deserialize<LearnedXslModel>(json);
+                        if (model == null) continue;
+
+                        summary.TotalModels++;
+                        summary.TotalPatterns += model.Patterns.Count;
+                        summary.TotalExamples += model.ExamplesCount;
+                        confidences.AddRange(model.Patterns.Select(p => p.Confidence));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Erro ao carregar modelo XSL para o resumo agregado: {File}", file);
+                    }
+                }
+
+                summary.AverageConfidence = confidences.Count > 0 ? confidences.Average() : 0.0;
+            }
+            catch (Exception ex)
+            {
+                // Degrade gracioso: resumo zerado em vez de derrubar o endpoint.
+                _logger.LogError(ex, "Erro ao agregar resumo de métricas de aprendizado");
+            }
+
+            return summary;
+        }
+
+        /// <summary>
         /// Carrega exemplos TCL constantemente da pasta ExamplesTclPath
         /// </summary>
         public async Task<List<TclExample>> LoadTclExamplesAsync(string layoutName = null)


### PR DESCRIPTION
Exige papel `operador` no endpoint de export de mapper e implementa o resumo real de learning (antes stub).

Closes #95
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7ocwdu5muXaKPzY4PQqww