### PR TITLE
fix: normaliza LayoutType numérico legado antes do gate generate-for-layout (#219)

### DIFF
--- a/Services/XmlAnalysis/AutoTransformationGeneratorService.cs
+++ b/Services/XmlAnalysis/AutoTransformationGeneratorService.cs
@@ -149,16 +149,23 @@ namespace LayoutParserApi.Services.XmlAnalysis
             {
                 _logger.LogInformation("Processando layout: {Name} (Type: {Type}, Guid: {Guid})", layout.Name, layout.LayoutType, layout.LayoutGuid);
 
+                // ✅ Issue #219: o `LayoutType` cru vindo da coluna SQL [LayoutType] pode divergir do
+                // `<LayoutType>` embutido no XML descriptografado do layout (ex.: cadastro legado com
+                // código numérico Sysmiddle "2" em vez do texto "TextPositional"). Normalizamos aqui
+                // antes de decidir o caminho de geração — ver ResolveEffectiveLayoutType.
+                var effectiveLayoutType = ResolveEffectiveLayoutType(layout);
+                processed.LayoutType = effectiveLayoutType;
+
                 // Verificar tipo do layout
-                if (layout.LayoutType == "TextPositional")
+                if (effectiveLayoutType == "TextPositional")
                     // TextPositional: gerar TCL e XSL
                     await ProcessTextPositionalLayoutAsync(layout, processed);
-                else if (layout.LayoutType == "XML")
+                else if (effectiveLayoutType == "XML")
                     // XML: gerar apenas XSL
                     await ProcessXmlLayoutAsync(layout, processed);
                 else
                 {
-                    processed.Warnings.Add($"Tipo de layout não suportado: {layout.LayoutType}");
+                    processed.Warnings.Add($"Tipo de layout não suportado: {effectiveLayoutType}");
                     processed.Success = false;
                     return processed;
                 }
@@ -172,6 +179,14 @@ namespace LayoutParserApi.Services.XmlAnalysis
 
             return processed;
         }
+
+        /// <summary>
+        /// Resolve o tipo efetivo do layout ("TextPositional"/"XML"), lidando com a divergência entre
+        /// a coluna SQL [LayoutType] e o XML descriptografado do layout.
+        /// ✅ Issue #219 — ver <see cref="LayoutTypeNormalizer"/> para a lógica completa e o racional.
+        /// </summary>
+        private string ResolveEffectiveLayoutType(LayoutRecord layout)
+            => LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, message => _logger.LogWarning("{Message}", message));
 
         /// <summary>
         /// Processa layout TextPositional (gera TCL e XSL)

--- a/Services/XmlAnalysis/LayoutTypeNormalizer.cs
+++ b/Services/XmlAnalysis/LayoutTypeNormalizer.cs
@@ -1,0 +1,122 @@
+using LayoutParserApi.Models.Database;
+
+using System.Xml.Linq;
+
+namespace LayoutParserApi.Services.XmlAnalysis
+{
+    /// <summary>
+    /// Resolve o tipo efetivo de um layout ("TextPositional"/"XML") a partir do valor cru vindo da
+    /// coluna SQL [LayoutType] (<see cref="LayoutRecord.LayoutType"/>), com fallback defensivo.
+    ///
+    /// ✅ Issue #219 (gate FIAT recusando `LAY_TXT_MQSERIES_ENVNFE_4.00_NFe` com
+    /// "Tipo de layout não suportado: 2"): o cadastro no banco (`tbLayout.LayoutType`) pode conter
+    /// um código numérico legado do Sysmiddle em vez do texto esperado por este serviço. O próprio
+    /// <see cref="LayoutParserApi.Services.Database.LayoutDatabaseService"/> já lida com essa
+    /// divergência em <c>IsTextPositionalLayout</c>, que ignora a coluna SQL e lê o valor real em
+    /// <c>/LayoutVO/LayoutType</c> dentro do XML descriptografado do layout — essa é a fonte
+    /// comprovadamente autoritativa (é o que decide hoje se o layout entra no catálogo Redis).
+    /// Reaproveitamos a mesma fonte aqui antes de recusar o layout.
+    ///
+    /// Extraído como classe estática independente (sem dependências de DI) para ser testável sem
+    /// precisar construir <see cref="AutoTransformationGeneratorService"/> inteiro.
+    /// </summary>
+    public static class LayoutTypeNormalizer
+    {
+        /// <summary>
+        /// Ordem de resolução:
+        /// 1. `layout.LayoutType` já é "TextPositional"/"XML" (case-insensitive) → usa direto, sem log.
+        /// 2. Senão, tenta ler `/LayoutVO/LayoutType` do XML descriptografado (mesma lógica usada por
+        ///    `LayoutDatabaseService.IsTextPositionalLayout`) — se vier um valor reconhecido, usa e
+        ///    loga Warning via <paramref name="onFallback"/> (a divergência SQL vs XML é sinal de
+        ///    cadastro desatualizado, auditável).
+        /// 3. Senão, tenta um mapa heurístico de códigos numéricos legados do Sysmiddle. **Este mapa
+        ///    não tem confirmação documentada do dono do produto** — hoje só há evidência do caso real
+        ///    "2" (layout MQSeries `LAY_TXT_MQSERIES_ENVNFE_4.00_NFe`, issue #219), que decrypta para
+        ///    `TextPositional` no XML (isso é validado no passo 2, então o passo 3 só entra se nem o
+        ///    conteúdo do XML puder ser lido). Loga Warning explícito pedindo confirmação.
+        /// 4. Senão, devolve o valor cru original — cai no warning "não suportado" já existente no
+        ///    chamador.
+        /// </summary>
+        /// <param name="layout">Registro do layout, com <c>LayoutType</c> cru e conteúdo (des)criptografado.</param>
+        /// <param name="onFallback">
+        /// Callback invocado quando a resolução não usa o valor cru diretamente (passos 2 ou 3), com
+        /// uma mensagem pronta para log de Warning — auditabilidade do fallback heurístico.
+        /// </param>
+        public static string ResolveEffectiveLayoutType(LayoutRecord layout, Action<string>? onFallback = null)
+        {
+            var rawType = layout.LayoutType?.Trim() ?? "";
+
+            if (string.Equals(rawType, "TextPositional", StringComparison.OrdinalIgnoreCase))
+                return "TextPositional";
+            if (string.Equals(rawType, "XML", StringComparison.OrdinalIgnoreCase))
+                return "XML";
+
+            // Passo 2: tentar a fonte autoritativa — o XML descriptografado do próprio layout.
+            var fromXml = TryExtractLayoutTypeFromDecryptedXml(layout);
+            if (!string.IsNullOrEmpty(fromXml))
+            {
+                onFallback?.Invoke(
+                    $"Layout {layout.Name} (Guid: {layout.LayoutGuid}) tem LayoutType='{rawType}' cadastrado no banco " +
+                    $"(tbLayout.LayoutType), mas o XML descriptografado do layout diz '{fromXml}'. Usando o valor do XML " +
+                    "(fonte autoritativa). Cadastro no banco parece desatualizado — considerar corrigir na origem.");
+                return fromXml;
+            }
+
+            // Passo 3: fallback heurístico para códigos numéricos legados — NÃO CONFIRMADO pelo dono.
+            // Único caso com evidência real até agora: "2" em layout MQSeries (issue #219), que na
+            // prática decripta para TextPositional (ver passo 2). Mantido aqui só como último recurso
+            // para quando o XML não puder ser lido/descriptografado.
+            if (rawType == "2")
+            {
+                onFallback?.Invoke(
+                    $"Layout {layout.Name} (Guid: {layout.LayoutGuid}) com LayoutType='2' (código numérico legado) e " +
+                    "sem XML legível para confirmar. Assumindo 'TextPositional' por heurística baseada no padrão " +
+                    "observado na issue #219 — ESTA SUPOSIÇÃO NÃO FOI CONFIRMADA PELO DONO DO PRODUTO. Corrigir o " +
+                    "cadastro do layout na origem (tbLayout.LayoutType) é a correção definitiva.");
+                return "TextPositional";
+            }
+
+            return rawType;
+        }
+
+        /// <summary>
+        /// Lê `/LayoutVO/LayoutType` do XML descriptografado do layout, com a mesma lógica de busca
+        /// (root == LayoutVO, ou LayoutVO filho, ou LayoutType direto no root) usada por
+        /// <see cref="LayoutParserApi.Services.Database.LayoutDatabaseService"/> — mantida aqui
+        /// separada para não acoplar este serviço à implementação interna daquele (que expõe só um
+        /// bool, não o valor).
+        /// </summary>
+        internal static string? TryExtractLayoutTypeFromDecryptedXml(LayoutRecord layout)
+        {
+            var xml = !string.IsNullOrEmpty(layout.DecryptedContent) ? layout.DecryptedContent : layout.ValueContent;
+            if (string.IsNullOrEmpty(xml))
+                return null;
+
+            try
+            {
+                var doc = XDocument.Parse(xml);
+                var root = doc.Root;
+                if (root == null)
+                    return null;
+
+                XElement? layoutTypeElement;
+                if (root.Name.LocalName == "LayoutVO")
+                    layoutTypeElement = root.Element("LayoutType");
+                else
+                {
+                    var layoutVo = root.Element("LayoutVO");
+                    layoutTypeElement = layoutVo != null ? layoutVo.Element("LayoutType") : root.Element("LayoutType");
+                }
+
+                var value = layoutTypeElement?.Value?.Trim();
+                return string.IsNullOrEmpty(value) ? null : value;
+            }
+            catch
+            {
+                // XML malformado/vazio: sem sinal confiável, deixa o chamador seguir para o próximo
+                // passo de resolução (fallback heurístico ou valor cru original).
+                return null;
+            }
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/XmlAnalysis/LayoutTypeNormalizerTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/XmlAnalysis/LayoutTypeNormalizerTests.cs
@@ -1,0 +1,132 @@
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Services.XmlAnalysis;
+
+using Xunit;
+
+namespace LayoutParserApi.Tests.Services.XmlAnalysis
+{
+    /// <summary>
+    /// Cobre a issue #219 — gate `generate-for-layout` recusava o layout FIAT
+    /// `LAY_TXT_MQSERIES_ENVNFE_4.00_NFe` com "Tipo de layout não suportado: 2", porque
+    /// `tbLayout.LayoutType` (coluna SQL crua) carrega um código numérico legado do Sysmiddle em vez
+    /// do texto esperado ("TextPositional"/"XML").
+    /// </summary>
+    public class LayoutTypeNormalizerTests
+    {
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComValorJaTexto_UsaDiretoSemFallback()
+        {
+            var layout = new LayoutRecord { LayoutType = "TextPositional" };
+
+            var fallbackChamado = false;
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, _ => fallbackChamado = true);
+
+            Assert.Equal("TextPositional", result);
+            Assert.False(fallbackChamado);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComValorXmlTipo_UsaDiretoSemFallback()
+        {
+            var layout = new LayoutRecord { LayoutType = "XML" };
+
+            var fallbackChamado = false;
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, _ => fallbackChamado = true);
+
+            Assert.Equal("XML", result);
+            Assert.False(fallbackChamado);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComCodigoNumericoEXmlDescriptografadoDivergente_UsaValorDoXml()
+        {
+            // Caso real da issue #219: tbLayout.LayoutType = "2" (código numérico legado), mas o XML
+            // descriptografado do layout (fonte autoritativa, mesma usada por
+            // LayoutDatabaseService.IsTextPositionalLayout) diz corretamente "TextPositional".
+            var layout = new LayoutRecord
+            {
+                Name = "LAY_TXT_MQSERIES_ENVNFE_4.00_NFe",
+                LayoutGuid = Guid.Parse("ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c"),
+                LayoutType = "2",
+                DecryptedContent = "<LayoutVO><LayoutType>TextPositional</LayoutType></LayoutVO>"
+            };
+
+            string? mensagemFallback = null;
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, msg => mensagemFallback = msg);
+
+            Assert.Equal("TextPositional", result);
+            Assert.NotNull(mensagemFallback);
+            Assert.Contains("LayoutType='2'", mensagemFallback);
+            Assert.Contains("TextPositional", mensagemFallback);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComCodigoNumericoDoisEXmlAninhadoEmLayoutVoFilho_UsaValorDoXml()
+        {
+            // Mesma divergência, mas com o XML tendo LayoutVO como elemento filho do root (variação de
+            // estrutura já tratada por LayoutDatabaseService.IsTextPositionalLayout).
+            var layout = new LayoutRecord
+            {
+                LayoutType = "2",
+                DecryptedContent = "<Root><LayoutVO><LayoutType>XML</LayoutType></LayoutVO></Root>"
+            };
+
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout);
+
+            Assert.Equal("XML", result);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComCodigoNumericoDoisSemXmlLegivel_CaiNoFallbackHeuristico()
+        {
+            // Sem conteúdo XML disponível para confirmar — usa a heurística documentada (não
+            // confirmada pelo dono) baseada no padrão observado na issue #219.
+            var layout = new LayoutRecord
+            {
+                Name = "LAY_SEM_XML",
+                LayoutType = "2",
+                DecryptedContent = "",
+                ValueContent = ""
+            };
+
+            string? mensagemFallback = null;
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, msg => mensagemFallback = msg);
+
+            Assert.Equal("TextPositional", result);
+            Assert.NotNull(mensagemFallback);
+            Assert.Contains("NÃO FOI CONFIRMADA", mensagemFallback);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComTipoDesconhecidoSemXml_DevolveValorCruOriginal()
+        {
+            // Código sem nenhuma evidência (nem "2", nem XML legível) — não inventa, devolve o valor
+            // cru para o chamador decidir (hoje: rejeita com "Tipo de layout não suportado").
+            var layout = new LayoutRecord
+            {
+                LayoutType = "99",
+                DecryptedContent = ""
+            };
+
+            var fallbackChamado = false;
+            var result = LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout, _ => fallbackChamado = true);
+
+            Assert.Equal("99", result);
+            Assert.False(fallbackChamado);
+        }
+
+        [Fact]
+        public void ResolveEffectiveLayoutType_ComXmlMalformado_NaoLancaECaiNoFallbackOuValorCru()
+        {
+            var layout = new LayoutRecord
+            {
+                LayoutType = "2",
+                DecryptedContent = "<Root><LayoutVO><LayoutType>Text" // XML incompleto/malformado
+            };
+
+            var exception = Record.Exception(() => LayoutTypeNormalizer.ResolveEffectiveLayoutType(layout));
+
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Contexto

Issue #219: `POST /api/AutoTransformation/generate-for-layout` recusava o layout FIAT
`LAY_TXT_MQSERIES_ENVNFE_4.00_NFe` (GUID `ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c`) com
`"Tipo de layout não suportado: 2"`.

## Diagnóstico confirmado

`Services/XmlAnalysis/AutoTransformationGeneratorService.cs` comparava `layout.LayoutType`
(string crua vinda da coluna SQL `tbLayout.[LayoutType]`, via `LayoutDatabaseService`)
literalmente contra `"TextPositional"`/`"XML"`. Quando o cadastro do layout tem um código
numérico legado do Sysmiddle (ex.: `"2"`) em vez do texto esperado, o gate recusa o layout —
mesmo que ele seja, na prática, `TextPositional`.

Evidência forte: `LayoutDatabaseService.IsTextPositionalLayout` **já lida com essa mesma
divergência**, mas descarta o valor — ele lê `/LayoutVO/LayoutType` do XML descriptografado
do próprio layout (fonte comprovadamente autoritativa, é o que hoje decide se o layout entra
no catálogo Redis) e só devolve um `bool`, sem propagar o valor real.

## Fix (defensivo, em código)

`Services/XmlAnalysis/LayoutTypeNormalizer.cs` (classe estática nova, testável isoladamente) —
`ResolveEffectiveLayoutType`, chamada no início de `ProcessLayoutAsync`:

1. Se `LayoutType` cru já é `TextPositional`/`XML` (case-insensitive) → usa direto, sem log.
2. Senão, lê `/LayoutVO/LayoutType` do XML descriptografado do layout (mesma lógica de
   `LayoutDatabaseService.IsTextPositionalLayout`) — se achar um valor reconhecido, usa e
   **loga Warning** avisando da divergência SQL vs XML (auditável).
3. Senão, fallback heurístico: `"2"` → `TextPositional`. **Não confirmado pelo dono do
   produto** — só entra quando nem o XML está legível. Warning explícito deixando isso claro.
4. Senão, devolve o valor cru original (cai no warning "não suportado" já existente).

## Testes

`tests/LayoutParserApi.Tests/Services/XmlAnalysis/LayoutTypeNormalizerTests.cs` — 7 casos,
cobrindo os 4 passos de resolução (incluindo o caso real da issue, LayoutType="2" com XML
dizendo TextPositional) + XML malformado não deve lançar.

## Quality gates

- `dotnet build`: 0 erros.
- `dotnet test`: **584/584 verdes**, sem regressão.

## Nota de autoridade

Push/PR normalmente é exclusivo de `@lp-devops` (`.claude/rules/agent-authority.md`).
Autorizado **excepcionalmente pelo dono** nesta rodada para avançar a implementação sem
espera de handoff.

## O que este PR NÃO resolve

Correção defensiva de código — não substitui a correção do dado na origem
(`tbLayout.LayoutType` do layout FIAT específico no banco `ConnectUS_Macgyver`), que continua
pendente de confirmação/ajuste pelo dono do produto. Ver comentário na issue #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)