### PR TITLE
test(di): composition root real do Program.cs via WebApplicationFactory (issue #90)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -966,3 +966,11 @@ finally
         // Ignore errors during shutdown
     }
 }
+
+// ✅ Issue #90: expõe a classe `Program` gerada implicitamente pelos top-level statements como
+// `public partial`, sem mudar comportamento algum em produção — é só uma declaração de tipo
+// adicional para o compilador mesclar com a gerada automaticamente (que não tem modificador
+// explícito, então herda o `public` daqui em vez de gerar conflito de acessibilidade).
+// Necessário para `WebApplicationFactory<Program>` no projeto de testes, que está em outro
+// assembly e não enxergaria a classe se ela ficasse `internal` (default do gerado).
+public partial class Program;

--- a/appsettings.Testing.json
+++ b/appsettings.Testing.json
@@ -1,0 +1,29 @@
+{
+  "_comentario": "Issue #90: overrides mínimos para exercitar a composition root real (Program.cs) via WebApplicationFactory<Program>, sem tocar infraestrutura de produção/dev. Carregado automaticamente pelo ASP.NET Core quando ASPNETCORE_ENVIRONMENT=Testing (convenção appsettings.{Environment}.json), com precedência sobre o appsettings.json base.",
+
+  "Logging": {
+    "File": {
+      "Directory": "Logs\\Testing"
+    }
+  },
+
+  "Redis": {
+    "_comentario": "Conexão inválida DE PROPÓSITO, com timeout curto: o Redis é opcional (Program.cs já degrada com try/catch), mas o timeout default de conexão levaria ~5s por tentativa em cada teste. abortConnect=true faz falhar rápido em vez de tentar reconectar em background.",
+    "ConnectionString": "127.0.0.1:1,connectTimeout=200,abortConnect=true"
+  },
+
+  "Database": {
+    "_comentario": "Host inalcançável DE PROPÓSITO com timeout curto — o SQL só é tocado por IHostedService em background (CachePermanentWarmupBackgroundService), nunca de forma síncrona no startup; um timeout curto evita apenas ruído de log demorado durante o teste.",
+    "Server": "127.0.0.1,1",
+    "ConnectionTimeout": "1"
+  },
+
+  "IdentityDatabase": {
+    "Server": "127.0.0.1,1",
+    "ConnectionTimeout": "1"
+  },
+
+  "LowCode": {
+    "RunnerPath": ""
+  }
+}

--- a/tests/LayoutParserApi.Tests/LayoutParserApi.Tests.csproj
+++ b/tests/LayoutParserApi.Tests/LayoutParserApi.Tests.csproj
@@ -31,6 +31,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <!-- Issue #90: WebApplicationFactory<Program> para o teste de composition root real
+         (ProgramCompositionRootTests). Traz Microsoft.AspNetCore.Mvc.Testing, que já referencia
+         o FrameworkReference correto — não conflita com o FrameworkReference herdado via
+         ProjectReference da API abaixo. -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/LayoutParserApi.Tests/ProgramCompositionRootTests.cs
+++ b/tests/LayoutParserApi.Tests/ProgramCompositionRootTests.cs
@@ -1,0 +1,171 @@
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Services.Cache;
+using LayoutParserApi.Services.Database;
+using LayoutParserApi.Services.Fiscal;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Learning;
+using LayoutParserApi.Services.Parsing.Interfaces;
+using LayoutParserApi.Services.Transformation;
+using LayoutParserApi.Services.Transformation.Ai;
+using LayoutParserApi.Services.Transformation.LowCode;
+using LayoutParserApi.Services.Validation;
+using LayoutParserApi.Services.XmlAnalysis;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace LayoutParserApi.Tests
+{
+    /// <summary>
+    /// Issue #90: exercita a COMPOSIÇÃO REAL de <c>Program.cs</c> via
+    /// <see cref="WebApplicationFactory{TEntryPoint}"/>, em vez de uma <c>ServiceCollection</c>
+    /// montada à mão pelo teste (a mesma classe de defeito da issue #33, materializada de novo na
+    /// mutação M4 da PR #89 — ver <c>DataGenerationControllerDiTests</c> para o histórico).
+    ///
+    /// <para>Trade-off documentado em <c>DataGenerationControllerDiTests</c> (linhas 31-37) sobre
+    /// por que <c>WebApplicationFactory&lt;Program&gt;</c> tinha sido descartado: o host real lê
+    /// <c>Logging:File:Directory</c> do <c>appsettings.json</c> (caminho de produção), tenta
+    /// conectar no Redis e liga <c>IHostedService</c>s que dependem de SQL. A destrava é exatamente
+    /// a recomendada pelo <c>@lp-qa</c> nesse comentário: <c>appsettings.Testing.json</c>
+    /// (ambiente <c>Testing</c>) redireciona esses três pontos para valores que falham rápido/local,
+    /// sem exigir Redis/SQL no ar e sem escrever no diretório de log do servidor.</para>
+    ///
+    /// <para>O host sobe DE VERDADE (<c>CreateClient()</c> força <c>WebHost.Build()+Start()</c>),
+    /// então apagar um <c>AddScoped</c>/<c>AddSingleton</c>/<c>AddHostedService</c> do
+    /// <c>Program.cs</c> faz este teste falhar — diferente da suíte anterior, que só provava
+    /// resolvibilidade de uma cópia da composição.</para>
+    /// </summary>
+    public class ProgramCompositionRootTests : IClassFixture<ProgramCompositionRootTests.ApiFactory>
+    {
+        private readonly ApiFactory _factory;
+
+        public ProgramCompositionRootTests(ApiFactory factory)
+        {
+            _factory = factory;
+        }
+
+        /// <summary>
+        /// <c>WebApplicationFactory</c> customizada só para forçar o ambiente <c>Testing</c> (o
+        /// gatilho de convenção do ASP.NET Core para carregar <c>appsettings.Testing.json</c>) —
+        /// nenhum serviço é substituído/mockado aqui: é a composição real de <c>Program.cs</c>.
+        /// </summary>
+        public class ApiFactory : WebApplicationFactory<Program>
+        {
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                builder.UseEnvironment("Testing");
+            }
+        }
+
+        /// <summary>
+        /// O host precisa terminar de subir (<c>Build()+Start()</c>) sem lançar — isso já falha se
+        /// QUALQUER registro obrigatório sumir do <c>Program.cs</c> (dependência não resolvível de
+        /// um controller/serviço referenciado na composição).
+        /// </summary>
+        [Fact]
+        public void Host_sobe_com_a_composicao_real_do_Program_cs()
+        {
+            using var scope = _factory.Services.CreateScope();
+            Assert.NotNull(scope.ServiceProvider);
+        }
+
+        /// <summary>
+        /// Guarda específica do critério de aceite da issue #90: a mutação M4 (comentar o
+        /// <c>AddHostedService&lt;AiCandidateStoreCleanupBackgroundService&gt;()</c>) tem que deixar
+        /// este teste VERMELHO. <c>IHostedService</c> não é resolvível por tipo concreto via
+        /// <c>GetService</c> — o container expõe todos os hosted services registrados através da
+        /// coleção <see cref="IHostedService"/>, então localizamos o nosso ali dentro.
+        /// </summary>
+        [Fact]
+        public void Program_cs_registra_os_tres_hosted_services_esperados()
+        {
+            var hostedServices = _factory.Services.GetServices<IHostedService>().ToList();
+
+            Assert.Contains(hostedServices, s => s is CachePermanentWarmupBackgroundService);
+            Assert.Contains(hostedServices, s => s is AiCandidateStoreCleanupBackgroundService);
+            Assert.Contains(hostedServices, s => s is LayoutValidationBackgroundService);
+        }
+
+        // --- Grupos de DI cobertos além de Generation (issue #90 pede 2-3 grupos) ---
+
+        [Theory]
+        // Cache
+        [InlineData(typeof(ILayoutCacheService))]
+        // Database
+        [InlineData(typeof(ILayoutDatabaseService))]
+        [InlineData(typeof(IDecryptionService))]
+        [InlineData(typeof(MapperDatabaseService))]
+        [InlineData(typeof(ICachedLayoutService))]
+        // XML Analysis
+        [InlineData(typeof(XmlAnalysisService))]
+        [InlineData(typeof(XsdValidationService))]
+        [InlineData(typeof(XmlDocumentTypeDetector))]
+        // Transformation
+        [InlineData(typeof(TransformationPipelineService))]
+        [InlineData(typeof(TclGeneratorService))]
+        [InlineData(typeof(XslGeneratorService))]
+        // Parsing
+        [InlineData(typeof(ILineSplitter))]
+        [InlineData(typeof(ILayoutValidator))]
+        [InlineData(typeof(ILayoutParserService))]
+        // Mapper Cache
+        [InlineData(typeof(ICachedMapperService))]
+        // Learning
+        [InlineData(typeof(ExampleLearningService))]
+        [InlineData(typeof(LayoutLearningService))]
+        // Validation
+        [InlineData(typeof(LayoutValidationService))]
+        [InlineData(typeof(DocumentValidationService))]
+        // Audit/Logging
+        [InlineData(typeof(IAuditLogger))]
+        [InlineData(typeof(ITechLogger))]
+        // LowCode (Transformation, Singleton)
+        [InlineData(typeof(LowCodeTransformationService))]
+        [InlineData(typeof(LowCodeAutoTransformationService))]
+        public void Servico_do_grupo_de_DI_resolve_sem_excecao(Type tipoDoServico)
+        {
+            using var scope = _factory.Services.CreateScope();
+
+            var servico = scope.ServiceProvider.GetRequiredService(tipoDoServico);
+
+            Assert.NotNull(servico);
+        }
+
+        /// <summary>
+        /// Controller real de um endpoint que depende de vários grupos ao mesmo tempo
+        /// (transformação low-code, IA, validação, banco) — resolver ele prova que a fiação entre
+        /// grupos também está correta, não só cada grupo isolado.
+        /// </summary>
+        [Fact]
+        public void TransformationExecutionController_resolve_pela_composicao_real()
+        {
+            using var scope = _factory.Services.CreateScope();
+
+            // Controllers do MVC não ficam registrados no container por tipo (o pipeline padrão os
+            // ativa via IControllerActivator/ActivatorUtilities, não via GetRequiredService) — usar
+            // ActivatorUtilities aqui reproduz a MESMA forma de ativação usada em runtime pelo
+            // framework, resolvendo cada dependência do construtor pelo container real.
+            var controller = ActivatorUtilities.CreateInstance<TransformationExecutionController>(scope.ServiceProvider);
+
+            Assert.NotNull(controller);
+        }
+
+        /// <summary>
+        /// O grupo Generation continua coberto — não é redundante em relação ao gate existente
+        /// (<c>AddGenerationServices</c>/<c>DataGenerationControllerDiTests</c>): aquele prova que o
+        /// GRUPO, isolado, resolve; este prova que ele resolve DENTRO da composição real completa
+        /// (nenhum outro registro do Program.cs conflita/sombra ele).
+        /// </summary>
+        [Fact]
+        public void DataGenerationController_resolve_pela_composicao_real()
+        {
+            using var scope = _factory.Services.CreateScope();
+
+            var controller = ActivatorUtilities.CreateInstance<DataGenerationController>(scope.ServiceProvider);
+
+            Assert.NotNull(controller);
+        }
+    }
+}


### PR DESCRIPTION
## Nota de processo
Autoridade de `git push`/`gh pr create` é normalmente exclusiva do `@lp-devops`. Nesta rodada o dono do projeto autorizou explicitamente que o `@lp-backend-dev` fizesse push e abrisse a(s) PR(s) diretamente — exceção pontual, não mudança da matriz de autoridade (`.claude/rules/agent-authority.md`).

## O que muda
Fecha a issue #90: hoje só o grupo `Generation` tinha um gate de DI que falha se o registro sumir do `Program.cs` real. Todo o resto (54 `AddScoped`/`AddSingleton`/`AddTransient` + 3 `AddHostedService`) só era coberto pelo build, que passa mesmo com DI quebrado (precedente: issue #33, e a mutação M4 da PR #89 que motivou esta issue).

- **`appsettings.Testing.json`** (novo): overrides mínimos para o ambiente `Testing` — `Logging:File:Directory` deixa de apontar pro servidor, `Redis`/`Database`/`IdentityDatabase` apontam para endpoints que falham rápido (sem exigir infra no ar), `LowCode:RunnerPath` vazio.
- **`Program.cs`**: adiciona `public partial class Program;` no fim do arquivo — não muda comportamento algum, só expõe a classe implícita dos top-level statements para o `WebApplicationFactory<Program>` do projeto de teste (assembly diferente).
- **`ProgramCompositionRootTests.cs`** (novo): sobe o host real via `WebApplicationFactory<Program>` (ambiente `Testing`) e verifica:
  - os 3 `AddHostedService` esperados (inclui `AiCandidateStoreCleanupBackgroundService`, alvo exato da mutação M4);
  - resolução sem exceção de serviços dos grupos Cache, Database, XML Analysis, Transformation, Parsing, Mapper Cache, Learning, Validation, Audit/Logging e LowCode;
  - `TransformationExecutionController` e `DataGenerationController` resolvidos pela composição completa (via `ActivatorUtilities`, mesma forma de ativação do MVC em runtime — controllers não ficam registrados por tipo no container).
- **`LayoutParserApi.Tests.csproj`**: adiciona `Microsoft.AspNetCore.Mvc.Testing`.

O gate por grupo existente (`AddGenerationServices`/`DataGenerationControllerDiTests`) foi mantido — não é redundante: prova que o grupo isolado resolve, este novo teste prova que ele resolve DENTRO da composição real completa.

## Quality gates
```
dotnet build      # verde
dotnet test       # 605/605 (suíte completa, incluindo os 27 testes novos)
```

## Próximos passos
- `@lp-doc`: nenhuma mudança de contrato de endpoint — não precisa atualizar Swagger/README.
- `@lp-qa`: se quiser reproduzir a mutação M4 contra este teste (comentar o `AddHostedService` e confirmar vermelho), o teste alvo é `Program_cs_registra_os_tres_hosted_services_esperados`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
