### PR TITLE
fix(tests): corrige build quebrado por parametro historyOptions ausente

### DIFF
--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
@@ -134,7 +134,8 @@ namespace LayoutParserApi.Tests.Controllers
                 aiUserInstructionStore: new AiUserInstructionStore(),
                 aiUserSessionStore: new SqlAiUserSessionStore(
                     NullLogger<SqlAiUserSessionStore>.Instance,
-                    new ConfigurationBuilder().Build()),
+                    new ConfigurationBuilder().Build(),
+                    Options.Create(new AiUserSessionHistoryOptions())),
                 currentUser: user,
                 mapperDb: null!,
                 layoutParser: null!,


### PR DESCRIPTION
Corrige o build quebrado em `develop` reportado no deploy de dev (PR #301): PR #297 (TTL, issue #97) adicionou o parâmetro obrigatório `IOptions<AiUserSessionHistoryOptions>` ao construtor de `SqlAiUserSessionStore`, e PR #299 (double x86, issue #104), mergeada quase ao mesmo tempo, instanciava o store direto em `TransformationExecutionControllerEndToEndAiCandidateTests.cs` sem esse parâmetro — clássico conflito silencioso entre duas PRs independentes que não se viam.

Fix: passa `Options.Create(new AiUserSessionHistoryOptions())` (mesmo padrão já usado em `SqlAiUserSessionStoreRetentionTests.cs`).

`dotnet build` 0 erros, `dotnet test` 624/624 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)