### PR TITLE
fix(database): elimina corrida de FK entre stores fiscais e remove FK cross-database invalida

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -507,6 +507,12 @@ try
     // Lab. Mesmo banco/padrão ADO.NET; compile/test-run reaproveitam CanonicalDiffer/XsdValidationService
     // (já registrados/disponíveis via DI) sem I/O externo/Ollama.
     builder.Services.AddScoped<IMappingReleaseStore, SqlMappingReleaseStore>();
+    // ✅ Investigação PR #310 (2026-09-05): schema fiscal criado em ordem de dependência de FK no
+    // startup, em vez de depender de qual store acima uma requisição real exercita primeiro. Ver
+    // <see cref="LayoutParserApi.Services.Database.FiscalSchemaInitializer"/> para o grafo completo.
+    builder.Services.AddScoped<IFiscalSchemaInitializer, LayoutParserApi.Services.Database.FiscalSchemaInitializer>();
+    // Roda uma vez em background, após o app subir — não bloqueia o startup se o SQL estiver lento/fora do ar.
+    builder.Services.AddHostedService<LayoutParserApi.Services.Database.FiscalSchemaInitializerBackgroundService>();
     builder.Services.AddScoped<IMappingCompileService, LayoutParserApi.Services.Fiscal.MappingCompileService>();
     builder.Services.AddScoped<IMappingTestRunService, LayoutParserApi.Services.Fiscal.MappingTestRunService>();
     // ✅ Issue #103 Passo 1: extração determinística (sem LLM) de tabelas de decisão fiscal a

--- a/Services/Database/FiscalSchemaInitializer.cs
+++ b/Services/Database/FiscalSchemaInitializer.cs
@@ -1,0 +1,110 @@
+using LayoutParserApi.Services.Interfaces;
+
+using Microsoft.Data.SqlClient;
+
+namespace LayoutParserApi.Services.Database
+{
+    /// <summary>
+    /// Implementação de <see cref="IFiscalSchemaInitializer"/> — chama, em ORDEM, o
+    /// <c>EnsureSchemaAsync</c> (agora <c>internal</c>) de cada store fiscal/identidade, uma vez no
+    /// startup, em vez de depender de qual store uma requisição real bate primeiro.
+    /// </summary>
+    /// <remarks>
+    /// Grafo de dependência de FK mapeado (issue da instabilidade de deploy, PR #310):
+    /// <list type="bullet">
+    /// <item>Banco <c>Database:*</c> (ConnectUS_Macgyver/Sysmiddle):
+    ///   <see cref="SqlFiscalPackageStore"/> (tbFiscalProject, tbFiscalMappingPackage,
+    ///   tbFiscalMappingPackageRevision, tbPackageArtifact) →
+    ///   <see cref="SqlMappingDraftStore"/> (tbMappingDraft.PackageId/RevisionId referenciam as
+    ///   tabelas acima) →
+    ///   <see cref="SqlMappingReleaseStore"/> (tbMappingRelease.DraftId referencia tbMappingDraft).
+    /// </item>
+    /// <item>Banco <c>IdentityDatabase:*</c> (físicamente outro servidor — sem relação de FK com o
+    ///   banco acima, SQL Server não suporta FK entre bancos):
+    ///   <see cref="SqlIdentityWorkspaceStore"/> e <see cref="SqlAiUserSessionStore"/>, cada um
+    ///   autossuficiente (FKs só apontam para tabelas do próprio bloco) — ordem entre os dois é
+    ///   irrelevante.
+    /// </item>
+    /// </list>
+    /// Adicionalmente, as colunas <c>WorkspaceId</c> de <c>tbFiscalProject</c>/
+    /// <c>tbFiscalMappingPackage</c>/<c>tbMappingDraft</c>/<c>tbMappingRelease</c> tinham
+    /// <c>REFERENCES dbo.tbFiscalWorkspace(WorkspaceId)</c> — uma FK que NUNCA funcionou, em
+    /// nenhuma ordem: <c>tbFiscalWorkspace</c> não existe no banco <c>Database:*</c> (o workspace
+    /// fiscal real, <c>tbLpFiscalWorkspace</c>, mora no banco <c>IdentityDatabase:*</c>, fisicamente
+    /// outro servidor — FK cross-database é impossível no SQL Server). Essa FK foi removida das 4
+    /// tabelas (coluna preservada, sem constraint); a validação de que o WorkspaceId existe é
+    /// responsabilidade da camada de aplicação via <see cref="IIdentityWorkspaceStore"/>.
+    /// </remarks>
+    public sealed class FiscalSchemaInitializer : IFiscalSchemaInitializer
+    {
+        private readonly ILogger<FiscalSchemaInitializer> _logger;
+        private readonly string _fiscalConnectionString;
+        private readonly string _identityConnectionString;
+
+        public FiscalSchemaInitializer(ILogger<FiscalSchemaInitializer> logger, IConfiguration configuration)
+        {
+            _logger = logger;
+
+            var fiscalServer = configuration["Database:Server"];
+            var fiscalDatabase = configuration["Database:Database"];
+            var fiscalUserId = configuration["Database:UserId"];
+            var fiscalPassword = configuration["Database:Password"];
+            _fiscalConnectionString =
+                $"Server={fiscalServer};Database={fiscalDatabase};User Id={fiscalUserId};Password={fiscalPassword};TrustServerCertificate=True;";
+
+            var identityServer = configuration["IdentityDatabase:Server"];
+            var identityDatabase = configuration["IdentityDatabase:Database"];
+            var identityUserId = configuration["IdentityDatabase:UserId"];
+            var identityPassword = configuration["IdentityDatabase:Password"];
+            _identityConnectionString =
+                $"Server={identityServer};Database={identityDatabase};User Id={identityUserId};Password={identityPassword};TrustServerCertificate=True;";
+        }
+
+        public async Task InitializeAsync(CancellationToken cancellationToken)
+        {
+            await InitializeFiscalSchemaAsync(cancellationToken);
+            await InitializeIdentitySchemaAsync(cancellationToken);
+        }
+
+        // Ordem impositiva: FiscalPackage → MappingDraft → MappingRelease (ver grafo no <remarks>).
+        private async Task InitializeFiscalSchemaAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var connection = new SqlConnection(_fiscalConnectionString);
+                await connection.OpenAsync(cancellationToken);
+
+                await SqlFiscalPackageStore.EnsureSchemaAsync(connection, cancellationToken);
+                await SqlMappingDraftStore.EnsureSchemaAsync(connection, cancellationToken);
+                await SqlMappingReleaseStore.EnsureSchemaAsync(connection, cancellationToken);
+
+                _logger.LogInformation("Schema fiscal (Database:*) inicializado com sucesso no startup, em ordem de dependência de FK.");
+            }
+            catch (Exception ex)
+            {
+                // Degrada graciosamente: cada store mantém seu próprio EnsureSchemaAsync lazy como
+                // safety net por requisição — não derruba o startup da API se o SQL estiver fora do ar.
+                _logger.LogWarning(ex, "Falha ao inicializar o schema fiscal (Database:*) no startup — cada store tentará novamente sob demanda.");
+            }
+        }
+
+        // Autossuficientes, sem dependência de ordem entre si.
+        private async Task InitializeIdentitySchemaAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var connection = new SqlConnection(_identityConnectionString);
+                await connection.OpenAsync(cancellationToken);
+
+                await SqlIdentityWorkspaceStore.EnsureSchemaAsync(connection, cancellationToken);
+                await SqlAiUserSessionStore.EnsureSchemaAsync(connection, cancellationToken);
+
+                _logger.LogInformation("Schema de identidade (IdentityDatabase:*) inicializado com sucesso no startup.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha ao inicializar o schema de identidade (IdentityDatabase:*) no startup — cada store tentará novamente sob demanda.");
+            }
+        }
+    }
+}

--- a/Services/Database/FiscalSchemaInitializerBackgroundService.cs
+++ b/Services/Database/FiscalSchemaInitializerBackgroundService.cs
@@ -1,0 +1,44 @@
+using LayoutParserApi.Services.Interfaces;
+
+namespace LayoutParserApi.Services.Database
+{
+    /// <summary>
+    /// Dispara <see cref="IFiscalSchemaInitializer"/> uma vez, em segundo plano, logo após o app subir
+    /// — mesmo padrão de <see cref="CachePermanentWarmupBackgroundService"/> (não bloquear o report de
+    /// "Running" ao Service Control Manager do Windows enquanto aguarda o SQL Server responder).
+    /// </summary>
+    /// <remarks>
+    /// Diferente do warm-up de cache, esta inicialização não tem retry em loop: o schema DDL é
+    /// idempotente e cada store mantém seu próprio <c>EnsureSchemaAsync</c> lazy como safety net por
+    /// requisição — se esta tentativa única falhar (SQL fora do ar no exato momento do startup), o
+    /// primeiro request real a cada store ainda cria a tabela sob demanda, só sem a garantia de ordem
+    /// entre stores até o SQL voltar (mesmo comportamento pré-existente, apenas sem regressão).
+    /// </remarks>
+    public sealed class FiscalSchemaInitializerBackgroundService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<FiscalSchemaInitializerBackgroundService> _logger;
+
+        public FiscalSchemaInitializerBackgroundService(
+            IServiceProvider serviceProvider,
+            ILogger<FiscalSchemaInitializerBackgroundService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var initializer = scope.ServiceProvider.GetRequiredService<IFiscalSchemaInitializer>();
+                await initializer.InitializeAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha inesperada ao inicializar o schema fiscal/identidade em background — stores individuais seguem com EnsureSchemaAsync lazy como safety net.");
+            }
+        }
+    }
+}

--- a/Services/Database/SqlAiUserSessionStore.cs
+++ b/Services/Database/SqlAiUserSessionStore.cs
@@ -232,18 +232,10 @@ namespace LayoutParserApi.Services.Database
             }
         }
 
-        private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
-        {
-            if (_schemaEnsured)
-                return;
-
-            await _schemaLock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_schemaEnsured)
-                    return;
-
-                const string ddl = @"
+        // ✅ Campo público-de-assembly — ver justificativa equivalente em
+        // <see cref="SqlIdentityWorkspaceStore.SchemaDdl"/>. Autossuficiente (FK só aponta para tabela
+        // criada no mesmo bloco).
+        public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbLpAiUserSession', 'U') IS NULL
 CREATE TABLE dbo.tbLpAiUserSession (
     UserId NVARCHAR(256) NOT NULL PRIMARY KEY,
@@ -264,7 +256,18 @@ CREATE TABLE dbo.tbLpAiUserSessionHistoryEntry (
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbLpAiUserSessionHistoryEntry_UserId_CreatedAt' AND object_id = OBJECT_ID('dbo.tbLpAiUserSessionHistoryEntry'))
 CREATE INDEX IX_tbLpAiUserSessionHistoryEntry_UserId_CreatedAt ON dbo.tbLpAiUserSessionHistoryEntry(UserId, CreatedAt DESC);";
 
-                using var command = new SqlCommand(ddl, connection);
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 _schemaEnsured = true;
             }

--- a/Services/Database/SqlFiscalPackageStore.cs
+++ b/Services/Database/SqlFiscalPackageStore.cs
@@ -556,22 +556,24 @@ namespace LayoutParserApi.Services.Database
             return result as string;
         }
 
-        private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
-        {
-            if (_schemaEnsured)
-                return;
-
-            await _schemaLock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_schemaEnsured)
-                    return;
-
-                const string ddl = @"
+        // ✅ Exposta como campo (não mais `const string` local) para o
+        // `FiscalSchemaInitializer` poder inicializar o schema fiscal inteiro, em ORDEM, uma única
+        // vez no startup — em vez de depender de qual store é exercitado primeiro por uma requisição
+        // real (causa raiz do 503 "MappingDraftStore falhou: FK ... references invalid table" da
+        // PR #310: `tbMappingDraft` podia ser criado antes de `tbFiscalMappingPackage` existir).
+        //
+        // ⚠️ `WorkspaceId` NÃO tem mais `REFERENCES dbo.tbFiscalWorkspace(WorkspaceId)`: essa FK
+        // nunca funcionou, em nenhuma ordem de execução — `tbFiscalWorkspace` não existe neste banco
+        // (`Database:*`, ConnectUS_Macgyver/Sysmiddle). O workspace fiscal real (`tbLpFiscalWorkspace`)
+        // mora num banco FISICAMENTE diferente (`IdentityDatabase:*`, ver <see cref="SqlIdentityWorkspaceStore"/>),
+        // e o SQL Server não suporta FK entre bancos distintos. A validação de que o `WorkspaceId`
+        // existe/pertence ao usuário é responsabilidade da camada de aplicação (via
+        // `IIdentityWorkspaceStore`), não do banco fiscal.
+        public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbFiscalProject', 'U') IS NULL
 CREATE TABLE dbo.tbFiscalProject (
     ProjectId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
-    WorkspaceId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalWorkspace(WorkspaceId),
+    WorkspaceId UNIQUEIDENTIFIER NOT NULL,
     Name NVARCHAR(256) NOT NULL,
     CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
 );
@@ -579,7 +581,7 @@ CREATE TABLE dbo.tbFiscalProject (
 IF OBJECT_ID('dbo.tbFiscalMappingPackage', 'U') IS NULL
 CREATE TABLE dbo.tbFiscalMappingPackage (
     PackageId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
-    WorkspaceId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalWorkspace(WorkspaceId),
+    WorkspaceId UNIQUEIDENTIFIER NOT NULL,
     ProjectId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalProject(ProjectId),
     Name NVARCHAR(256) NOT NULL,
     IdempotencyKey NVARCHAR(128) NOT NULL,
@@ -618,7 +620,20 @@ CREATE TABLE dbo.tbPackageArtifact (
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbPackageArtifact_RevisionId' AND object_id = OBJECT_ID('dbo.tbPackageArtifact'))
 CREATE INDEX IX_tbPackageArtifact_RevisionId ON dbo.tbPackageArtifact(RevisionId);";
 
-                using var command = new SqlCommand(ddl, connection);
+        // internal (não mais private): chamado também pelo FiscalSchemaInitializer no startup, além
+        // do próprio store por requisição (idempotente — safety net se o initializer não rodou/falhou).
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 _schemaEnsured = true;
             }

--- a/Services/Database/SqlIdentityWorkspaceStore.cs
+++ b/Services/Database/SqlIdentityWorkspaceStore.cs
@@ -252,18 +252,12 @@ namespace LayoutParserApi.Services.Database
             return ReadWorkspaceSummary(reader);
         }
 
-        private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
-        {
-            if (_schemaEnsured)
-                return;
-
-            await _schemaLock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_schemaEnsured)
-                    return;
-
-                const string ddl = @"
+        // ✅ Campo público-de-assembly (não mais `const string` local) para o
+        // `FiscalSchemaInitializer` poder disparar o schema de identidade no startup, junto com o
+        // de `SqlAiUserSessionStore` (mesmo banco `IdentityDatabase:*`). Autossuficiente — todas as
+        // FKs abaixo apontam para tabelas criadas neste mesmo bloco, então não há dependência de
+        // ordem com outro store.
+        public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbLpUser', 'U') IS NULL
 CREATE TABLE dbo.tbLpUser (
     UserId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
@@ -303,7 +297,18 @@ CREATE TABLE dbo.tbLpWorkspaceMembership (
     CONSTRAINT UQ_tbLpWorkspaceMembership UNIQUE (WorkspaceId, UserId)
 );";
 
-                using var command = new SqlCommand(ddl, connection);
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 _schemaEnsured = true;
             }

--- a/Services/Database/SqlMappingDraftStore.cs
+++ b/Services/Database/SqlMappingDraftStore.cs
@@ -357,22 +357,16 @@ namespace LayoutParserApi.Services.Database
                 Convert.ToBase64String(rowVersion));
         }
 
-        private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
-        {
-            if (_schemaEnsured)
-                return;
-
-            await _schemaLock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_schemaEnsured)
-                    return;
-
-                const string ddl = @"
+        // ✅ Campo público-de-assembly (não mais `const string` local) — ver comentário equivalente
+        // em <see cref="SqlFiscalPackageStore.SchemaDdl"/> sobre o `FiscalSchemaInitializer` e sobre a
+        // remoção da FK inválida `REFERENCES dbo.tbFiscalWorkspace`. Além disso, `PackageId`/`RevisionId`
+        // referenciam tabelas criadas por <see cref="SqlFiscalPackageStore"/> — ESTE store depende de
+        // aquele ter rodado primeiro (mesmo banco `Database:*`), daí a ordem imposta pelo initializer.
+        public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbMappingDraft', 'U') IS NULL
 CREATE TABLE dbo.tbMappingDraft (
     DraftId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
-    WorkspaceId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalWorkspace(WorkspaceId),
+    WorkspaceId UNIQUEIDENTIFIER NOT NULL,
     PackageId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalMappingPackage(PackageId),
     RevisionId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalMappingPackageRevision(RevisionId),
     Engine NVARCHAR(16) NOT NULL,
@@ -416,7 +410,18 @@ CREATE TABLE dbo.tbMappingDraftRuleDecision (
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbMappingDraftRuleDecision_RuleId' AND object_id = OBJECT_ID('dbo.tbMappingDraftRuleDecision'))
 CREATE INDEX IX_tbMappingDraftRuleDecision_RuleId ON dbo.tbMappingDraftRuleDecision(RuleId);";
 
-                using var command = new SqlCommand(ddl, connection);
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 _schemaEnsured = true;
             }

--- a/Services/Database/SqlMappingReleaseStore.cs
+++ b/Services/Database/SqlMappingReleaseStore.cs
@@ -233,22 +233,15 @@ namespace LayoutParserApi.Services.Database
                 reader.IsDBNull(reader.GetOrdinal("PreviousPublishedReleaseId")) ? null : reader.GetGuid(reader.GetOrdinal("PreviousPublishedReleaseId")));
         }
 
-        private static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
-        {
-            if (_schemaEnsured)
-                return;
-
-            await _schemaLock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_schemaEnsured)
-                    return;
-
-                const string ddl = @"
+        // ✅ Campo público-de-assembly — mesma justificativa de <see cref="SqlFiscalPackageStore.SchemaDdl"/>
+        // (FiscalSchemaInitializer + remoção da FK cross-database inválida). `DraftId` referencia
+        // `tbMappingDraft`, criada por <see cref="SqlMappingDraftStore"/> — ESTE store depende daquele
+        // ter rodado primeiro (mesmo banco `Database:*`).
+        public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbMappingRelease', 'U') IS NULL
 CREATE TABLE dbo.tbMappingRelease (
     ReleaseId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
-    WorkspaceId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbFiscalWorkspace(WorkspaceId),
+    WorkspaceId UNIQUEIDENTIFIER NOT NULL,
     DraftId UNIQUEIDENTIFIER NOT NULL REFERENCES dbo.tbMappingDraft(DraftId),
     Engine NVARCHAR(16) NOT NULL,
     ArtifactsJson NVARCHAR(MAX) NOT NULL,
@@ -307,7 +300,18 @@ CREATE TABLE dbo.tbMappingTransition (
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbMappingTransition_ReleaseId' AND object_id = OBJECT_ID('dbo.tbMappingTransition'))
 CREATE INDEX IX_tbMappingTransition_ReleaseId ON dbo.tbMappingTransition(ReleaseId);";
 
-                using var command = new SqlCommand(ddl, connection);
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 _schemaEnsured = true;
             }

--- a/Services/Interfaces/IFiscalSchemaInitializer.cs
+++ b/Services/Interfaces/IFiscalSchemaInitializer.cs
@@ -1,0 +1,20 @@
+namespace LayoutParserApi.Services.Interfaces
+{
+    /// <summary>
+    /// Garante, uma única vez no startup (fora do request-path), que TODAS as tabelas fiscais/de
+    /// identidade sejam criadas na ORDEM correta de dependência de foreign key — elimina a corrida
+    /// entre stores que causava o 503 "MappingDraftStore falhou: FK ... references invalid table"
+    /// (PR #310): cada store fazia DDL lazy na primeira requisição que o exercitasse, sem garantia
+    /// de que a tabela referenciada por FK já existisse.
+    /// </summary>
+    public interface IFiscalSchemaInitializer
+    {
+        /// <summary>
+        /// Inicializa o schema fiscal (banco <c>Database:*</c>, ConnectUS_Macgyver/Sysmiddle) e o
+        /// schema de identidade (banco <c>IdentityDatabase:*</c>) em ordem topológica. Degrada
+        /// graciosamente: se o SQL estiver indisponível no startup, loga e retorna — cada store
+        /// continua com seu próprio <c>EnsureSchemaAsync</c> lazy como safety net por requisição.
+        /// </summary>
+        Task InitializeAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/LayoutParserApi.Tests/Database/FiscalSchemaInitializerOrderTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/FiscalSchemaInitializerOrderTests.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+
+using LayoutParserApi.Services.Database;
+
+namespace LayoutParserApi.Tests.Database
+{
+    /// <summary>
+    /// Reproduz, sem precisar de um SQL Server real, o cenário do 503 investigado na PR #310
+    /// ("MappingDraftStore falhou: FK ... references invalid table") — banco "vazio" onde a
+    /// requisição bate primeiro no store DEPENDENTE (ex.: <c>SqlMappingDraftStore</c>) antes de
+    /// qualquer request ter passado pelo store que cria a tabela referenciada
+    /// (<c>SqlFiscalPackageStore</c>).
+    /// </summary>
+    /// <remarks>
+    /// Em vez de fixar a ordem esperada como uma lista solta (que poderia divergir do DDL real e
+    /// mascarar uma regressão), o teste PARSEIA o texto de <c>SchemaDdl</c> de cada store — extraindo
+    /// toda tabela criada (<c>CREATE TABLE dbo.X</c>) e toda tabela referenciada
+    /// (<c>REFERENCES dbo.Y</c>) — e valida que, na ordem em que
+    /// <see cref="FiscalSchemaInitializer"/> concatena os DDLs (FiscalPackage → MappingDraft →
+    /// MappingRelease), NENHUMA tabela é referenciada por FK antes de ter sido criada. Isso pega
+    /// tanto a regressão original (ordem invertida) quanto uma tabela nova entrando na cadeia sem
+    /// atualizar a ordem do initializer.
+    /// </remarks>
+    public class FiscalSchemaInitializerOrderTests
+    {
+        private static readonly Regex CreateTableRegex = new(@"CREATE TABLE dbo\.(\w+)", RegexOptions.Compiled);
+        private static readonly Regex ReferencesRegex = new(@"REFERENCES dbo\.(\w+)\(", RegexOptions.Compiled);
+
+        // Ordem real usada por FiscalSchemaInitializer.InitializeFiscalSchemaAsync — mesmo banco
+        // Database:* (ConnectUS_Macgyver/Sysmiddle). Mantida em sincronia manualmente com o initializer;
+        // qualquer divergência de ordem é pega pelo teste abaixo mesmo assim, porque a validação real
+        // é sobre "tabela criada antes de referenciada", não sobre esta lista em si.
+        private static readonly string[] SysmiddleDbDdlInOrder =
+        {
+            SqlFiscalPackageStore.SchemaDdl,
+            SqlMappingDraftStore.SchemaDdl,
+            SqlMappingReleaseStore.SchemaDdl
+        };
+
+        [Fact]
+        public void Ordem_do_initializer_nunca_referencia_tabela_ainda_nao_criada()
+        {
+            var tabelasJaCriadas = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var ddl in SysmiddleDbDdlInOrder)
+            {
+                // Dentro do MESMO bloco de DDL, uma tabela pode referenciar outra criada mais acima
+                // no mesmo texto (ex.: tbFiscalMappingPackageRevision -> tbFiscalMappingPackage) —
+                // isso é seguro porque o SQL Server executa o batch inteiro em ordem sequencial.
+                // Simulamos isso processando o texto linha a linha, registrando CREATE TABLE assim
+                // que aparece, antes de validar REFERENCES subsequentes.
+                var linhas = ddl.Split('\n');
+                foreach (var linha in linhas)
+                {
+                    var referencias = ReferencesRegex.Matches(linha);
+                    foreach (Match referencia in referencias)
+                    {
+                        var tabelaReferenciada = referencia.Groups[1].Value;
+                        Assert.True(
+                            tabelasJaCriadas.Contains(tabelaReferenciada),
+                            $"FK para dbo.{tabelaReferenciada} apareceria ANTES dessa tabela existir " +
+                            "— mesma classe de bug do 503 investigado na PR #310. Ajuste a ordem em " +
+                            "FiscalSchemaInitializer (e nesta lista de teste).");
+                    }
+
+                    var criacoes = CreateTableRegex.Matches(linha);
+                    foreach (Match criacao in criacoes)
+                        tabelasJaCriadas.Add(criacao.Groups[1].Value);
+                }
+            }
+
+            // Sanidade: as 9 tabelas do grafo fiscal (Slice 2: tbFiscalProject, tbFiscalMappingPackage,
+            // tbFiscalMappingPackageRevision, tbPackageArtifact; Slice 3: tbMappingDraft,
+            // tbMappingDraftRule, tbMappingDraftRuleDecision; Slice 5: tbMappingRelease,
+            // tbMappingTransition) realmente foram encontradas — um teste que passasse com a lista
+            // vazia (ex.: regex quebrado por refactor) seria um falso positivo silencioso.
+            Assert.Equal(9, tabelasJaCriadas.Count);
+        }
+
+        [Fact]
+        public void tbFiscalWorkspace_nao_e_mais_referenciada_por_nenhum_store_do_banco_fiscal()
+        {
+            // Regressão do achado real: `dbo.tbFiscalWorkspace` nunca existiu no banco Database:*
+            // (ConnectUS_Macgyver) — o workspace fiscal real (`tbLpFiscalWorkspace`) mora no banco
+            // FISICAMENTE diferente `IdentityDatabase:*` (ver SqlIdentityWorkspaceStore), e FK entre
+            // bancos distintos não é suportada pelo SQL Server. A FK foi removida das 4 tabelas que a
+            // declaravam; este teste impede reintrodução acidental.
+            foreach (var ddl in SysmiddleDbDdlInOrder)
+                Assert.DoesNotContain("tbFiscalWorkspace", ddl);
+        }
+
+        [Fact]
+        public void Schema_de_identidade_e_autossuficiente_sem_dependencia_do_banco_fiscal()
+        {
+            // SqlIdentityWorkspaceStore e SqlAiUserSessionStore vivem em IdentityDatabase:* — um SQL
+            // Server fisicamente diferente do banco fiscal (Database:*). Toda FK declarada neles
+            // precisa apontar para uma tabela criada no PRÓPRIO bloco, nunca para o outro banco.
+            var identityDdls = new[] { SqlIdentityWorkspaceStore.SchemaDdl, SqlAiUserSessionStore.SchemaDdl };
+            var tabelasDoBancoFiscal = new[]
+            {
+                "tbFiscalProject", "tbFiscalMappingPackage", "tbFiscalMappingPackageRevision",
+                "tbPackageArtifact", "tbMappingDraft", "tbMappingDraftRule",
+                "tbMappingDraftRuleDecision", "tbMappingRelease", "tbMappingTransition"
+            };
+
+            foreach (var ddl in identityDdls)
+                foreach (var tabelaFiscal in tabelasDoBancoFiscal)
+                    Assert.DoesNotContain(tabelaFiscal, ddl);
+        }
+    }
+}


### PR DESCRIPTION
Corrige a causa raiz do 503 investigado na PR #310: dois bugs distintos.

## 1. Race de ordem de DDL lazy
SqlFiscalPackageStore, SqlMappingDraftStore e SqlMappingReleaseStore criam tabelas sob demanda (IF OBJECT_ID... IS NULL CREATE TABLE) com FK entre si, sem garantir ordem. Se a primeira requisicao bater no store errado primeiro, a FK falha.

## 2. Causa raiz de fato: FK cross-database invalida
WorkspaceId REFERENCES dbo.tbFiscalWorkspace(WorkspaceId) em 4 tabelas, mas tbFiscalWorkspace nunca existiu no banco Database:* (ConnectUS_Macgyver, 172.31.249.51). O workspace fiscal real (tbLpFiscalWorkspace) mora em IdentityDatabase:*, um SQL Server FISICAMENTE DIFERENTE (localhost\SQLEXPRESS). FK cross-database e impossivel no SQL Server - essa FK nunca funcionou, em nenhuma ordem.

## Correcao
- IFiscalSchemaInitializer / FiscalSchemaInitializer (novo) - cria o schema fiscal e de identidade em ordem topologica correta
- FiscalSchemaInitializerBackgroundService (novo) - dispara uma vez no startup, sem bloquear o SCM (mesmo padrao de CachePermanentWarmupBackgroundService)
- EnsureSchemaAsync virou internal, DDL extraido para campo publico estatico; FK invalida removida das 4 tabelas fiscais
- Teste novo: parseia o DDL real e falha se alguma FK referenciar tabela ainda nao criada (validado por mutacao)

dotnet build 0 erros, dotnet test 677/677 verdes.

## Achado adicional, fora de escopo desta PR
Varias queries SELECT/JOIN dbo.tbWorkspaceMembership nesses mesmos stores tem a mesma classe de bug (tabela que so existe no outro banco) - quebra em runtime ListProjectsForMemberAsync, GetDraftIfMemberAsync etc. Precisa virar issue propria (cross-database join real exige outra abordagem - linked server, replicacao, ou consolidar em um so banco).

Push feito pelo orquestrador - implementacao de @lp-backend-dev.

Generated with Claude Code