### PR TITLE
feat(fiscal): listagem de projetos, nova revisao de pacote e inventario Excel (front #201)

### DIFF
--- a/Controllers/FiscalMappingPackagesController.cs
+++ b/Controllers/FiscalMappingPackagesController.cs
@@ -119,6 +119,156 @@ namespace LayoutParserApi.Controllers
             return CreatedAtAction(nameof(GetPackage), new { workspaceId, packageId = package.PackageId }, ToResponse(package));
         }
 
+        /// <summary>
+        /// Lista os projetos fiscais do workspace (Gap 1 — issue #201/#229). Leitura pura — NÃO é o
+        /// CRUD completo de projeto descartado na decisão original da issue #229 (ver
+        /// <see cref="FiscalProject"/>); existe só para o front-end navegar/selecionar projeto sem
+        /// exigir o GUID colado manualmente.
+        /// </summary>
+        [HttpGet("projects")]
+        public async Task<IActionResult> ListProjects(Guid workspaceId, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound();
+
+            WorkspaceSummary? membership;
+            try
+            {
+                membership = await _identityWorkspaceService.GetWorkspaceForMemberAsync(workspaceId, userId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao verificar membership do workspace {WorkspaceId} para listar projetos.", workspaceId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Não foi possível listar os projetos no momento." });
+            }
+
+            if (membership == null)
+                return NotFound();
+
+            IReadOnlyList<Services.Interfaces.ProjectSummary> projects;
+            try
+            {
+                projects = await _packageService.ListProjectsAsync(workspaceId, userId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao listar projetos do workspace {WorkspaceId}.", workspaceId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Não foi possível listar os projetos no momento." });
+            }
+
+            return Ok(new
+            {
+                projects = projects.Select(p => new
+                {
+                    projectId = p.ProjectId,
+                    workspaceId = p.WorkspaceId,
+                    name = p.Name,
+                    createdAt = p.CreatedAt
+                })
+            });
+        }
+
+        /// <summary>
+        /// Cria uma nova revisão de um pacote já existente (Gap 2 — issue #201). Mesmo formato
+        /// multipart de <see cref="CreatePackage"/> — cada arquivo identificado pelo NOME DO CAMPO.
+        /// </summary>
+#pragma warning disable SCS0016
+        [HttpPost("mapping-packages/{packageId:guid}/revisions")]
+        [RequestSizeLimit(10 * Services.Validation.MultipartUploadValidator.MaxArtifactSizeBytes)]
+        public async Task<IActionResult> CreateRevision(
+            Guid workspaceId,
+            Guid packageId,
+            CancellationToken cancellationToken)
+#pragma warning restore SCS0016
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound();
+
+            if (Request.Form.Files.Count == 0)
+                return UnprocessableEntity(new { error = "Nenhum artefato enviado." });
+
+            if (Request.Form.Files.Count > MaxArtifactsPerUpload)
+                return UnprocessableEntity(new { error = $"Excede o limite de {MaxArtifactsPerUpload} artefatos por upload." });
+
+            var artifacts = new List<UploadedArtifactInput>();
+            foreach (var file in Request.Form.Files)
+            {
+                if (!ArtifactKind.IsValid(file.Name))
+                    return UnprocessableEntity(new { error = $"Campo de upload desconhecido: \"{file.Name}\". Esperado um de: {string.Join(", ", ArtifactKind.All)}." });
+
+                if (file.Length == 0)
+                    return UnprocessableEntity(new { error = $"Artefato \"{file.Name}\" está vazio." });
+
+                if (file.Length > Services.Validation.MultipartUploadValidator.MaxArtifactSizeBytes)
+                    return UnprocessableEntity(new { error = $"Artefato \"{file.Name}\" excede o limite de tamanho." });
+
+                using var memoryStream = new MemoryStream();
+                await file.CopyToAsync(memoryStream, cancellationToken);
+
+                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray()));
+            }
+
+            CreateRevisionOutcome outcome;
+            try
+            {
+                outcome = await _packageService.CreateRevisionAsync(workspaceId, packageId, userId, artifacts, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao criar revisão do pacote de mapeamento fiscal {PackageId} (workspace={WorkspaceId}).", packageId, workspaceId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Não foi possível criar a revisão no momento." });
+            }
+
+            if (outcome.NotFound)
+                return NotFound();
+
+            if (!outcome.Success)
+                return UnprocessableEntity(new { error = outcome.Error });
+
+            return CreatedAtAction(nameof(GetPackage), new { workspaceId, packageId }, ToResponse(outcome.Package!));
+        }
+
+        /// <summary>
+        /// Inventário de estrutura (abas/colunas/linhas) de um artefato <c>spec</c> (XLSX) da revisão
+        /// mais recente (Gap 3 — issue #201) — reusa <see cref="Services.Fiscal.FiscalMappingRuleExtractor"/>,
+        /// sem devolver o conteúdo bruto da planilha.
+        /// </summary>
+        [HttpGet("mapping-packages/{packageId:guid}/artifacts/{artifactId:guid}/excel-inventory")]
+        public async Task<IActionResult> GetExcelInventory(Guid workspaceId, Guid packageId, Guid artifactId, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound();
+
+            ExcelInventoryOutcome outcome;
+            try
+            {
+                outcome = await _packageService.GetExcelInventoryAsync(workspaceId, packageId, artifactId, userId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao gerar inventário do artefato {ArtifactId} (pacote={PackageId}).", artifactId, packageId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Não foi possível gerar o inventário no momento." });
+            }
+
+            if (outcome.NotFound)
+                return NotFound();
+
+            if (!outcome.Success)
+                return UnprocessableEntity(new { error = outcome.Error });
+
+            var inventory = outcome.Inventory!;
+            return Ok(new
+            {
+                decisionSheets = inventory.DecisionSheets.Select(s => new
+                {
+                    sheetName = s.SheetName,
+                    columns = s.Columns,
+                    ruleCount = s.RuleCount
+                }),
+                skippedSheets = inventory.SkippedSheets
+            });
+        }
+
         /// <summary>Pacote + inventário de artefatos da revisão mais recente. Nunca expõe conteúdo bruto.</summary>
         [HttpGet("mapping-packages/{packageId:guid}")]
         public async Task<IActionResult> GetPackage(Guid workspaceId, Guid packageId, CancellationToken cancellationToken)

--- a/Services/Database/SqlFiscalPackageStore.cs
+++ b/Services/Database/SqlFiscalPackageStore.cs
@@ -400,6 +400,162 @@ namespace LayoutParserApi.Services.Database
             await command.ExecuteNonQueryAsync(cancellationToken);
         }
 
+        public async Task<IReadOnlyList<ProjectSummary>> ListProjectsForMemberAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            // Join com tbWorkspaceMembership: defesa em profundidade — o controller já checou
+            // membership antes de chamar, mas a store nunca confia cegamente no WorkspaceId da rota.
+            using var command = new SqlCommand(
+                @"SELECT p.ProjectId, p.WorkspaceId, p.Name, p.CreatedAt
+                  FROM dbo.tbFiscalProject p
+                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = p.WorkspaceId AND m.UserId = @UserId
+                  WHERE p.WorkspaceId = @WorkspaceId
+                  ORDER BY p.CreatedAt DESC;",
+                connection);
+            command.Parameters.AddWithValue("@WorkspaceId", workspaceId);
+            command.Parameters.AddWithValue("@UserId", userId);
+
+            var projects = new List<ProjectSummary>();
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                projects.Add(new ProjectSummary(
+                    reader.GetGuid(reader.GetOrdinal("ProjectId")),
+                    reader.GetGuid(reader.GetOrdinal("WorkspaceId")),
+                    reader.GetString(reader.GetOrdinal("Name")),
+                    new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("CreatedAt")), TimeSpan.Zero)));
+            }
+
+            return projects;
+        }
+
+        public async Task<PackageDetail> CreateRevisionAsync(
+            Guid packageId,
+            Guid createdByUserId,
+            IReadOnlyList<PackageArtifact> artifacts,
+            CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            var revisionId = Guid.NewGuid();
+            var createdAt = DateTimeOffset.UtcNow;
+
+            using var tx = connection.BeginTransaction();
+            try
+            {
+                int revisionNumber;
+                using (var selectMax = new SqlCommand(
+                    "SELECT ISNULL(MAX(RevisionNumber), 0) FROM dbo.tbFiscalMappingPackageRevision WHERE PackageId = @PackageId;",
+                    connection, tx))
+                {
+                    selectMax.Parameters.AddWithValue("@PackageId", packageId);
+                    revisionNumber = (int)await selectMax.ExecuteScalarAsync(cancellationToken) + 1;
+                }
+
+                using (var insertRevision = new SqlCommand(
+                    @"INSERT INTO dbo.tbFiscalMappingPackageRevision (RevisionId, PackageId, RevisionNumber, CreatedByUserId, CreatedAt)
+                      VALUES (@RevisionId, @PackageId, @RevisionNumber, @CreatedByUserId, SYSUTCDATETIME());",
+                    connection, tx))
+                {
+                    insertRevision.Parameters.AddWithValue("@RevisionId", revisionId);
+                    insertRevision.Parameters.AddWithValue("@PackageId", packageId);
+                    insertRevision.Parameters.AddWithValue("@RevisionNumber", revisionNumber);
+                    insertRevision.Parameters.AddWithValue("@CreatedByUserId", createdByUserId);
+                    await insertRevision.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                foreach (var artifact in artifacts)
+                {
+                    artifact.ArtifactId = artifact.ArtifactId == Guid.Empty ? Guid.NewGuid() : artifact.ArtifactId;
+                    artifact.RevisionId = revisionId;
+
+                    using var insertArtifact = new SqlCommand(
+                        @"INSERT INTO dbo.tbPackageArtifact
+                            (ArtifactId, RevisionId, Kind, Sha256, SizeBytes, OriginalFileName, MimeDeclared, MimeSniffed,
+                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath)
+                          VALUES
+                            (@ArtifactId, @RevisionId, @Kind, @Sha256, @SizeBytes, @OriginalFileName, @MimeDeclared, @MimeSniffed,
+                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath);",
+                        connection, tx);
+
+                    insertArtifact.Parameters.AddWithValue("@ArtifactId", artifact.ArtifactId);
+                    insertArtifact.Parameters.AddWithValue("@RevisionId", revisionId);
+                    insertArtifact.Parameters.AddWithValue("@Kind", artifact.Kind);
+                    insertArtifact.Parameters.AddWithValue("@Sha256", artifact.Sha256);
+                    insertArtifact.Parameters.AddWithValue("@SizeBytes", artifact.SizeBytes);
+                    insertArtifact.Parameters.AddWithValue("@OriginalFileName", artifact.OriginalFileName);
+                    insertArtifact.Parameters.AddWithValue("@MimeDeclared", artifact.MimeDeclared);
+                    insertArtifact.Parameters.AddWithValue("@MimeSniffed", artifact.MimeSniffed);
+                    insertArtifact.Parameters.AddWithValue("@UploadedByUserId", artifact.UploadedByUserId);
+                    insertArtifact.Parameters.AddWithValue("@Classification", (object?)artifact.Classification ?? DBNull.Value);
+                    insertArtifact.Parameters.AddWithValue("@RetentionPolicy", (object?)artifact.RetentionPolicy ?? DBNull.Value);
+                    insertArtifact.Parameters.AddWithValue("@InspectionStatus", artifact.InspectionStatus);
+                    insertArtifact.Parameters.AddWithValue("@StoragePath", artifact.StoragePath);
+                    await insertArtifact.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                await tx.CommitAsync(cancellationToken);
+
+                var packageDetail = await LoadPackageHeaderAsync(connection, packageId, cancellationToken)
+                    ?? throw new InvalidOperationException($"Pacote {packageId} sumiu durante a criação da revisão.");
+
+                return packageDetail with
+                {
+                    LatestRevision = new RevisionSummary(
+                        revisionId,
+                        revisionNumber,
+                        createdAt,
+                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt)).ToList())
+                };
+            }
+            catch
+            {
+                await tx.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        /// <summary>Só o cabeçalho do pacote (sem revisão) — usado internamente por <see cref="CreateRevisionAsync"/>.</summary>
+        private static async Task<PackageDetail?> LoadPackageHeaderAsync(SqlConnection connection, Guid packageId, CancellationToken cancellationToken)
+        {
+            using var command = new SqlCommand(
+                "SELECT WorkspaceId, ProjectId, Name, CreatedAt FROM dbo.tbFiscalMappingPackage WHERE PackageId = @PackageId;",
+                connection);
+            command.Parameters.AddWithValue("@PackageId", packageId);
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+                return null;
+
+            return new PackageDetail(
+                packageId,
+                reader.GetGuid(reader.GetOrdinal("WorkspaceId")),
+                reader.GetGuid(reader.GetOrdinal("ProjectId")),
+                reader.GetString(reader.GetOrdinal("Name")),
+                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("CreatedAt")), TimeSpan.Zero),
+                null!); // LatestRevision preenchida pelo chamador.
+        }
+
+        public async Task<string?> GetArtifactStoragePathAsync(Guid artifactId, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var command = new SqlCommand(
+                "SELECT StoragePath FROM dbo.tbPackageArtifact WHERE ArtifactId = @ArtifactId;",
+                connection);
+            command.Parameters.AddWithValue("@ArtifactId", artifactId);
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result as string;
+        }
+
         private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
         {
             if (_schemaEnsured)

--- a/Services/Fiscal/FiscalPackageService.cs
+++ b/Services/Fiscal/FiscalPackageService.cs
@@ -16,6 +16,7 @@ namespace LayoutParserApi.Services.Fiscal
     {
         private readonly IFiscalPackageStore _store;
         private readonly IAntivirusScanner _antivirusScanner;
+        private readonly IFiscalMappingRuleExtractor _ruleExtractor;
         private readonly ILogger<FiscalPackageService> _logger;
         private readonly string _storePath;
         private readonly MultipartUploadValidator _validator = new();
@@ -26,11 +27,13 @@ namespace LayoutParserApi.Services.Fiscal
         public FiscalPackageService(
             IFiscalPackageStore store,
             IAntivirusScanner antivirusScanner,
+            IFiscalMappingRuleExtractor ruleExtractor,
             ILogger<FiscalPackageService> logger,
             IConfiguration configuration)
         {
             _store = store;
             _antivirusScanner = antivirusScanner;
+            _ruleExtractor = ruleExtractor;
             _logger = logger;
             _storePath = configuration["ML:FiscalMappingPackagesPath"]
                 ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "FiscalMappingPackages");
@@ -50,28 +53,15 @@ namespace LayoutParserApi.Services.Fiscal
 
             // 1. Valida CADA artefato antes de tocar em disco/SQL — 422 sem inferência silenciosa
             //    (aceite explícito da issue: divergência de MIME/tamanho/tipo obrigatório = rejeita).
-            var validated = new List<(UploadedArtifactInput Input, UploadValidationResult Result, string Sha256)>();
-            foreach (var artifact in artifacts)
-            {
-                var result = _validator.Validate(artifact.Content, artifact.OriginalFileName, artifact.Kind);
-                if (!result.IsValid)
-                {
-                    // Nunca logar o conteúdo — só metadado (nome sanitizado, kind, tamanho).
-                    _logger.LogWarning(
-                        "Upload rejeitado (workspace={WorkspaceId}, kind={Kind}, tamanho={Size}): {Error}",
-                        workspaceId, artifact.Kind, artifact.Content.Length, result.Error);
-                    return new CreatePackageOutcome(false, $"Artefato \"{artifact.Kind}\": {result.Error}", null);
-                }
-
-                var sha256 = ComputeSha256(artifact.Content);
-                validated.Add((artifact, result, sha256));
-            }
+            var (validationOk, validationError, validated) = ValidateArtifacts(artifacts, workspaceId);
+            if (!validationOk)
+                return new CreatePackageOutcome(false, validationError, null);
 
             // Chave de idempotência: header explícito OU hash determinístico do conjunto de hashes
             // (ordenado, para não depender da ordem de envio no multipart).
             var effectiveKey = !string.IsNullOrWhiteSpace(idempotencyKey)
                 ? idempotencyKey
-                : ComputeSha256(System.Text.Encoding.UTF8.GetBytes(string.Join('|', validated.Select(v => v.Sha256).OrderBy(s => s, StringComparer.Ordinal))));
+                : ComputeSha256(System.Text.Encoding.UTF8.GetBytes(string.Join('|', validated!.Select(v => v.Sha256).OrderBy(s => s, StringComparer.Ordinal))));
 
             var existing = await _store.FindPackageByIdempotencyKeyAsync(workspaceId, projectId, effectiveKey, cancellationToken);
             if (existing != null)
@@ -92,7 +82,7 @@ namespace LayoutParserApi.Services.Fiscal
 
             try
             {
-                foreach (var (input, result, sha256) in validated)
+                foreach (var (input, result, sha256) in validated!)
                 {
                     var safeName = SanitizeFileName(input.OriginalFileName);
                     var artifactId = Guid.NewGuid();
@@ -141,6 +131,160 @@ namespace LayoutParserApi.Services.Fiscal
 
         public Task<PackageDetail?> GetPackageIfMemberAsync(Guid packageId, Guid userId, CancellationToken cancellationToken)
             => _store.GetPackageIfMemberAsync(packageId, userId, cancellationToken);
+
+        public Task<IReadOnlyList<ProjectSummary>> ListProjectsAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+            => _store.ListProjectsForMemberAsync(workspaceId, userId, cancellationToken);
+
+        /// <summary>
+        /// Cria uma nova revisão de um pacote existente (Gap 2 — issue #201): mesma validação/gravação
+        /// em disco/antivírus assíncrono de <see cref="CreatePackageAsync"/>, sem idempotência (uma
+        /// revisão nova é sempre uma intenção explícita de correção, não um reenvio de rede).
+        /// </summary>
+        public async Task<CreateRevisionOutcome> CreateRevisionAsync(
+            Guid workspaceId,
+            Guid packageId,
+            Guid userId,
+            IReadOnlyList<UploadedArtifactInput> artifacts,
+            CancellationToken cancellationToken)
+        {
+            if (artifacts.Count == 0)
+                return new CreateRevisionOutcome(false, "Nenhum artefato enviado.", false, null);
+
+            // Confirma existência + membership ANTES de tocar em disco — "não existe" e "não é seu"
+            // respondem o mesmo 404, mesmo padrão do GET.
+            var existingPackage = await _store.GetPackageIfMemberAsync(packageId, userId, cancellationToken);
+            if (existingPackage == null || existingPackage.WorkspaceId != workspaceId)
+                return new CreateRevisionOutcome(false, null, true, null);
+
+            var (validationOk, validationError, validated) = ValidateArtifacts(artifacts, workspaceId);
+            if (!validationOk)
+                return new CreateRevisionOutcome(false, validationError, false, null);
+
+            var revisionId = Guid.NewGuid(); // usado só para o path físico — a store gera o RevisionId real.
+            var entities = new List<PackageArtifact>();
+            var writtenPaths = new List<string>();
+
+            try
+            {
+                foreach (var (input, result, sha256) in validated!)
+                {
+                    var safeName = SanitizeFileName(input.OriginalFileName);
+                    var artifactId = Guid.NewGuid();
+                    var relativePath = Path.Combine(
+                        workspaceId.ToString(), packageId.ToString(), revisionId.ToString(), $"{artifactId}_{safeName}");
+                    var absolutePath = Path.Combine(_storePath, relativePath);
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+                    await File.WriteAllBytesAsync(absolutePath, input.Content, cancellationToken);
+                    writtenPaths.Add(absolutePath);
+
+                    entities.Add(new PackageArtifact
+                    {
+                        ArtifactId = artifactId,
+                        Kind = input.Kind,
+                        Sha256 = sha256,
+                        SizeBytes = input.Content.Length,
+                        OriginalFileName = safeName,
+                        MimeDeclared = input.ContentType ?? "unknown",
+                        MimeSniffed = result.MimeSniffed,
+                        UploadedByUserId = userId,
+                        UploadedAt = DateTimeOffset.UtcNow,
+                        InspectionStatus = Models.Entities.Fiscal.InspectionStatus.Pending,
+                        StoragePath = relativePath,
+                    });
+                }
+
+                var packageDetail = await _store.CreateRevisionAsync(packageId, userId, entities, cancellationToken);
+
+                foreach (var (entity, absolutePath) in entities.Zip(writtenPaths))
+                    DispatchAntivirusScan(entity.ArtifactId, absolutePath, _antivirusScanner, _store, _logger);
+
+                return new CreateRevisionOutcome(true, null, false, packageDetail);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao criar nova revisão do pacote de mapeamento fiscal {PackageId}.", packageId);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Inventário de estrutura (abas/colunas/linhas) de um artefato <c>spec</c> (XLSX) — reusa
+        /// <see cref="IFiscalMappingRuleExtractor"/> (issue #103), sem parser de Excel novo. Nunca
+        /// devolve conteúdo bruto da planilha, só a estrutura reconhecida.
+        /// </summary>
+        public async Task<ExcelInventoryOutcome> GetExcelInventoryAsync(
+            Guid workspaceId,
+            Guid packageId,
+            Guid artifactId,
+            Guid userId,
+            CancellationToken cancellationToken)
+        {
+            var package = await _store.GetPackageIfMemberAsync(packageId, userId, cancellationToken);
+            if (package == null || package.WorkspaceId != workspaceId)
+                return new ExcelInventoryOutcome(false, null, true, null);
+
+            var artifact = package.LatestRevision.Artifacts.FirstOrDefault(a => a.ArtifactId == artifactId);
+            if (artifact == null)
+                return new ExcelInventoryOutcome(false, null, true, null);
+
+            if (artifact.Kind != ArtifactKind.Spec)
+                return new ExcelInventoryOutcome(false, $"Inventário de estrutura só está disponível para artefatos do tipo \"{ArtifactKind.Spec}\" — este é \"{artifact.Kind}\".", false, null);
+
+            var relativePath = await _store.GetArtifactStoragePathAsync(artifactId, cancellationToken);
+            if (relativePath == null)
+                return new ExcelInventoryOutcome(false, null, true, null);
+
+            var absolutePath = Path.Combine(_storePath, relativePath);
+            try
+            {
+                using var stream = File.OpenRead(absolutePath);
+                var extraction = _ruleExtractor.Extract(stream);
+
+                var decisionSheets = extraction.Rules
+                    .GroupBy(r => r.SheetName)
+                    .Select(g => new ExcelSheetInventory(
+                        g.Key,
+                        g.SelectMany(r => r.Conditions.Select(c => c.Field)).Distinct().ToList(),
+                        g.Count()))
+                    .ToList();
+
+                return new ExcelInventoryOutcome(true, null, false, new ExcelInventoryResult(decisionSheets, extraction.SkippedSheets));
+            }
+            catch (Exception ex)
+            {
+                // Nunca logar o conteúdo do Excel — só metadado (artifactId/packageId).
+                _logger.LogError(ex, "Falha ao gerar inventário do artefato {ArtifactId} do pacote {PackageId}.", artifactId, packageId);
+                return new ExcelInventoryOutcome(false, "Não foi possível ler a estrutura do arquivo Excel — pode estar corrompido.", false, null);
+            }
+        }
+
+        /// <summary>
+        /// Valida cada artefato do upload (compartilhado por <see cref="CreatePackageAsync"/> e
+        /// <see cref="CreateRevisionAsync"/>) — para na primeira falha, 422 sem inferência silenciosa.
+        /// </summary>
+        private (bool Success, string? Error, List<(UploadedArtifactInput Input, UploadValidationResult Result, string Sha256)>? Validated) ValidateArtifacts(
+            IReadOnlyList<UploadedArtifactInput> artifacts, Guid workspaceId)
+        {
+            var validated = new List<(UploadedArtifactInput Input, UploadValidationResult Result, string Sha256)>();
+            foreach (var artifact in artifacts)
+            {
+                var result = _validator.Validate(artifact.Content, artifact.OriginalFileName, artifact.Kind);
+                if (!result.IsValid)
+                {
+                    // Nunca logar o conteúdo — só metadado (nome sanitizado, kind, tamanho).
+                    _logger.LogWarning(
+                        "Upload rejeitado (workspace={WorkspaceId}, kind={Kind}, tamanho={Size}): {Error}",
+                        workspaceId, artifact.Kind, artifact.Content.Length, result.Error);
+                    return (false, $"Artefato \"{artifact.Kind}\": {result.Error}", null);
+                }
+
+                var sha256 = ComputeSha256(artifact.Content);
+                validated.Add((artifact, result, sha256));
+            }
+
+            return (true, null, validated);
+        }
 
         private Task EnsureProjectAsync(Guid workspaceId, Guid projectId, CancellationToken cancellationToken)
             // Projeto mínimo criado sob demanda — Slice 2 não expõe CRUD de projeto. A store garante a

--- a/Services/Interfaces/IFiscalPackageService.cs
+++ b/Services/Interfaces/IFiscalPackageService.cs
@@ -7,6 +7,30 @@ namespace LayoutParserApi.Services.Interfaces
     public sealed record CreatePackageOutcome(bool Success, string? Error, PackageDetail? Package);
 
     /// <summary>
+    /// Resultado de uma tentativa de criar uma nova revisão. <see cref="NotFound"/> distingue "pacote
+    /// não existe/não é seu" (404) de "artefatos inválidos" (422) — o controller decide o status HTTP.
+    /// </summary>
+    public sealed record CreateRevisionOutcome(bool Success, string? Error, bool NotFound, PackageDetail? Package);
+
+    /// <summary>Inventário de uma aba do Excel reconhecida como tabela de decisão fiscal.</summary>
+    public sealed record ExcelSheetInventory(string SheetName, IReadOnlyList<string> Columns, int RuleCount);
+
+    /// <summary>
+    /// Inventário de estrutura de um artefato <c>spec</c> (XLSX), reaproveitando
+    /// <see cref="LayoutParserApi.Services.Fiscal.IFiscalMappingRuleExtractor"/> (issue #103) —
+    /// nenhum parser de Excel novo. Front-end usa isto para exibir abas/colunas/linhas antes de
+    /// confirmar o upload, sem que a API precise devolver o conteúdo bruto da planilha.
+    /// </summary>
+    public sealed record ExcelInventoryResult(IReadOnlyList<ExcelSheetInventory> DecisionSheets, IReadOnlyList<string> SkippedSheets);
+
+    /// <summary>
+    /// Resultado de uma tentativa de gerar o inventário. <see cref="NotFound"/> cobre pacote/artefato
+    /// inexistente ou alheio (404); <see cref="Error"/> cobre "não é um artefato spec" ou Excel
+    /// corrompido (422) — nunca propaga exceção de parsing para o cliente.
+    /// </summary>
+    public sealed record ExcelInventoryOutcome(bool Success, string? Error, bool NotFound, ExcelInventoryResult? Inventory);
+
+    /// <summary>
     /// Orquestra o upload de um <c>FiscalMappingPackage</c> (Slice 2 — issue #229): valida cada
     /// artefato (<c>MultipartUploadValidator</c>) → grava no filesystem → grava metadado no SQL →
     /// dispara scan de antivírus assíncrono. Fail-closed na validação (nenhuma inferência silenciosa),
@@ -29,5 +53,29 @@ namespace LayoutParserApi.Services.Interfaces
             CancellationToken cancellationToken);
 
         Task<PackageDetail?> GetPackageIfMemberAsync(Guid packageId, Guid userId, CancellationToken cancellationToken);
+
+        /// <summary>Lista os projetos fiscais do workspace, só para quem é membro. Leitura pura (issue de contrato #201).</summary>
+        Task<IReadOnlyList<ProjectSummary>> ListProjectsAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Cria uma nova revisão de um pacote já existente — mesma validação/armazenamento/antivírus
+        /// assíncrono de <see cref="CreatePackageAsync"/>, mas sem criar pacote novo nem checar
+        /// idempotência (reenvio idêntico intencional ainda cria uma revisão nova — é uma correção,
+        /// não um reenvio de rede).
+        /// </summary>
+        Task<CreateRevisionOutcome> CreateRevisionAsync(
+            Guid workspaceId,
+            Guid packageId,
+            Guid userId,
+            IReadOnlyList<UploadedArtifactInput> artifacts,
+            CancellationToken cancellationToken);
+
+        /// <summary>Inventário de estrutura (abas/colunas/linhas) de um artefato <c>spec</c> (XLSX) da revisão mais recente.</summary>
+        Task<ExcelInventoryOutcome> GetExcelInventoryAsync(
+            Guid workspaceId,
+            Guid packageId,
+            Guid artifactId,
+            Guid userId,
+            CancellationToken cancellationToken);
     }
 }

--- a/Services/Interfaces/IFiscalPackageStore.cs
+++ b/Services/Interfaces/IFiscalPackageStore.cs
@@ -29,6 +29,13 @@ namespace LayoutParserApi.Services.Interfaces
         RevisionSummary LatestRevision);
 
     /// <summary>
+    /// Projeto fiscal mínimo (listagem de leitura — NÃO é o CRUD de projeto descartado na issue #229,
+    /// ver <see cref="FiscalProject"/>). Devolvido para o front-end navegar/selecionar projeto em vez
+    /// de exigir o GUID colado manualmente.
+    /// </summary>
+    public sealed record ProjectSummary(Guid ProjectId, Guid WorkspaceId, string Name, DateTimeOffset CreatedAt);
+
+    /// <summary>
     /// Acesso a dado de <see cref="FiscalMappingPackage"/>/<see cref="FiscalMappingPackageRevision"/>/
     /// <see cref="PackageArtifact"/> (Slice 2 — issue #229). Mesmo padrão ADO.NET cru de
     /// <c>SqlIdentityWorkspaceStore</c>: DDL idempotente na primeira chamada por processo.
@@ -69,5 +76,30 @@ namespace LayoutParserApi.Services.Interfaces
 
         /// <summary>Atualiza o status de inspeção de antivírus de um artefato (job assíncrono pós-upload).</summary>
         Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Lista os <see cref="FiscalProject"/> do workspace, só para quem é membro (join com
+        /// <c>tbWorkspaceMembership</c> — defesa em profundidade, o chamador já deve ter checado
+        /// membership antes). Leitura pura — não é o CRUD de projeto descartado na issue #229.
+        /// </summary>
+        Task<IReadOnlyList<ProjectSummary>> ListProjectsForMemberAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Cria uma NOVA revisão (imutável) de um <see cref="FiscalMappingPackage"/> já existente — o
+        /// número sequencial é <c>MAX(RevisionNumber) + 1</c> dentro do próprio pacote. O chamador é
+        /// responsável por já ter confirmado existência/membership do pacote antes de chamar isto.
+        /// </summary>
+        Task<PackageDetail> CreateRevisionAsync(
+            Guid packageId,
+            Guid createdByUserId,
+            IReadOnlyList<PackageArtifact> artifacts,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Caminho relativo em disco (<c>PackageArtifact.StoragePath</c>) de um artefato — uso interno
+        /// do serviço para abrir o arquivo (ex.: inventário de estrutura do Excel), nunca exposto
+        /// diretamente ao cliente. O chamador já deve ter confirmado membership/posse do pacote dono.
+        /// </summary>
+        Task<string?> GetArtifactStoragePathAsync(Guid artifactId, CancellationToken cancellationToken);
     }
 }

--- a/tests/LayoutParserApi.Tests/Controllers/FiscalMappingPackagesControllerTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/FiscalMappingPackagesControllerTests.cs
@@ -2,6 +2,7 @@ using LayoutParserApi.Controllers;
 using LayoutParserApi.Models.Entities.Fiscal;
 using LayoutParserApi.Services.Interfaces;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -42,6 +43,9 @@ namespace LayoutParserApi.Tests.Controllers
         private sealed class FakePackageService : IFiscalPackageService
         {
             public Dictionary<Guid, (PackageDetail Detail, Guid OwnerUserId)> Packages { get; } = new();
+            public Dictionary<Guid, List<ProjectSummary>> ProjectsByWorkspace { get; } = new();
+            public CreateRevisionOutcome? NextCreateRevisionOutcome { get; set; }
+            public ExcelInventoryOutcome? NextExcelInventoryOutcome { get; set; }
 
             public Task<CreatePackageOutcome> CreatePackageAsync(Guid workspaceId, Guid projectId, Guid userId, string packageName, string? idempotencyKey, IReadOnlyList<UploadedArtifactInput> artifacts, CancellationToken cancellationToken)
                 => throw new NotSupportedException("Não exercitado neste conjunto de testes.");
@@ -53,6 +57,16 @@ namespace LayoutParserApi.Tests.Controllers
 
                 return Task.FromResult<PackageDetail?>(entry.Detail);
             }
+
+            public Task<IReadOnlyList<ProjectSummary>> ListProjectsAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ProjectSummary>>(
+                    ProjectsByWorkspace.TryGetValue(workspaceId, out var projects) ? projects : new List<ProjectSummary>());
+
+            public Task<CreateRevisionOutcome> CreateRevisionAsync(Guid workspaceId, Guid packageId, Guid userId, IReadOnlyList<UploadedArtifactInput> artifacts, CancellationToken cancellationToken)
+                => Task.FromResult(NextCreateRevisionOutcome ?? throw new NotSupportedException("Configure NextCreateRevisionOutcome antes de chamar."));
+
+            public Task<ExcelInventoryOutcome> GetExcelInventoryAsync(Guid workspaceId, Guid packageId, Guid artifactId, Guid userId, CancellationToken cancellationToken)
+                => Task.FromResult(NextExcelInventoryOutcome ?? throw new NotSupportedException("Configure NextExcelInventoryOutcome antes de chamar."));
         }
 
         private static FiscalMappingPackagesController BuildController(FakePackageService packageService, FakeIdentityWorkspaceService identityService, FakeCurrentUser user)
@@ -156,6 +170,193 @@ namespace LayoutParserApi.Tests.Controllers
             var result = await controller.GetPackage(workspaceForjado, packageId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        // ---- Gap 1 (issue #201): listagem de projetos fiscais ----
+
+        [Fact]
+        public async Task ListProjects_membro_recebe_200_com_a_lista_do_workspace()
+        {
+            var packageService = new FakePackageService();
+            var identityService = new FakeIdentityWorkspaceService();
+            var userId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            identityService.Memberships.Add((workspaceId, userId));
+            packageService.ProjectsByWorkspace[workspaceId] = new List<ProjectSummary>
+            {
+                new(Guid.NewGuid(), workspaceId, "Projeto A", DateTimeOffset.UtcNow)
+            };
+
+            var controller = BuildController(packageService, identityService, new FakeCurrentUser { UserId = userId });
+
+            var result = await controller.ListProjects(workspaceId, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ListProjects_nao_membro_recebe_404()
+        {
+            var packageService = new FakePackageService();
+            var identityService = new FakeIdentityWorkspaceService(); // sem membership cadastrada.
+            var controller = BuildController(packageService, identityService, new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.ListProjects(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task ListProjects_sem_identidade_resolvida_retorna_404_uniforme()
+        {
+            var controller = BuildController(new FakePackageService(), new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = null });
+
+            var result = await controller.ListProjects(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        // ---- Gap 2 (issue #201): nova revisão de pacote existente ----
+
+        [Fact]
+        public async Task CreateRevision_pacote_inexistente_ou_alheio_recebe_404()
+        {
+            var packageService = new FakePackageService
+            {
+                NextCreateRevisionOutcome = new CreateRevisionOutcome(false, null, true, null)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+            AttachMultipartForm(controller, ("sample", "sample.txt", "text/plain", new byte[] { 1, 2, 3 }));
+
+            var result = await controller.CreateRevision(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateRevision_artefato_invalido_recebe_422()
+        {
+            var packageService = new FakePackageService
+            {
+                NextCreateRevisionOutcome = new CreateRevisionOutcome(false, "Artefato \"sample\": extensão errada.", false, null)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+            AttachMultipartForm(controller, ("sample", "sample.txt", "text/plain", new byte[] { 1, 2, 3 }));
+
+            var result = await controller.CreateRevision(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateRevision_sucesso_recebe_201_com_revisionNumber_incrementado()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            var detail = new PackageDetail(packageId, workspaceId, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                new RevisionSummary(Guid.NewGuid(), 2, DateTimeOffset.UtcNow, Array.Empty<ArtifactSummary>()));
+            var packageService = new FakePackageService
+            {
+                NextCreateRevisionOutcome = new CreateRevisionOutcome(true, null, false, detail)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+            AttachMultipartForm(controller, ("sample", "sample.txt", "text/plain", new byte[] { 1, 2, 3 }));
+
+            var result = await controller.CreateRevision(workspaceId, packageId, CancellationToken.None);
+
+            var created = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(nameof(FiscalMappingPackagesController.GetPackage), created.ActionName);
+        }
+
+        [Fact]
+        public async Task CreateRevision_sem_identidade_resolvida_retorna_404_uniforme()
+        {
+            var controller = BuildController(new FakePackageService(), new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = null });
+            AttachMultipartForm(controller, ("sample", "sample.txt", "text/plain", new byte[] { 1, 2, 3 }));
+
+            var result = await controller.CreateRevision(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        // ---- Gap 3 (issue #201): inventário de estrutura do Excel ----
+
+        [Fact]
+        public async Task GetExcelInventory_pacote_ou_artefato_inexistente_recebe_404()
+        {
+            var packageService = new FakePackageService
+            {
+                NextExcelInventoryOutcome = new ExcelInventoryOutcome(false, null, true, null)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.GetExcelInventory(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetExcelInventory_artefato_que_nao_e_spec_recebe_422()
+        {
+            var packageService = new FakePackageService
+            {
+                NextExcelInventoryOutcome = new ExcelInventoryOutcome(false, "Inventário de estrutura só está disponível para artefatos do tipo \"spec\".", false, null)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.GetExcelInventory(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetExcelInventory_sucesso_recebe_200_com_abas_e_colunas()
+        {
+            var inventory = new ExcelInventoryResult(
+                new List<ExcelSheetInventory> { new("Regra-CST", new[] { "orig", "CST" }, 3) },
+                new List<string> { "Layout-Emissao" });
+            var packageService = new FakePackageService
+            {
+                NextExcelInventoryOutcome = new ExcelInventoryOutcome(true, null, false, inventory)
+            };
+            var controller = BuildController(packageService, new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = Guid.NewGuid() });
+
+            var result = await controller.GetExcelInventory(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetExcelInventory_sem_identidade_resolvida_retorna_404_uniforme()
+        {
+            var controller = BuildController(new FakePackageService(), new FakeIdentityWorkspaceService(), new FakeCurrentUser { UserId = null });
+
+            var result = await controller.GetExcelInventory(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        /// <summary>Monta um <c>Request.Form.Files</c> multipart mínimo para exercitar <c>CreateRevision</c> sem servidor HTTP real.</summary>
+        private static void AttachMultipartForm(FiscalMappingPackagesController controller, params (string FieldName, string FileName, string ContentType, byte[] Content)[] files)
+        {
+            var formFiles = new FormFileCollection();
+            foreach (var (fieldName, fileName, contentType, content) in files)
+            {
+                var stream = new MemoryStream(content);
+                var formFile = new FormFile(stream, 0, content.Length, fieldName, fileName)
+                {
+                    Headers = new HeaderDictionary(),
+                    ContentType = contentType,
+                };
+                formFiles.Add(formFile);
+            }
+
+            var httpContext = new DefaultHttpContext
+            {
+                Request = { Form = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), formFiles) }
+            };
+
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
         }
     }
 }

--- a/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
+++ b/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
@@ -97,6 +97,15 @@ namespace LayoutParserApi.Tests.Integration
                 => Task.FromResult<ArtifactSummary?>(null);
 
             public Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<IReadOnlyList<ProjectSummary>> ListProjectsForMemberAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ProjectSummary>>(Array.Empty<ProjectSummary>());
+
+            public Task<PackageDetail> CreateRevisionAsync(Guid packageId, Guid createdByUserId, IReadOnlyList<PackageArtifact> artifacts, CancellationToken cancellationToken)
+                => throw new NotSupportedException("Não exercitado neste conjunto de testes.");
+
+            public Task<string?> GetArtifactStoragePathAsync(Guid artifactId, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(null);
         }
 
         private sealed class NoOpAntivirusScanner : IAntivirusScanner
@@ -327,7 +336,7 @@ namespace LayoutParserApi.Tests.Integration
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> { ["ML:FiscalMappingPackagesPath"] = tempStorePath })
                 .Build();
-            var packageService = new FiscalPackageService(packageStore, new NoOpAntivirusScanner(), NullLogger<FiscalPackageService>.Instance, configuration);
+            var packageService = new FiscalPackageService(packageStore, new NoOpAntivirusScanner(), new FiscalMappingRuleExtractor(NullLogger<FiscalMappingRuleExtractor>.Instance), NullLogger<FiscalPackageService>.Instance, configuration);
 
             var artifacts = new List<UploadedArtifactInput>
             {

--- a/tests/LayoutParserApi.Tests/Services/Fiscal/FiscalPackageServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Fiscal/FiscalPackageServiceTests.cs
@@ -4,6 +4,7 @@ using LayoutParserApi.Services.Interfaces;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LayoutParserApi.Tests.Services.Fiscal
 {
@@ -21,6 +22,9 @@ namespace LayoutParserApi.Tests.Services.Fiscal
         private sealed class FakeStore : IFiscalPackageStore
         {
             public int CreateCallCount;
+            public int CreateRevisionCallCount;
+            public PackageDetail? PackageForMember { get; set; }
+            public string? ArtifactStoragePath { get; set; }
             private readonly Dictionary<string, PackageDetail> _byIdempotencyKey = new();
 
             public Task<bool> EnsureProjectExistsAsync(Guid workspaceId, Guid projectId, CancellationToken cancellationToken)
@@ -41,7 +45,7 @@ namespace LayoutParserApi.Tests.Services.Fiscal
             }
 
             public Task<PackageDetail?> GetPackageIfMemberAsync(Guid packageId, Guid userId, CancellationToken cancellationToken)
-                => Task.FromResult<PackageDetail?>(null);
+                => Task.FromResult(PackageForMember);
 
             public Task<PackageDetail?> FindPackageByIdempotencyKeyAsync(Guid workspaceId, Guid projectId, string idempotencyKey, CancellationToken cancellationToken)
                 => Task.FromResult(_byIdempotencyKey.TryGetValue($"{workspaceId}|{projectId}|{idempotencyKey}", out var d) ? d : null);
@@ -51,6 +55,25 @@ namespace LayoutParserApi.Tests.Services.Fiscal
 
             public Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken)
                 => Task.CompletedTask;
+
+            public Task<IReadOnlyList<ProjectSummary>> ListProjectsForMemberAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ProjectSummary>>(Array.Empty<ProjectSummary>());
+
+            public Task<PackageDetail> CreateRevisionAsync(Guid packageId, Guid createdByUserId, IReadOnlyList<PackageArtifact> artifacts, CancellationToken cancellationToken)
+            {
+                CreateRevisionCallCount++;
+                var nextRevisionNumber = PackageForMember!.LatestRevision.RevisionNumber + 1;
+                var detail = PackageForMember with
+                {
+                    LatestRevision = new RevisionSummary(Guid.NewGuid(), nextRevisionNumber, DateTimeOffset.UtcNow,
+                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, DateTimeOffset.UtcNow)).ToList())
+                };
+                PackageForMember = detail; // próxima revisão parte deste novo estado.
+                return Task.FromResult(detail);
+            }
+
+            public Task<string?> GetArtifactStoragePathAsync(Guid artifactId, CancellationToken cancellationToken)
+                => Task.FromResult(ArtifactStoragePath);
         }
 
         private sealed class FakeScanner : IAntivirusScanner
@@ -76,7 +99,7 @@ namespace LayoutParserApi.Tests.Services.Fiscal
                 .AddInMemoryCollection(new Dictionary<string, string?> { ["ML:FiscalMappingPackagesPath"] = storePath })
                 .Build();
 
-            return new FiscalPackageService(store, new FakeScanner(), logger, config);
+            return new FiscalPackageService(store, new FakeScanner(), new FiscalMappingRuleExtractor(NullLogger<FiscalMappingRuleExtractor>.Instance), logger, config);
         }
 
         // --- idempotência ---
@@ -114,6 +137,140 @@ namespace LayoutParserApi.Tests.Services.Fiscal
 
             Assert.Equal(1, store.CreateCallCount);
             Assert.Equal(first.Package!.PackageId, second.Package!.PackageId);
+        }
+
+        // --- Gap 2 (issue #201): nova revisão de pacote existente ---
+
+        [Fact]
+        public async Task CreateRevisionAsync_pacote_inexistente_ou_alheio_devolve_NotFound()
+        {
+            var store = new FakeStore(); // PackageForMember não configurado — simula "não existe/não é seu".
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+            var artifacts = new[] { new UploadedArtifactInput(ArtifactKind.Sample, "sample.txt", "text/plain", System.Text.Encoding.UTF8.GetBytes("linha 1")) };
+
+            var outcome = await service.CreateRevisionAsync(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), artifacts, CancellationToken.None);
+
+            Assert.False(outcome.Success);
+            Assert.True(outcome.NotFound);
+            Assert.Equal(0, store.CreateRevisionCallCount);
+        }
+
+        [Fact]
+        public async Task CreateRevisionAsync_workspaceId_divergente_do_dono_real_tambem_NotFound()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceReal = Guid.NewGuid();
+            var store = new FakeStore
+            {
+                PackageForMember = new PackageDetail(packageId, workspaceReal, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                    new RevisionSummary(Guid.NewGuid(), 1, DateTimeOffset.UtcNow, Array.Empty<ArtifactSummary>()))
+            };
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+            var artifacts = new[] { new UploadedArtifactInput(ArtifactKind.Sample, "sample.txt", "text/plain", System.Text.Encoding.UTF8.GetBytes("linha 1")) };
+
+            var outcome = await service.CreateRevisionAsync(Guid.NewGuid(), packageId, Guid.NewGuid(), artifacts, CancellationToken.None);
+
+            Assert.True(outcome.NotFound);
+        }
+
+        [Fact]
+        public async Task CreateRevisionAsync_artefato_invalido_devolve_422_sem_criar_revisao()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            var store = new FakeStore
+            {
+                PackageForMember = new PackageDetail(packageId, workspaceId, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                    new RevisionSummary(Guid.NewGuid(), 1, DateTimeOffset.UtcNow, Array.Empty<ArtifactSummary>()))
+            };
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+            // Extensão errada de propósito (kind Sample espera .txt).
+            var artifacts = new[] { new UploadedArtifactInput(ArtifactKind.Sample, "sample.xml", "text/xml", System.Text.Encoding.UTF8.GetBytes("<a/>")) };
+
+            var outcome = await service.CreateRevisionAsync(workspaceId, packageId, Guid.NewGuid(), artifacts, CancellationToken.None);
+
+            Assert.False(outcome.Success);
+            Assert.False(outcome.NotFound);
+            Assert.NotNull(outcome.Error);
+            Assert.Equal(0, store.CreateRevisionCallCount);
+        }
+
+        [Fact]
+        public async Task CreateRevisionAsync_sucesso_incrementa_o_numero_da_revisao()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            var store = new FakeStore
+            {
+                PackageForMember = new PackageDetail(packageId, workspaceId, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                    new RevisionSummary(Guid.NewGuid(), 1, DateTimeOffset.UtcNow, Array.Empty<ArtifactSummary>()))
+            };
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+            var artifacts = new[] { new UploadedArtifactInput(ArtifactKind.Sample, "sample.txt", "text/plain", System.Text.Encoding.UTF8.GetBytes("linha 1")) };
+
+            var outcome = await service.CreateRevisionAsync(workspaceId, packageId, Guid.NewGuid(), artifacts, CancellationToken.None);
+
+            Assert.True(outcome.Success);
+            Assert.Equal(1, store.CreateRevisionCallCount);
+            Assert.Equal(2, outcome.Package!.LatestRevision.RevisionNumber); // 🔴 se a store parar de incrementar, isto quebra.
+        }
+
+        // --- Gap 3 (issue #201): inventário de estrutura do Excel ---
+
+        [Fact]
+        public async Task GetExcelInventoryAsync_pacote_inexistente_ou_alheio_devolve_NotFound()
+        {
+            var store = new FakeStore();
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+
+            var outcome = await service.GetExcelInventoryAsync(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.True(outcome.NotFound);
+        }
+
+        [Fact]
+        public async Task GetExcelInventoryAsync_artefato_que_nao_e_spec_devolve_422()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            var artifactId = Guid.NewGuid();
+            var store = new FakeStore
+            {
+                PackageForMember = new PackageDetail(packageId, workspaceId, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                    new RevisionSummary(Guid.NewGuid(), 1, DateTimeOffset.UtcNow,
+                        new[] { new ArtifactSummary(artifactId, ArtifactKind.Sample, "hash", 10, "sample.txt", InspectionStatus.Pending, DateTimeOffset.UtcNow) }))
+            };
+            var service = BuildService(store, new CapturingLogger(), _tempStorePath);
+
+            var outcome = await service.GetExcelInventoryAsync(workspaceId, packageId, artifactId, Guid.NewGuid(), CancellationToken.None);
+
+            Assert.False(outcome.Success);
+            Assert.False(outcome.NotFound);
+            Assert.Contains("spec", outcome.Error);
+        }
+
+        [Fact]
+        public async Task GetExcelInventoryAsync_planilha_real_devolve_abas_e_colunas_reconhecidas()
+        {
+            var packageId = Guid.NewGuid();
+            var workspaceId = Guid.NewGuid();
+            var artifactId = Guid.NewGuid();
+            var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Fiscal", "regra-cst-decision-table.xlsx");
+            var store = new FakeStore
+            {
+                PackageForMember = new PackageDetail(packageId, workspaceId, Guid.NewGuid(), "Pacote", DateTimeOffset.UtcNow,
+                    new RevisionSummary(Guid.NewGuid(), 1, DateTimeOffset.UtcNow,
+                        new[] { new ArtifactSummary(artifactId, ArtifactKind.Spec, "hash", 10, "spec.xlsx", InspectionStatus.Pending, DateTimeOffset.UtcNow) })),
+                // Caminho absoluto direto — a service compõe com _storePath, então usa caminho relativo vazio e storePath = pasta da fixture.
+                ArtifactStoragePath = "regra-cst-decision-table.xlsx",
+            };
+            var service = BuildService(store, new CapturingLogger(), Path.Combine(AppContext.BaseDirectory, "Fixtures", "Fiscal"));
+
+            var outcome = await service.GetExcelInventoryAsync(workspaceId, packageId, artifactId, Guid.NewGuid(), CancellationToken.None);
+
+            Assert.True(outcome.Success, outcome.Error);
+            Assert.NotNull(outcome.Inventory);
+            Assert.NotEmpty(outcome.Inventory!.DecisionSheets.Concat(outcome.Inventory.SkippedSheets.Select(s => new ExcelSheetInventory(s, Array.Empty<string>(), 0))));
         }
 
         // --- conteúdo bruto nunca em log ---
@@ -213,6 +370,15 @@ namespace LayoutParserApi.Tests.Services.Fiscal
 
             public Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken)
                 => Task.CompletedTask;
+
+            public Task<IReadOnlyList<ProjectSummary>> ListProjectsForMemberAsync(Guid workspaceId, Guid userId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ProjectSummary>>(Array.Empty<ProjectSummary>());
+
+            public Task<PackageDetail> CreateRevisionAsync(Guid packageId, Guid createdByUserId, IReadOnlyList<PackageArtifact> artifacts, CancellationToken cancellationToken)
+                => throw new NotSupportedException("Não exercitado neste conjunto de testes.");
+
+            public Task<string?> GetArtifactStoragePathAsync(Guid artifactId, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(null);
         }
 
         [Fact]


### PR DESCRIPTION
Resolve os 3 gaps de contrato reportados pelo front-end (LayoutParserReact issue #201, parcialmente bloqueado).

## 1. Listagem de projetos fiscais
GET /api/workspaces/{workspaceId}/projects - leitura pura (nao e o CRUD completo descartado na issue #229). Exige membership do workspace, 404 uniforme.

Resposta: { "projects": [{ "projectId", "workspaceId", "name", "createdAt" }] }

## 2. Nova revisao de pacote
POST /api/workspaces/{workspaceId}/mapping-packages/{packageId}/revisions - o conceito de revisao ja existia no modelo (FiscalMappingPackageRevision.RevisionNumber), so nunca tinha sido exposto alem da revisao 1. Mesmo formato multipart do endpoint original. 404 pacote alheio/inexistente, 422 artefato invalido, 201 com revisionNumber incrementado.

## 3. Inventario de estrutura do Excel
GET .../mapping-packages/{packageId}/artifacts/{artifactId}/excel-inventory - reaproveita IFiscalMappingRuleExtractor (issue #103), nenhum parser novo. So funciona para artefatos kind=spec.

Resposta: { "decisionSheets": [{ "sheetName", "columns", "ruleCount" }], "skippedSheets": [...] }

dotnet build verde, dotnet test 658/658 (18 novos, 0 regressao).

Push feito pelo orquestrador - trabalho implementado por @lp-backend-dev, que nao conseguiu fazer push por limitacao de ambiente (nao por regra de autoridade).

Generated with Claude Code