### PR TITLE
hotfix: corrige build quebrado de testes (aiUserSessionStore) bloqueando deploy

### DIFF
--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
@@ -287,6 +287,9 @@ namespace LayoutParserApi.Tests.Controllers
                 aiCandidateService: new SpyAiCandidateService(),
                 aiFallbackGate: new SpyAiFallbackSuppressionGate(),
                 aiUserInstructionStore: new LayoutParserApi.Services.Transformation.Ai.AiUserInstructionStore(),
+                aiUserSessionStore: new LayoutParserApi.Services.Database.SqlAiUserSessionStore(
+                    NullLogger<LayoutParserApi.Services.Database.SqlAiUserSessionStore>.Instance,
+                    new ConfigurationBuilder().Build()),
                 currentUser: new FakeCurrentUser(),
                 mapperDb: mapperDb,
                 layoutParser: parserFake,

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -161,6 +161,9 @@ namespace LayoutParserApi.Tests.Controllers
                 aiCandidateService: aiSpy,
                 aiFallbackGate: new SpyAiFallbackSuppressionGate(),
                 aiUserInstructionStore: new LayoutParserApi.Services.Transformation.Ai.AiUserInstructionStore(),
+                aiUserSessionStore: new LayoutParserApi.Services.Database.SqlAiUserSessionStore(
+                    NullLogger<LayoutParserApi.Services.Database.SqlAiUserSessionStore>.Instance,
+                    new ConfigurationBuilder().Build()),
                 currentUser: new FakeCurrentUser(),
                 mapperDb: null!,
                 layoutParser: null!,

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -9,6 +9,7 @@ using LayoutParserApi.Services.Transformation.LowCode;
 using LayoutParserApi.Services.Transformation.Ai;
 
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -105,6 +106,9 @@ namespace LayoutParserApi.Tests.Controllers
                 aiCandidateService: spy,
                 aiFallbackGate: new SpyAiFallbackSuppressionGate(),
                 aiUserInstructionStore: new LayoutParserApi.Services.Transformation.Ai.AiUserInstructionStore(),
+                aiUserSessionStore: new LayoutParserApi.Services.Database.SqlAiUserSessionStore(
+                    NullLogger<LayoutParserApi.Services.Database.SqlAiUserSessionStore>.Instance,
+                    new ConfigurationBuilder().Build()),
                 currentUser: user,
                 mapperDb: null!,
                 layoutParser: null!,


### PR DESCRIPTION
## Problema

A issue #97 (PR #286) adicionou o parâmetro obrigatório `aiUserSessionStore` ao construtor de
`TransformationExecutionController`, mas 3 arquivos de teste que instanciam o controller
diretamente não foram atualizados. Isso quebra a compilação da solution inteira (`CS7036`) em
`master` desde o merge, bloqueando todo deploy de produção.

## Correção

Adiciona o argumento `aiUserSessionStore` (`SqlAiUserSessionStore` com config vazia, mesmo padrão
já usado em `AiTransformationCandidateServiceTests`) nos 3 pontos de instanciação:

- `TransformationExecutionControllerUserIsolationTests.cs`
- `TransformationExecutionControllerPathwayDiagnosticsTests.cs`
- `TransformationExecutionControllerFieldMappingsTests.cs`

## Validação

- `dotnet build` da solution inteira: limpo, 0 erros.
- `dotnet test`: 567/571 passando. As 4 falhas restantes são pré-existentes (diferença de path
  Windows vs Linux), não relacionadas a esta correção.

Confirmado pelo dono como hotfix urgente — build quebrado bloqueia deploy de produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7ocwdu5muXaKPzY4PQqww