### PR TITLE
fix(swagger): corrige 500 em /api/swagger/v1/swagger.json

### DIFF
--- a/Controllers/ParseController.cs
+++ b/Controllers/ParseController.cs
@@ -742,8 +742,13 @@ namespace LayoutParserApi.Controllers
         [ProducesResponseType(typeof(AutomaticParseResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(AutomaticParseResponse), StatusCodes.Status422UnprocessableEntity)]
 #pragma warning disable SCS0016 // A API não usa autenticação por cookie: aceita identidade apenas do BFF em loopback.
+        // ✅ FIX (2026-09-03): documentFile NÃO leva [FromForm] explícito — o model binding do
+        // ASP.NET Core já trata IFormFile como multipart/form-data automaticamente, e o
+        // Swashbuckle não sabe gerar schema para [FromForm] + IFormFile combinados (quebrava
+        // /api/swagger/v1/swagger.json com 500 em produção). Mesmo padrão já usado em
+        // Upload/Detect deste controller — não reintroduza o atributo aqui.
         public async Task<IActionResult> Auto(
-            [FromForm] IFormFile? documentFile,
+            IFormFile? documentFile,
             [FromForm] string? layoutGuidOverride,
             [FromServices] IAutomaticLayoutDetectionService automaticLayoutDetection,
             CancellationToken cancellationToken)


### PR DESCRIPTION
Corrige o bug reportado pelo dono (Swagger em produção não abria) — `ParseController.Auto` usava `[FromForm] IFormFile?` explícito, combinação que o Swashbuckle não sabe gerar schema, quebrando `/api/swagger/v1/swagger.json` com 500 em qualquer ambiente. `Upload`/`Detect` no mesmo controller já usavam o padrão correto (`IFormFile` sem `[FromForm]`).

**Reproduzido localmente** rodando a API com `ASPNETCORE_ENVIRONMENT=Production`: 500 antes do fix (stack trace confirma `SwaggerGeneratorException` em `ParseController.Auto`), 200 depois.

`dotnet build` 0 erros, `dotnet test` 624/624 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)