### PR TITLE
feat(health): gate de capacidade via IHealthCheck (#90)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -463,7 +463,15 @@ try
             HealthStatus.Unhealthy, new[] { "ready" }))
         .Add(new HealthCheckRegistration("catalog",
             sp => new CatalogHealthCheck(sp.GetRequiredService<CatalogWarmupState>()),
-            HealthStatus.Unhealthy, new[] { "ready" }));
+            HealthStatus.Unhealthy, new[] { "ready" }))
+        // ✅ Issue #90: gate de capacidade dos 3 adapters de explicação de mapeamento (sysmiddle/
+        // tcl/xslt) — a implementação nunca reporta Unhealthy (ver classe), então o failureStatus
+        // aqui só é o piso de segurança caso o contrato seja violado no futuro.
+        .Add(new HealthCheckRegistration("mapping-explanation-capabilities",
+            sp => new MappingExplanationCapabilityHealthCheck(
+                sp.GetRequiredService<IEnumerable<LayoutParserApi.Services.Interfaces.IMappingExplanationAdapter>>(),
+                sp.GetRequiredService<ILogger<MappingExplanationCapabilityHealthCheck>>()),
+            HealthStatus.Degraded, new[] { "ready" }));
 
     // XML Analysis Services
     builder.Services.AddScoped<XmlAnalysisService>();

--- a/Services/Fiscal/SysmiddleExplanationAdapter.cs
+++ b/Services/Fiscal/SysmiddleExplanationAdapter.cs
@@ -57,6 +57,33 @@ namespace LayoutParserApi.Services.Fiscal
             _logger = logger;
         }
 
+        /// <summary>
+        /// Dependência real: catálogo de mappers Sysmiddle (<see cref="ICachedMapperService"/>, por
+        /// trás dele SQL + decryptor). Timeout curto (issue #90) — é sonda, não caminho de dados.
+        /// </summary>
+        public async Task<CapabilityHealth> CheckAvailabilityAsync(CancellationToken cancellationToken)
+        {
+            // GetAllMappersAsync não aceita CancellationToken — timeout aplicado por fora via
+            // Task.WhenAny, mesmo racional de "sonda com timeout curto" do resto do health check.
+            try
+            {
+                var mappersTask = _cachedMapperService.GetAllMappersAsync();
+                var completed = await Task.WhenAny(mappersTask, Task.Delay(TimeSpan.FromSeconds(3), cancellationToken));
+                if (completed != mappersTask)
+                    return new CapabilityHealth(CapabilityStatus.Unavailable, "Catálogo de mappers Sysmiddle não respondeu dentro do timeout (3s).");
+
+                var mappers = await mappersTask;
+                return mappers.Count > 0
+                    ? new CapabilityHealth(CapabilityStatus.Healthy, $"Catálogo de mappers Sysmiddle com {mappers.Count} entrada(s).")
+                    : new CapabilityHealth(CapabilityStatus.Degraded, "Catálogo de mappers Sysmiddle vazio — explicação sem conteúdo pra retornar.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gate de capacidade (#90): catálogo de mappers Sysmiddle indisponível.");
+                return new CapabilityHealth(CapabilityStatus.Unavailable, $"Catálogo de mappers Sysmiddle falhou: {ex.Message}");
+            }
+        }
+
         public async Task<MappingExplanation?> ExplainAsync(MappingExplanationRequest request, CancellationToken cancellationToken)
         {
             // Sysmiddle não tem versionamento explícito — só "current" é aceito (design §0).

--- a/Services/Fiscal/TclExplanationAdapter.cs
+++ b/Services/Fiscal/TclExplanationAdapter.cs
@@ -33,6 +33,32 @@ namespace LayoutParserApi.Services.Fiscal
             _logger = logger;
         }
 
+        /// <summary>
+        /// Dependência real: <see cref="IMappingDraftStore"/> (SQL). Consulta um Guid inexistente de
+        /// propósito — exercita o round-trip real sem depender de haver draft cadastrado. Timeout
+        /// curto (issue #90), nunca lança.
+        /// </summary>
+        public async Task<CapabilityHealth> CheckAvailabilityAsync(CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(3));
+
+            try
+            {
+                await _store.GetDraftIfMemberAsync(Guid.Empty, Guid.Empty, timeoutCts.Token);
+                return new CapabilityHealth(CapabilityStatus.Healthy, "MappingDraftStore respondeu.");
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                return new CapabilityHealth(CapabilityStatus.Unavailable, "MappingDraftStore não respondeu dentro do timeout (3s).");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gate de capacidade (#90): MappingDraftStore indisponível para engine=tcl.");
+                return new CapabilityHealth(CapabilityStatus.Unavailable, $"MappingDraftStore falhou: {ex.Message}");
+            }
+        }
+
         public async Task<MappingExplanation?> ExplainAsync(MappingExplanationRequest request, CancellationToken cancellationToken)
         {
             if (!Guid.TryParse(request.MappingId, out var draftId))

--- a/Services/Fiscal/XsltExplanationAdapter.cs
+++ b/Services/Fiscal/XsltExplanationAdapter.cs
@@ -43,6 +43,31 @@ namespace LayoutParserApi.Services.Fiscal
             _logger = logger;
         }
 
+        /// <summary>
+        /// Dependência real: mesmo <see cref="IMappingDraftStore"/> (SQL) usado pelo Tcl adapter —
+        /// ver <see cref="TclExplanationAdapter.CheckAvailabilityAsync"/> para o racional completo.
+        /// </summary>
+        public async Task<CapabilityHealth> CheckAvailabilityAsync(CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(3));
+
+            try
+            {
+                await _store.GetDraftIfMemberAsync(Guid.Empty, Guid.Empty, timeoutCts.Token);
+                return new CapabilityHealth(CapabilityStatus.Healthy, "MappingDraftStore respondeu.");
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                return new CapabilityHealth(CapabilityStatus.Unavailable, "MappingDraftStore não respondeu dentro do timeout (3s).");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gate de capacidade (#90): MappingDraftStore indisponível para engine=xslt.");
+                return new CapabilityHealth(CapabilityStatus.Unavailable, $"MappingDraftStore falhou: {ex.Message}");
+            }
+        }
+
         public async Task<MappingExplanation?> ExplainAsync(MappingExplanationRequest request, CancellationToken cancellationToken)
         {
             if (!Guid.TryParse(request.MappingId, out var draftId))

--- a/Services/Health/ReadinessHealthChecks.cs
+++ b/Services/Health/ReadinessHealthChecks.cs
@@ -226,4 +226,59 @@ namespace LayoutParserApi.Services.Health
             return Task.FromResult(resultado);
         }
     }
+
+    /// <summary>
+    /// Issue #90 — gate de capacidade explícito para os 3 adapters de <c>IMappingExplanationAdapter</c>
+    /// (sysmiddle/tcl/xslt): antes, "registrado no DI" era tratado como "disponível", e a dependência
+    /// real (catálogo de mappers, SQL) só falhava tarde, no primeiro request. Cada adapter roda seu
+    /// próprio <see cref="IMappingExplanationAdapter.CheckAvailabilityAsync"/> (timeout curto, nunca
+    /// lança); esta sonda agrega o pior status entre os 3.
+    ///
+    /// <para><b>Nunca Unhealthy</b> — MVP de observabilidade (design §"O que falta de decisão externa"):
+    /// o objetivo é reportar capacidade degradada, não recusar requests nem travar o boot/deploy.
+    /// Pior caso agregado vira <c>Degraded</c> (200 em <c>/health/ready</c>), nunca <c>Unhealthy</c>.</para>
+    /// </summary>
+    public sealed class MappingExplanationCapabilityHealthCheck : IHealthCheck
+    {
+        private readonly IEnumerable<IMappingExplanationAdapter> _adapters;
+        private readonly ILogger<MappingExplanationCapabilityHealthCheck> _logger;
+
+        public MappingExplanationCapabilityHealthCheck(
+            IEnumerable<IMappingExplanationAdapter> adapters,
+            ILogger<MappingExplanationCapabilityHealthCheck> logger)
+        {
+            _adapters = adapters;
+            _logger = logger;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            var data = new Dictionary<string, object>();
+            var anyDegraded = false;
+
+            foreach (var adapter in _adapters)
+            {
+                CapabilityHealth health;
+                try
+                {
+                    health = await adapter.CheckAvailabilityAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    // Defesa extra: mesmo que a implementação quebre o contrato "nunca lança", o gate
+                    // de capacidade em si não pode derrubar a sonda inteira (princípio de resiliência).
+                    _logger.LogWarning(ex, "CheckAvailabilityAsync do adapter {Engine} lançou — tratado como degradado.", adapter.Engine);
+                    health = new CapabilityHealth(CapabilityStatus.Unavailable, $"CheckAvailabilityAsync lançou: {ex.Message}");
+                }
+
+                data[adapter.Engine] = new { status = health.Status.ToString(), reason = health.Reason };
+                if (health.Status != CapabilityStatus.Healthy)
+                    anyDegraded = true;
+            }
+
+            return anyDegraded
+                ? HealthCheckResult.Degraded("Uma ou mais capacidades de explicação de mapeamento estão degradadas — ver detalhe por engine.", data: data)
+                : HealthCheckResult.Healthy("Todas as capacidades de explicação de mapeamento estão saudáveis.", data);
+        }
+    }
 }

--- a/Services/Interfaces/IMappingExplanationAdapter.cs
+++ b/Services/Interfaces/IMappingExplanationAdapter.cs
@@ -11,6 +11,21 @@ namespace LayoutParserApi.Services.Interfaces
         /// <summary>"current" (sysmiddle) ou "draft" (tcl/xslt — só isso hoje, Slice 5 introduz número real).</summary>
         string Version);
 
+    /// <summary>Severidade da capacidade — mesma semântica de <c>Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus</c>, sem acoplar o contrato do adapter ao pacote de health checks.</summary>
+    public enum CapabilityStatus
+    {
+        Healthy,
+        Degraded,
+        Unavailable,
+    }
+
+    /// <summary>
+    /// Resultado do gate de capacidade (issue #90): a dependência REAL por trás do adapter (SQL,
+    /// catálogo de mappers, `.exe` de decrypt) foi checada, em vez de assumir "registrado no DI" ==
+    /// "disponível".
+    /// </summary>
+    public sealed record CapabilityHealth(CapabilityStatus Status, string Reason);
+
     /// <summary>
     /// Um dos 3 tradutores determinísticos (sem LLM) de um artefato de mapeamento real para o
     /// contrato canônico <see cref="MappingExplanation"/>. Nunca lança para conteúdo não
@@ -27,5 +42,14 @@ namespace LayoutParserApi.Services.Interfaces
         /// para "não encontrado", só para falha de infraestrutura real.
         /// </summary>
         Task<MappingExplanation?> ExplainAsync(MappingExplanationRequest request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Issue #90 — gate de capacidade explícito: verifica a dependência real por trás do adapter
+        /// (não apenas "foi registrado no DI"). Chamado pelo health check agregado no boot/sonda de
+        /// readiness, NUNCA no caminho de <see cref="ExplainAsync"/> (observabilidade, não bloqueio de
+        /// request — MVP do design §"O que falta de decisão externa"). Implementações usam timeout
+        /// curto e nunca lançam — falha de checagem também é reportada como <see cref="CapabilityHealth"/>.
+        /// </summary>
+        Task<CapabilityHealth> CheckAvailabilityAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Resumo
- Implementa gate de capacidade real nos adapters de explicação de mapeamento via IHealthCheck, seguindo o plano técnico do backlog pendente (docs/architecture/plano-tecnico-backlog-pendente-2026-09-02.md).

## Test plan
- [x] `dotnet build` verde
- [x] `dotnet test` validado por quem implementou

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7ocwdu5muXaKPzY4PQqww