### PR TITLE
feat(mapping-release): endpoint de listagem paginada por workspace (front #198)

### DIFF
--- a/Controllers/MappingGovernanceController.cs
+++ b/Controllers/MappingGovernanceController.cs
@@ -41,6 +41,34 @@ namespace LayoutParserApi.Controllers
             _logger = logger;
         }
 
+        /// <summary>
+        /// Lista releases do workspace, paginado (issue #198 do front — não havia NENHUM endpoint de
+        /// descoberta: os 3 endpoints de governança abaixo exigem <c>releaseId</c> já conhecido).
+        /// Rota própria (sem <c>{releaseId}</c>) via <c>~/</c> porque a rota base do controller já fixa
+        /// esse segmento. Qualquer papel do workspace pode ler — só as mutações (approve/publish/
+        /// rollback) exigem papel elevado.
+        /// </summary>
+        [HttpGet("~/api/workspaces/{workspaceId:guid}/mapping-releases")]
+        [RequireWorkspaceRole(WorkspaceRole.Owner, WorkspaceRole.FiscalAdmin, WorkspaceRole.Mapper, WorkspaceRole.Reviewer, WorkspaceRole.Operator, WorkspaceRole.Viewer)]
+        public async Task<IActionResult> List(Guid workspaceId, [FromQuery] int page = 1, [FromQuery] int pageSize = 20, CancellationToken cancellationToken = default)
+        {
+            if (page < 1)
+                return BadRequest(new { error = "\"page\" deve ser >= 1." });
+
+            if (pageSize < 1 || pageSize > 100)
+                return BadRequest(new { error = "\"pageSize\" deve estar entre 1 e 100." });
+
+            var (items, totalCount) = await _releaseStore.ListByWorkspaceAsync(workspaceId, page, pageSize, cancellationToken);
+
+            return Ok(new
+            {
+                items = items.Select(ToReleaseResponse),
+                page,
+                pageSize,
+                totalCount,
+            });
+        }
+
         /// <summary><c>test_passed → in_review → approved</c>. Bloqueado se a release estiver <c>test_failed</c> (ou qualquer status diferente de <c>test_passed</c>).</summary>
         [HttpPost("approve")]
         [RequireWorkspaceRole(WorkspaceRole.Reviewer, WorkspaceRole.FiscalAdmin)]

--- a/Services/Database/SqlMappingReleaseStore.cs
+++ b/Services/Database/SqlMappingReleaseStore.cs
@@ -123,6 +123,43 @@ namespace LayoutParserApi.Services.Database
             return ReadReleaseDetail(reader);
         }
 
+        public async Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(
+            Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            var items = new List<MappingReleaseDetail>();
+            var totalCount = 0;
+
+            // COUNT(*) OVER() traz o total na mesma ida ao banco — evita um segundo round-trip só
+            // para paginação. Isolamento por WorkspaceId direto na cláusula WHERE (nunca em memória).
+            using var command = new SqlCommand(
+                @"SELECT ReleaseId, WorkspaceId, DraftId, Engine, ArtifactsJson, SourceRuleIdsJson,
+                         CompileDiagnosticsJson, RulesSnapshotHash, TestRunSummaryJson, Status, CorrelationId,
+                         CreatedAt, RowVersion, Environment, ApprovedByUserId, ApprovedAt, ApprovalJustification,
+                         PublishedByUserId, PublishedAt, PreviousPublishedReleaseId,
+                         COUNT(*) OVER() AS TotalCount
+                  FROM dbo.tbMappingRelease
+                  WHERE WorkspaceId = @WorkspaceId
+                  ORDER BY CreatedAt DESC
+                  OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY;",
+                connection);
+            command.Parameters.AddWithValue("@WorkspaceId", workspaceId);
+            command.Parameters.AddWithValue("@Offset", (page - 1) * pageSize);
+            command.Parameters.AddWithValue("@PageSize", pageSize);
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                items.Add(ReadReleaseDetail(reader));
+                totalCount = reader.GetInt32(reader.GetOrdinal("TotalCount"));
+            }
+
+            return (items, totalCount);
+        }
+
         public async Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken)
         {
             using var connection = new SqlConnection(_connectionString);

--- a/Services/Interfaces/IMappingReleaseStore.cs
+++ b/Services/Interfaces/IMappingReleaseStore.cs
@@ -59,6 +59,15 @@ namespace LayoutParserApi.Services.Interfaces
 
         Task<MappingReleaseDetail?> GetReleaseIfMemberAsync(Guid releaseId, Guid userId, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Lista releases do workspace, paginado e ordenado por <c>CreatedAt DESC</c> (mais recente
+        /// primeiro). Isolamento por <paramref name="workspaceId"/> feito na query SQL — nunca filtra
+        /// em memória (RBAC de acesso ao workspace já é responsabilidade de
+        /// <c>RequireWorkspaceRoleAttribute</c> no controller).
+        /// </summary>
+        Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(
+            Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken);
+
         /// <summary>Atualiza o resultado do Fiscal Test Lab — <c>test_passed</c>/<c>test_failed</c> conforme <see cref="MappingTestRunSummary.RequiredGatesPassed"/>.</summary>
         Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken);
 

--- a/tests/LayoutParserApi.Tests/Controllers/MappingGovernanceControllerTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/MappingGovernanceControllerTests.cs
@@ -73,6 +73,13 @@ namespace LayoutParserApi.Tests.Controllers
             public Task<MappingReleaseDetail?> GetReleaseIfMemberAsync(Guid releaseId, Guid userId, CancellationToken cancellationToken)
                 => Task.FromResult(ById.TryGetValue(releaseId, out var r) ? r : null);
 
+            public Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken)
+            {
+                var doWorkspace = ById.Values.Where(r => r.WorkspaceId == workspaceId).OrderByDescending(r => r.CreatedAt).ToList();
+                var pagina = doWorkspace.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+                return Task.FromResult(((IReadOnlyList<MappingReleaseDetail>)pagina, doWorkspace.Count));
+            }
+
             public Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken)
                 => throw new NotSupportedException();
 
@@ -352,6 +359,101 @@ namespace LayoutParserApi.Tests.Controllers
             var result = await RunFilterAsync(filter, workspaceId, userId, currentUser);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        // --- Listagem (issue #198 do front) ---
+
+        [Fact]
+        public async Task List_workspace_sem_releases_retorna_vazio()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var controller = BuildController(store, new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.List(workspaceId, 1, 20, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = Assert.IsAssignableFrom<object>(ok.Value);
+            var totalCount = (int)payload.GetType().GetProperty("totalCount")!.GetValue(payload)!;
+            var items = (System.Collections.IEnumerable)payload.GetType().GetProperty("items")!.GetValue(payload)!;
+            Assert.Equal(0, totalCount);
+            Assert.Empty(items.Cast<object>());
+        }
+
+        [Fact]
+        public async Task List_pagina_multiplas_releases_do_workspace()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            for (var i = 0; i < 5; i++)
+            {
+                var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.DraftCompiled);
+                store.ById[release.ReleaseId] = release;
+            }
+
+            var controller = BuildController(store, new FakeCurrentUser { UserId = Guid.NewGuid() });
+            var result = await controller.List(workspaceId, 1, 2, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ok.Value!;
+            var totalCount = (int)payload.GetType().GetProperty("totalCount")!.GetValue(payload)!;
+            var items = ((System.Collections.IEnumerable)payload.GetType().GetProperty("items")!.GetValue(payload)!).Cast<object>().ToList();
+            Assert.Equal(5, totalCount); // total real, mesmo a página trazendo só 2.
+            Assert.Equal(2, items.Count);
+        }
+
+        [Fact]
+        public async Task List_isola_releases_de_outro_workspace()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var outroWorkspaceId = Guid.NewGuid();
+            var releaseDoWorkspace = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.DraftCompiled);
+            var releaseDeOutro = NewRelease(outroWorkspaceId, Guid.NewGuid(), MappingReleaseStatus.DraftCompiled);
+            store.ById[releaseDoWorkspace.ReleaseId] = releaseDoWorkspace;
+            store.ById[releaseDeOutro.ReleaseId] = releaseDeOutro;
+
+            var controller = BuildController(store, new FakeCurrentUser { UserId = Guid.NewGuid() });
+            var result = await controller.List(workspaceId, 1, 20, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ok.Value!;
+            var totalCount = (int)payload.GetType().GetProperty("totalCount")!.GetValue(payload)!;
+            Assert.Equal(1, totalCount); // a release do outro workspace não aparece.
+        }
+
+        [Theory]
+        [InlineData(0, 20)]
+        [InlineData(-1, 20)]
+        [InlineData(1, 0)]
+        [InlineData(1, 101)]
+        public async Task List_parametros_invalidos_retorna_400(int page, int pageSize)
+        {
+            var store = new FakeReleaseStore();
+            var controller = BuildController(store, new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.List(Guid.NewGuid(), page, pageSize, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        // --- RBAC do endpoint de leitura: Viewer (papel mais baixo) tem acesso, diferente das mutações ---
+
+        [Fact]
+        public async Task RequireWorkspaceRole_leitura_aceita_viewer()
+        {
+            var workspaceId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var workspaceStore = new FakeIdentityWorkspaceStore();
+            workspaceStore.Memberships[(workspaceId, userId)] = WorkspaceRole.Viewer;
+            var currentUser = new FakeCurrentUser { UserId = userId };
+            var filter = new RequireWorkspaceRoleFilter(
+                new[] { WorkspaceRole.Owner, WorkspaceRole.FiscalAdmin, WorkspaceRole.Mapper, WorkspaceRole.Reviewer, WorkspaceRole.Operator, WorkspaceRole.Viewer },
+                currentUser, workspaceStore, NullLogger<RequireWorkspaceRoleFilter>.Instance);
+
+            var result = await RunFilterAsync(filter, workspaceId, userId, currentUser);
+
+            Assert.IsType<OkResult>(result);
         }
     }
 }

--- a/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
+++ b/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
@@ -195,6 +195,9 @@ namespace LayoutParserApi.Tests.Integration
             public Task<MappingReleaseDetail?> GetReleaseIfMemberAsync(Guid releaseId, Guid userId, CancellationToken cancellationToken)
                 => Task.FromResult(ById.TryGetValue(releaseId, out var r) ? r : null);
 
+            public Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
             public Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken)
             {
                 if (!ById.TryGetValue(releaseId, out var existing))

--- a/tests/LayoutParserApi.Tests/Services/Fiscal/MappingCompileServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Fiscal/MappingCompileServiceTests.cs
@@ -62,6 +62,9 @@ namespace LayoutParserApi.Tests.Services.Fiscal
             public Task<MappingReleaseDetail?> GetReleaseIfMemberAsync(Guid releaseId, Guid userId, CancellationToken cancellationToken)
                 => Task.FromResult(ById.TryGetValue(releaseId, out var r) ? r : null);
 
+            public Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
             public Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken)
             {
                 if (!ById.TryGetValue(releaseId, out var existing))

--- a/tests/LayoutParserApi.Tests/Services/Fiscal/MappingTestRunServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Fiscal/MappingTestRunServiceTests.cs
@@ -30,6 +30,9 @@ namespace LayoutParserApi.Tests.Services.Fiscal
             public Task<MappingReleaseDetail?> GetReleaseIfMemberAsync(Guid releaseId, Guid userId, CancellationToken cancellationToken)
                 => Task.FromResult(Release?.ReleaseId == releaseId ? Release : null);
 
+            public Task<(IReadOnlyList<MappingReleaseDetail> Items, int TotalCount)> ListByWorkspaceAsync(Guid workspaceId, int page, int pageSize, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
             public Task<MappingReleaseDetail?> ApplyTestRunResultAsync(Guid releaseId, MappingTestRunSummary summary, CancellationToken cancellationToken)
             {
                 LastAppliedSummary = summary;


### PR DESCRIPTION
Resolve o gap de contrato reportado pelo front-end (LayoutParserReact issue #198, prioridade alta, bloqueio total): nao existia nenhum endpoint de listagem de MappingRelease, so busca por releaseId ja conhecido.

## Contrato

GET /api/workspaces/{workspaceId}/mapping-releases?page={page}&pageSize={pageSize}

- page (default 1, min 1), pageSize (default 20, entre 1-100) - 400 se fora da faixa.
- Isolamento por workspace na query SQL (nunca em memoria). Sem membership -> 404.
- RBAC: qualquer papel do workspace pode listar (leitura), diferente de approve/publish/rollback.
- Resposta: { items: [...], page, pageSize, totalCount }, ordenado por CreatedAt DESC. Cada item reaproveita o shape ja usado em approve/publish/rollback (releaseId, workspaceId, draftId, engine, status, environment, approvedByUserId, approvedAt, approvalJustification, publishedByUserId, publishedAt, previousPublishedReleaseId, correlationId, eTag).

So lista releases (nao drafts) - a issue #198 menciona releases explicitamente; MappingDraft tem ciclo de vida e store separados.

dotnet build verde, dotnet test 648/648 (8 novos, 0 regressao).

Push feito pelo orquestrador - trabalho implementado por @lp-backend-dev, que corretamente nao fez push por conta propria (autoridade exclusiva de @lp-devops).

Generated with Claude Code