### PR TITLE
fix(security): corrige path traversal real em leitura de PDF de orientações (CodeQL cs/path-injection)

### DIFF
--- a/Services/Database/SqlAiUserSessionStore.cs
+++ b/Services/Database/SqlAiUserSessionStore.cs
@@ -1,3 +1,5 @@
+using LayoutParserApi.Services.Logging;
+
 using Microsoft.Data.SqlClient;
 
 namespace LayoutParserApi.Services.Database
@@ -136,7 +138,7 @@ namespace LayoutParserApi.Services.Database
             catch (Exception ex)
             {
                 // Degrade: histórico é auditoria, não pode quebrar o job de IA que acabou de terminar.
-                _logger.LogWarning(ex, "Falha ao gravar histórico de sessão de IA (ticket={Ticket}) — degradado, não afeta o pathway de IA em si", ticket);
+                _logger.LogWarning(ex, "Falha ao gravar histórico de sessão de IA (ticket={Ticket}) — degradado, não afeta o pathway de IA em si", LogMessageSanitizer.Sanitize(ticket));
             }
         }
 

--- a/Services/XmlAnalysis/PdfOrientationReader.cs
+++ b/Services/XmlAnalysis/PdfOrientationReader.cs
@@ -1,3 +1,5 @@
+using LayoutParserApi.Services.Logging;
+
 using UglyToad.PdfPig;
 
 namespace LayoutParserApi.Services.XmlAnalysis
@@ -50,13 +52,13 @@ namespace LayoutParserApi.Services.XmlAnalysis
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha ao listar PDFs de orientação em {Pasta}", pdfFolderPath);
+                _logger.LogWarning(ex, "Falha ao listar PDFs de orientação em {Pasta}", LogMessageSanitizer.Sanitize(pdfFolderPath));
                 return result;
             }
 
             if (arquivosPdf.Count == 0)
             {
-                _logger.LogInformation("Nenhum PDF de orientação encontrado em {Pasta}", pdfFolderPath);
+                _logger.LogInformation("Nenhum PDF de orientação encontrado em {Pasta}", LogMessageSanitizer.Sanitize(pdfFolderPath));
                 return result;
             }
 

--- a/Services/XmlAnalysis/XsdValidationService.cs
+++ b/Services/XmlAnalysis/XsdValidationService.cs
@@ -1,4 +1,6 @@
 using LayoutParserApi.Models.XmlAnalysis;
+using LayoutParserApi.Services.Logging;
+using LayoutParserApi.Services.Security;
 using LayoutParserApi.Services.XmlAnalysis.Models;
 
 using System.Xml;
@@ -372,7 +374,16 @@ namespace LayoutParserApi.Services.XmlAnalysis
 
             try
             {
-                var pdfPath = Path.Combine(_pdfBasePath, xsdVersion);
+                // xsdVersion vem de parâmetro de request (controller) — nunca combine direto num
+                // Path.Combine sem validar. SafePathResolver barra "..", separador de caminho e
+                // qualquer resultado que escape de _pdfBasePath (path traversal, CodeQL cs/path-injection).
+                var pdfPath = SafePathResolver.Resolve(_pdfBasePath, xsdVersion);
+                if (pdfPath == null)
+                {
+                    _logger.LogWarning("Versão de XSD rejeitada para leitura de orientações PDF: {XsdVersion}", LogMessageSanitizer.Sanitize(xsdVersion));
+                    result.Orientations.Add("Pasta de orientações PDF não encontrada.");
+                    return result;
+                }
 
                 if (!Directory.Exists(pdfPath))
                 {

--- a/security-code-scan-baseline.json
+++ b/security-code-scan-baseline.json
@@ -21,6 +21,12 @@
     "Nao remova entradas por conveniencia - so remova quando o achado subjacente for corrigido no",
     "codigo (o que tambem deve refletir sozinho, pois o SCS para de reportar aquele achado).",
     "",
+    "2026-09-02 (@lp-devops, PR #278): XsdValidationService.cs (227->229, 241->243, 346->348) teve",
+    "o numero de linha atualizado de novo - a correcao do path traversal real da issue #172",
+    "(SafePathResolver.Resolve em xsdVersion, PR #278) adicionou linhas acima dos achados ja",
+    "aceitos, deslocando-os. Mesmos achados, nao vulnerabilidades novas - confirmado lendo cada",
+    "linha antes de mover.",
+    "",
     "2026-09-02 (coordenador, PR #276): ParseController.cs (575->586, instrumentacao/logging da",
     "issue #99 deslocou o codigo) e XsdValidationService.cs (221->227, 235->241, 340->346, leitura",
     "de PDF da issue #172 deslocou o codigo) tiveram o numero de linha atualizado - mesmos achados",
@@ -94,8 +100,8 @@
     { "code": "SCS0018", "file": "Services/Validation/DocumentMLValidationService.cs", "line": 178 },
     { "code": "SCS0018", "file": "Services/Validation/DocumentMLValidationService.cs", "line": 206 },
     { "code": "SCS0018", "file": "Services/XmlAnalysis/TransformationPipelineService.cs", "line": 393 },
-    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 227 },
-    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 241 },
-    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 346 }
+    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 229 },
+    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 243 },
+    { "code": "SCS0018", "file": "Services/XmlAnalysis/XsdValidationService.cs", "line": 348 }
   ]
 }

--- a/tests/LayoutParserApi.Tests/Services/XmlAnalysis/XsdValidationServiceOrientationPathTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/XmlAnalysis/XsdValidationServiceOrientationPathTests.cs
@@ -1,0 +1,89 @@
+using LayoutParserApi.Services.XmlAnalysis;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace LayoutParserApi.Tests.Services.XmlAnalysis
+{
+    /// <summary>
+    /// Cobre o fix de path traversal (CodeQL cs/path-injection) em
+    /// <see cref="XsdValidationService.GetOrientationsAsync"/>: <c>xsdVersion</c> vem de
+    /// parâmetro de request e antes ia direto para <c>Path.Combine</c> com <c>_pdfBasePath</c>,
+    /// sem validação — um valor como <c>../../../Windows</c> escaparia da pasta de PDFs.
+    /// </summary>
+    public class XsdValidationServiceOrientationPathTests : IDisposable
+    {
+        private readonly string _pdfBaseDir;
+
+        public XsdValidationServiceOrientationPathTests()
+        {
+            _pdfBaseDir = Path.Combine(Path.GetTempPath(), "xsd-orientation-tests-" + Guid.NewGuid());
+            Directory.CreateDirectory(_pdfBaseDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_pdfBaseDir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private XsdValidationService CreateService()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["XsdValidation:BasePath"] = _pdfBaseDir,
+                    ["XsdValidation:PdfBasePath"] = _pdfBaseDir
+                })
+                .Build();
+
+            var detector = new XmlDocumentTypeDetector(NullLogger<XmlDocumentTypeDetector>.Instance);
+            var pdfReader = new PdfOrientationReader(NullLogger<PdfOrientationReader>.Instance);
+
+            return new XsdValidationService(NullLogger<XsdValidationService>.Instance, config, detector, pdfReader);
+        }
+
+        [Fact]
+        public async Task GetOrientationsAsync_XsdVersionComPathTraversal_NaoEscapaDaPastaBase()
+        {
+            // Pasta irmã fora do _pdfBaseDir, que um "../" tentaria alcançar.
+            var pastaVizinha = Path.Combine(Path.GetDirectoryName(_pdfBaseDir)!, "outra-pasta-" + Guid.NewGuid());
+            Directory.CreateDirectory(pastaVizinha);
+            File.WriteAllText(Path.Combine(pastaVizinha, "segredo.txt"), "não deveria ser alcançável");
+
+            try
+            {
+                var service = CreateService();
+                var xsdVersionMalicioso = "../" + Path.GetFileName(pastaVizinha);
+
+                var resultado = await service.GetOrientationsAsync(xsdVersionMalicioso, errorCodes: null);
+
+                // Degrada graciosamente: não lança, devolve o fallback de "pasta não encontrada"
+                // (mesmo formato que o caso legítimo de pasta ausente — não revela que o valor
+                // foi rejeitado por tentativa de path traversal).
+                Assert.False(resultado.Success);
+                Assert.Contains(resultado.Orientations, o => o.Contains("Pasta de orientações PDF não encontrada"));
+            }
+            finally
+            {
+                try { Directory.Delete(pastaVizinha, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task GetOrientationsAsync_XsdVersionValida_ContinuaFuncionando()
+        {
+            var versao = "PL_010b_NT2025_002_v1.30";
+            Directory.CreateDirectory(Path.Combine(_pdfBaseDir, versao));
+
+            var service = CreateService();
+            var resultado = await service.GetOrientationsAsync(versao, errorCodes: null);
+
+            Assert.True(resultado.Success);
+            // Sem PDFs na pasta, cai no fallback genérico — mas a pasta válida foi aceita (sem
+            // cair no "pasta não encontrada" que indicaria rejeição indevida pelo validador).
+            Assert.DoesNotContain(resultado.Orientations, o => o.Contains("Pasta de orientações PDF não encontrada"));
+        }
+    }
+}


### PR DESCRIPTION
## Problema

O CodeQL identificou (no PR automático #277, develop→master) um achado real de path traversal
(`cs/path-injection`) na leitura de PDF de orientações (issue #172): o parâmetro `xsdVersion`,
vindo diretamente de uma request do usuário, era combinado num path de arquivo via `Path.Combine`
sem sanitização — permitindo escapar do diretório esperado (ex.: `../../`) e ler arquivos
arbitrários do host.

## Correção

- Sanitização do path via `SafePathResolver.Resolve` — mesmo padrão de resolução segura já usado
  em outros pontos do projeto.
- `LogMessageSanitizer.Sanitize` aplicado em 3 pontos de log relacionados, prevenindo log forging
  a partir do mesmo input não confiável.
- 2 novos testes cobrindo o ataque (path traversal via `xsdVersion` malicioso).

## Validação

- `dotnet build`: 0 erros.
- Testes: 7/7 passando (incluindo os 2 novos).

## Contexto

Achado surgiu do CodeQL rodando no PR automático #277 (develop→master), que ainda está aberto —
ou seja, a versão vulnerável **ainda não chegou em produção**. Este PR corrige a origem
(`develop`) antes da promoção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7ocwdu5muXaKPzY4PQqww