### PR TITLE
fix(database): migra pacote fiscal/drafts/releases para IdentityDatabase (banco dedicado)

### DIFF
--- a/Services/Database/FiscalSchemaInitializer.cs
+++ b/Services/Database/FiscalSchemaInitializer.cs
@@ -10,47 +10,48 @@ namespace LayoutParserApi.Services.Database
     /// startup, em vez de depender de qual store uma requisição real bate primeiro.
     /// </summary>
     /// <remarks>
-    /// Grafo de dependência de FK mapeado (issue da instabilidade de deploy, PR #310):
+    /// Grafo de dependência de FK mapeado (issue da instabilidade de deploy, PR #310) e atualizado
+    /// após a migração de banco (PR seguinte a #312): <see cref="SqlFiscalPackageStore"/>,
+    /// <see cref="SqlMappingDraftStore"/> e <see cref="SqlMappingReleaseStore"/> deixaram de usar o
+    /// banco compartilhado <c>Database:*</c> (ConnectUS_Macgyver/Sysmiddle) e passaram a usar o banco
+    /// DEDICADO do projeto (<c>IdentityDatabase:*</c>), o mesmo já usado por
+    /// <see cref="SqlIdentityWorkspaceStore"/> e <see cref="SqlAiUserSessionStore"/>. Motivo: essas
+    /// tabelas fiscais são exclusivas deste projeto e não deveriam depender do SQL Server
+    /// compartilhado por ~231.890 times da NDD (ver <c>.claude/rules/security.md</c>) — a FK inválida
+    /// corrigida na PR #312 (removida, não recriada) era sintoma dessa divergência de banco, não a
+    /// causa raiz completa.
+    /// <para>
+    /// Com todos os 5 stores agora no MESMO servidor físico (<c>IdentityDatabase:*</c>), o
+    /// initializer usa uma ÚNICA conexão para todo o schema, em ordem de dependência de FK:
     /// <list type="bullet">
-    /// <item>Banco <c>Database:*</c> (ConnectUS_Macgyver/Sysmiddle):
-    ///   <see cref="SqlFiscalPackageStore"/> (tbFiscalProject, tbFiscalMappingPackage,
-    ///   tbFiscalMappingPackageRevision, tbPackageArtifact) →
-    ///   <see cref="SqlMappingDraftStore"/> (tbMappingDraft.PackageId/RevisionId referenciam as
-    ///   tabelas acima) →
-    ///   <see cref="SqlMappingReleaseStore"/> (tbMappingRelease.DraftId referencia tbMappingDraft).
-    /// </item>
-    /// <item>Banco <c>IdentityDatabase:*</c> (físicamente outro servidor — sem relação de FK com o
-    ///   banco acima, SQL Server não suporta FK entre bancos):
-    ///   <see cref="SqlIdentityWorkspaceStore"/> e <see cref="SqlAiUserSessionStore"/>, cada um
-    ///   autossuficiente (FKs só apontam para tabelas do próprio bloco) — ordem entre os dois é
-    ///   irrelevante.
-    /// </item>
+    /// <item><see cref="SqlFiscalPackageStore"/> (tbFiscalProject, tbFiscalMappingPackage,
+    ///   tbFiscalMappingPackageRevision, tbPackageArtifact) →</item>
+    /// <item><see cref="SqlMappingDraftStore"/> (tbMappingDraft.PackageId/RevisionId referenciam as
+    ///   tabelas acima) →</item>
+    /// <item><see cref="SqlMappingReleaseStore"/> (tbMappingRelease.DraftId referencia tbMappingDraft) →</item>
+    /// <item><see cref="SqlIdentityWorkspaceStore"/> e <see cref="SqlAiUserSessionStore"/>, cada um
+    ///   autossuficiente (FKs só apontam para tabelas do próprio bloco) — ordem entre os dois (e em
+    ///   relação aos três primeiros) é irrelevante, mantidos por último por não serem dependência de
+    ///   ninguém.</item>
     /// </list>
+    /// </para>
     /// Adicionalmente, as colunas <c>WorkspaceId</c> de <c>tbFiscalProject</c>/
     /// <c>tbFiscalMappingPackage</c>/<c>tbMappingDraft</c>/<c>tbMappingRelease</c> tinham
     /// <c>REFERENCES dbo.tbFiscalWorkspace(WorkspaceId)</c> — uma FK que NUNCA funcionou, em
-    /// nenhuma ordem: <c>tbFiscalWorkspace</c> não existe no banco <c>Database:*</c> (o workspace
-    /// fiscal real, <c>tbLpFiscalWorkspace</c>, mora no banco <c>IdentityDatabase:*</c>, fisicamente
-    /// outro servidor — FK cross-database é impossível no SQL Server). Essa FK foi removida das 4
-    /// tabelas (coluna preservada, sem constraint); a validação de que o WorkspaceId existe é
-    /// responsabilidade da camada de aplicação via <see cref="IIdentityWorkspaceStore"/>.
+    /// nenhuma ordem: <c>tbFiscalWorkspace</c> nunca existiu em banco nenhum (o workspace fiscal
+    /// real é <c>tbLpFiscalWorkspace</c>). Essa FK foi removida das 4 tabelas (coluna preservada, sem
+    /// constraint) antes mesmo desta migração; não foi recriada apontando para
+    /// <c>tbLpFiscalWorkspace</c> mesmo agora que ambos moram no mesmo banco — ver comentário em
+    /// <see cref="SqlFiscalPackageStore.SchemaDdl"/>.
     /// </remarks>
     public sealed class FiscalSchemaInitializer : IFiscalSchemaInitializer
     {
         private readonly ILogger<FiscalSchemaInitializer> _logger;
-        private readonly string _fiscalConnectionString;
         private readonly string _identityConnectionString;
 
         public FiscalSchemaInitializer(ILogger<FiscalSchemaInitializer> logger, IConfiguration configuration)
         {
             _logger = logger;
-
-            var fiscalServer = configuration["Database:Server"];
-            var fiscalDatabase = configuration["Database:Database"];
-            var fiscalUserId = configuration["Database:UserId"];
-            var fiscalPassword = configuration["Database:Password"];
-            _fiscalConnectionString =
-                $"Server={fiscalServer};Database={fiscalDatabase};User Id={fiscalUserId};Password={fiscalPassword};TrustServerCertificate=True;";
 
             var identityServer = configuration["IdentityDatabase:Server"];
             var identityDatabase = configuration["IdentityDatabase:Database"];
@@ -62,48 +63,26 @@ namespace LayoutParserApi.Services.Database
 
         public async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            await InitializeFiscalSchemaAsync(cancellationToken);
-            await InitializeIdentitySchemaAsync(cancellationToken);
-        }
-
-        // Ordem impositiva: FiscalPackage → MappingDraft → MappingRelease (ver grafo no <remarks>).
-        private async Task InitializeFiscalSchemaAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                using var connection = new SqlConnection(_fiscalConnectionString);
-                await connection.OpenAsync(cancellationToken);
-
-                await SqlFiscalPackageStore.EnsureSchemaAsync(connection, cancellationToken);
-                await SqlMappingDraftStore.EnsureSchemaAsync(connection, cancellationToken);
-                await SqlMappingReleaseStore.EnsureSchemaAsync(connection, cancellationToken);
-
-                _logger.LogInformation("Schema fiscal (Database:*) inicializado com sucesso no startup, em ordem de dependência de FK.");
-            }
-            catch (Exception ex)
-            {
-                // Degrada graciosamente: cada store mantém seu próprio EnsureSchemaAsync lazy como
-                // safety net por requisição — não derruba o startup da API se o SQL estiver fora do ar.
-                _logger.LogWarning(ex, "Falha ao inicializar o schema fiscal (Database:*) no startup — cada store tentará novamente sob demanda.");
-            }
-        }
-
-        // Autossuficientes, sem dependência de ordem entre si.
-        private async Task InitializeIdentitySchemaAsync(CancellationToken cancellationToken)
-        {
             try
             {
                 using var connection = new SqlConnection(_identityConnectionString);
                 await connection.OpenAsync(cancellationToken);
 
+                // Ordem impositiva: FiscalPackage → MappingDraft → MappingRelease (FK entre eles) →
+                // IdentityWorkspace/AiUserSession (autossuficientes, ordem irrelevante entre si).
+                await SqlFiscalPackageStore.EnsureSchemaAsync(connection, cancellationToken);
+                await SqlMappingDraftStore.EnsureSchemaAsync(connection, cancellationToken);
+                await SqlMappingReleaseStore.EnsureSchemaAsync(connection, cancellationToken);
                 await SqlIdentityWorkspaceStore.EnsureSchemaAsync(connection, cancellationToken);
                 await SqlAiUserSessionStore.EnsureSchemaAsync(connection, cancellationToken);
 
-                _logger.LogInformation("Schema de identidade (IdentityDatabase:*) inicializado com sucesso no startup.");
+                _logger.LogInformation("Schema fiscal e de identidade (IdentityDatabase:*) inicializado com sucesso no startup, em ordem de dependência de FK.");
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Falha ao inicializar o schema de identidade (IdentityDatabase:*) no startup — cada store tentará novamente sob demanda.");
+                // Degrada graciosamente: cada store mantém seu próprio EnsureSchemaAsync lazy como
+                // safety net por requisição — não derruba o startup da API se o SQL estiver fora do ar.
+                _logger.LogWarning(ex, "Falha ao inicializar o schema fiscal/identidade (IdentityDatabase:*) no startup — cada store tentará novamente sob demanda.");
             }
         }
     }

--- a/Services/Database/SqlFiscalPackageStore.cs
+++ b/Services/Database/SqlFiscalPackageStore.cs
@@ -6,9 +6,14 @@ using Microsoft.Data.SqlClient;
 namespace LayoutParserApi.Services.Database
 {
     /// <summary>
-    /// Implementação SQL de <see cref="IFiscalPackageStore"/> — Slice 2 (issue #229). Mesmo banco
-    /// <c>ConnectUS_Macgyver</c> e mesmo padrão ADO.NET cru de <see cref="SqlIdentityWorkspaceStore"/>
-    /// (DDL idempotente por processo, connection string montada de <c>Database:*</c>).
+    /// Implementação SQL de <see cref="IFiscalPackageStore"/> — Slice 2 (issue #229). Migrado do
+    /// banco compartilhado <c>ConnectUS_Macgyver</c> (<c>Database:*</c>) para o banco DEDICADO do
+    /// projeto (<c>IdentityDatabase:*</c>, mesmo usado por <see cref="SqlIdentityWorkspaceStore"/>)
+    /// — a raiz do bug de FK cross-database investigado na PR #312 era justamente essas tabelas
+    /// fiscais morarem no banco compartilhado enquanto o workspace real mora em outro servidor
+    /// físico. Mesmo padrão ADO.NET cru de <see cref="SqlIdentityWorkspaceStore"/> (DDL idempotente
+    /// por processo). Ver <c>.claude/rules/security.md</c> para o histórico da credencial
+    /// compartilhada que motivou a separação original de identidade.
     /// </summary>
     public sealed class SqlFiscalPackageStore : IFiscalPackageStore
     {
@@ -23,10 +28,12 @@ namespace LayoutParserApi.Services.Database
         public SqlFiscalPackageStore(ILogger<SqlFiscalPackageStore> logger, IConfiguration configuration)
         {
             _logger = logger;
-            var server = configuration["Database:Server"];
-            var database = configuration["Database:Database"];
-            var userId = configuration["Database:UserId"];
-            var password = configuration["Database:Password"];
+            // ✅ Banco dedicado do projeto (não mais o ConnectUS_Macgyver compartilhado) — mesmo
+            // padrão de SqlIdentityWorkspaceStore.
+            var server = configuration["IdentityDatabase:Server"];
+            var database = configuration["IdentityDatabase:Database"];
+            var userId = configuration["IdentityDatabase:UserId"];
+            var password = configuration["IdentityDatabase:Password"];
 
             _connectionString = $"Server={server};Database={database};User Id={userId};Password={password};TrustServerCertificate=True;";
         }
@@ -197,7 +204,7 @@ namespace LayoutParserApi.Services.Database
             using var selectPackage = new SqlCommand(
                 @"SELECT p.PackageId, p.WorkspaceId, p.ProjectId, p.Name, p.CreatedAt
                   FROM dbo.tbFiscalMappingPackage p
-                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = p.WorkspaceId AND m.UserId = @UserId
+                  JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = p.WorkspaceId AND m.UserId = @UserId
                   WHERE p.PackageId = @PackageId;",
                 connection);
             selectPackage.Parameters.AddWithValue("@PackageId", packageId);
@@ -406,12 +413,12 @@ namespace LayoutParserApi.Services.Database
             await connection.OpenAsync(cancellationToken);
             await EnsureSchemaAsync(connection, cancellationToken);
 
-            // Join com tbWorkspaceMembership: defesa em profundidade — o controller já checou
+            // Join com tbLpWorkspaceMembership: defesa em profundidade — o controller já checou
             // membership antes de chamar, mas a store nunca confia cegamente no WorkspaceId da rota.
             using var command = new SqlCommand(
                 @"SELECT p.ProjectId, p.WorkspaceId, p.Name, p.CreatedAt
                   FROM dbo.tbFiscalProject p
-                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = p.WorkspaceId AND m.UserId = @UserId
+                  JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = p.WorkspaceId AND m.UserId = @UserId
                   WHERE p.WorkspaceId = @WorkspaceId
                   ORDER BY p.CreatedAt DESC;",
                 connection);
@@ -562,13 +569,16 @@ namespace LayoutParserApi.Services.Database
         // real (causa raiz do 503 "MappingDraftStore falhou: FK ... references invalid table" da
         // PR #310: `tbMappingDraft` podia ser criado antes de `tbFiscalMappingPackage` existir).
         //
-        // ⚠️ `WorkspaceId` NÃO tem mais `REFERENCES dbo.tbFiscalWorkspace(WorkspaceId)`: essa FK
-        // nunca funcionou, em nenhuma ordem de execução — `tbFiscalWorkspace` não existe neste banco
-        // (`Database:*`, ConnectUS_Macgyver/Sysmiddle). O workspace fiscal real (`tbLpFiscalWorkspace`)
-        // mora num banco FISICAMENTE diferente (`IdentityDatabase:*`, ver <see cref="SqlIdentityWorkspaceStore"/>),
-        // e o SQL Server não suporta FK entre bancos distintos. A validação de que o `WorkspaceId`
-        // existe/pertence ao usuário é responsabilidade da camada de aplicação (via
-        // `IIdentityWorkspaceStore`), não do banco fiscal.
+        // ⚠️ `WorkspaceId` NÃO tem `REFERENCES dbo.tbLpFiscalWorkspace(WorkspaceId)` mesmo agora que
+        // este store mora no MESMO banco (`IdentityDatabase:*`) que `tbLpFiscalWorkspace` (ver
+        // <see cref="SqlIdentityWorkspaceStore"/>). Historicamente essa FK nunca funcionou (apontava
+        // para `dbo.tbFiscalWorkspace`, tabela que não existia em banco nenhum) porque este store
+        // vivia fisicamente separado (`Database:*`, ConnectUS_Macgyver/Sysmiddle) antes da migração
+        // documentada no cabeçalho da classe. Agora que os dois moram juntos, uma FK real seria
+        // tecnicamente possível — mantida de fora por ora para não acoplar a ordem de schema deste
+        // store à de `SqlIdentityWorkspaceStore` sem necessidade; a validação de que o `WorkspaceId`
+        // existe/pertence ao usuário continua responsabilidade da camada de aplicação (via
+        // `IIdentityWorkspaceStore`).
         public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbFiscalProject', 'U') IS NULL
 CREATE TABLE dbo.tbFiscalProject (

--- a/Services/Database/SqlMappingDraftStore.cs
+++ b/Services/Database/SqlMappingDraftStore.cs
@@ -8,10 +8,12 @@ using Microsoft.Data.SqlClient;
 namespace LayoutParserApi.Services.Database
 {
     /// <summary>
-    /// Implementação SQL de <see cref="IMappingDraftStore"/> — Slice 3 (issue #230). Mesmo banco
-    /// <c>ConnectUS_Macgyver</c> e mesmo padrão ADO.NET cru de <see cref="SqlFiscalPackageStore"/>
-    /// (DDL idempotente por processo). Só LÊ as tabelas do Slice 2 (revisão/artefato) — nunca escreve
-    /// nelas, respeitando "não tocar código dos Slices 1/2 além de reaproveitar".
+    /// Implementação SQL de <see cref="IMappingDraftStore"/> — Slice 3 (issue #230). Migrado do
+    /// banco compartilhado <c>ConnectUS_Macgyver</c> (<c>Database:*</c>) para o banco DEDICADO do
+    /// projeto (<c>IdentityDatabase:*</c>), junto com <see cref="SqlFiscalPackageStore"/> — mesma
+    /// justificativa (raiz do bug de FK cross-database da PR #312). Mesmo padrão ADO.NET cru. Só LÊ
+    /// as tabelas do Slice 2 (revisão/artefato) — nunca escreve nelas, respeitando "não tocar código
+    /// dos Slices 1/2 além de reaproveitar".
     /// </summary>
     public sealed class SqlMappingDraftStore : IMappingDraftStore
     {
@@ -26,10 +28,11 @@ namespace LayoutParserApi.Services.Database
         public SqlMappingDraftStore(ILogger<SqlMappingDraftStore> logger, IConfiguration configuration)
         {
             _logger = logger;
-            var server = configuration["Database:Server"];
-            var database = configuration["Database:Database"];
-            var userId = configuration["Database:UserId"];
-            var password = configuration["Database:Password"];
+            // ✅ Banco dedicado do projeto (não mais o ConnectUS_Macgyver compartilhado).
+            var server = configuration["IdentityDatabase:Server"];
+            var database = configuration["IdentityDatabase:Database"];
+            var userId = configuration["IdentityDatabase:UserId"];
+            var password = configuration["IdentityDatabase:Password"];
 
             _connectionString = $"Server={server};Database={database};User Id={userId};Password={password};TrustServerCertificate=True;";
         }
@@ -109,7 +112,7 @@ namespace LayoutParserApi.Services.Database
             using (var selectDraft = new SqlCommand(
                 @"SELECT d.WorkspaceId, d.PackageId, d.RevisionId, d.Engine, d.CreatedAt
                   FROM dbo.tbMappingDraft d
-                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
+                  JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
                   WHERE d.DraftId = @DraftId;",
                 connection))
             {
@@ -141,7 +144,7 @@ namespace LayoutParserApi.Services.Database
                          r.Cardinality, r.EvidenceJson, r.Confidence, r.Status, r.OpenQuestionsJson, r.CreatedAt, r.RowVersion
                   FROM dbo.tbMappingDraftRule r
                   JOIN dbo.tbMappingDraft d ON d.DraftId = r.DraftId
-                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
+                  JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
                   WHERE r.RuleId = @RuleId AND r.DraftId = @DraftId;",
                 connection);
             command.Parameters.AddWithValue("@RuleId", ruleId);
@@ -252,7 +255,7 @@ namespace LayoutParserApi.Services.Database
                           r.Operation = COALESCE(@EditedOperation, r.Operation)
                       FROM dbo.tbMappingDraftRule r
                       JOIN dbo.tbMappingDraft d ON d.DraftId = r.DraftId
-                      JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
+                      JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
                       WHERE r.RuleId = @RuleId AND r.DraftId = @DraftId AND r.RowVersion = @ExpectedRowVersion;",
                     connection, tx))
                 {
@@ -273,7 +276,7 @@ namespace LayoutParserApi.Services.Database
                         using var existsCheck = new SqlCommand(
                             @"SELECT 1 FROM dbo.tbMappingDraftRule r
                               JOIN dbo.tbMappingDraft d ON d.DraftId = r.DraftId
-                              JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
+                              JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = d.WorkspaceId AND m.UserId = @UserId
                               WHERE r.RuleId = @RuleId AND r.DraftId = @DraftId;",
                             connection, tx);
                         existsCheck.Parameters.AddWithValue("@RuleId", ruleId);
@@ -361,7 +364,8 @@ namespace LayoutParserApi.Services.Database
         // em <see cref="SqlFiscalPackageStore.SchemaDdl"/> sobre o `FiscalSchemaInitializer` e sobre a
         // remoção da FK inválida `REFERENCES dbo.tbFiscalWorkspace`. Além disso, `PackageId`/`RevisionId`
         // referenciam tabelas criadas por <see cref="SqlFiscalPackageStore"/> — ESTE store depende de
-        // aquele ter rodado primeiro (mesmo banco `Database:*`), daí a ordem imposta pelo initializer.
+        // aquele ter rodado primeiro (mesmo banco `IdentityDatabase:*`, desde a migração descrita no
+        // cabeçalho da classe), daí a ordem imposta pelo initializer.
         public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbMappingDraft', 'U') IS NULL
 CREATE TABLE dbo.tbMappingDraft (

--- a/Services/Database/SqlMappingReleaseStore.cs
+++ b/Services/Database/SqlMappingReleaseStore.cs
@@ -8,9 +8,12 @@ using Microsoft.Data.SqlClient;
 namespace LayoutParserApi.Services.Database
 {
     /// <summary>
-    /// Implementação SQL de <see cref="IMappingReleaseStore"/> — Slice 5 (issue #231). Mesmo banco
-    /// <c>ConnectUS_Macgyver</c> e mesmo padrão ADO.NET cru de <see cref="SqlMappingDraftStore"/> (DDL
-    /// idempotente por processo, JSON em <c>NVARCHAR(MAX)</c> para as coleções).
+    /// Implementação SQL de <see cref="IMappingReleaseStore"/> — Slice 5 (issue #231). Migrado do
+    /// banco compartilhado <c>ConnectUS_Macgyver</c> (<c>Database:*</c>) para o banco DEDICADO do
+    /// projeto (<c>IdentityDatabase:*</c>), junto com <see cref="SqlFiscalPackageStore"/> e
+    /// <see cref="SqlMappingDraftStore"/> — mesma justificativa (raiz do bug de FK cross-database
+    /// da PR #312). Mesmo padrão ADO.NET cru (DDL idempotente por processo, JSON em
+    /// <c>NVARCHAR(MAX)</c> para as coleções).
     /// </summary>
     public sealed class SqlMappingReleaseStore : IMappingReleaseStore
     {
@@ -25,10 +28,11 @@ namespace LayoutParserApi.Services.Database
         public SqlMappingReleaseStore(ILogger<SqlMappingReleaseStore> logger, IConfiguration configuration)
         {
             _logger = logger;
-            var server = configuration["Database:Server"];
-            var database = configuration["Database:Database"];
-            var userId = configuration["Database:UserId"];
-            var password = configuration["Database:Password"];
+            // ✅ Banco dedicado do projeto (não mais o ConnectUS_Macgyver compartilhado).
+            var server = configuration["IdentityDatabase:Server"];
+            var database = configuration["IdentityDatabase:Database"];
+            var userId = configuration["IdentityDatabase:UserId"];
+            var password = configuration["IdentityDatabase:Password"];
 
             _connectionString = $"Server={server};Database={database};User Id={userId};Password={password};TrustServerCertificate=True;";
         }
@@ -111,7 +115,7 @@ namespace LayoutParserApi.Services.Database
                          r.CreatedAt, r.RowVersion, r.Environment, r.ApprovedByUserId, r.ApprovedAt, r.ApprovalJustification,
                          r.PublishedByUserId, r.PublishedAt, r.PreviousPublishedReleaseId
                   FROM dbo.tbMappingRelease r
-                  JOIN dbo.tbWorkspaceMembership m ON m.WorkspaceId = r.WorkspaceId AND m.UserId = @UserId
+                  JOIN dbo.tbLpWorkspaceMembership m ON m.WorkspaceId = r.WorkspaceId AND m.UserId = @UserId
                   WHERE r.ReleaseId = @ReleaseId;",
                 connection);
             command.Parameters.AddWithValue("@ReleaseId", releaseId);
@@ -236,7 +240,7 @@ namespace LayoutParserApi.Services.Database
         // ✅ Campo público-de-assembly — mesma justificativa de <see cref="SqlFiscalPackageStore.SchemaDdl"/>
         // (FiscalSchemaInitializer + remoção da FK cross-database inválida). `DraftId` referencia
         // `tbMappingDraft`, criada por <see cref="SqlMappingDraftStore"/> — ESTE store depende daquele
-        // ter rodado primeiro (mesmo banco `Database:*`).
+        // ter rodado primeiro (mesmo banco `IdentityDatabase:*`).
         public static readonly string SchemaDdl = @"
 IF OBJECT_ID('dbo.tbMappingRelease', 'U') IS NULL
 CREATE TABLE dbo.tbMappingRelease (

--- a/appsettings.json
+++ b/appsettings.json
@@ -98,13 +98,19 @@
     "ConnectionTimeout": "30",
     "CommandTimeout": "30"
   },
-  // ✅ Banco DEDICADO da LayoutParserApi (identidade/workspace) — NÃO é o ConnectUS_Macgyver.
-  // SQL Server local na mesma máquina da API (SQL Server 2025 Express). Credencial separada
-  // da do Sysmiddle: nunca reusar "Database:Password" aqui. Senha real via
-  // `dotnet user-secrets` (dev) ou env var `IdentityDatabase__Password` (prod) — nunca em texto
-  // plano neste arquivo (ver .claude/rules/security.md).
+  // ✅ Banco DEDICADO da LayoutParserApi (identidade/workspace/pacotes fiscais/drafts/releases) —
+  // NÃO é o ConnectUS_Macgyver. SQL Server rodando em Docker na VM Ubuntu de produção
+  // (elson@172.25.32.5, container "layoutparser-identity-sql",
+  // mcr.microsoft.com/mssql/server:2022-latest, porta publicada 1433 — CONFIRMAR com o dono se a
+  // porta publicada do container é realmente 1433:1433 e não outra mapeada; não foi possível
+  // inspecionar o container diretamente nesta sessão). O valor anterior ("localhost\SQLEXPRESS")
+  // era um resquício de configuração local de dev (ver commit 0a2162b, que introduziu esta seção
+  // já com esse valor) — nunca foi atualizado para produção. Credencial separada da do Sysmiddle:
+  // nunca reusar "Database:Password" aqui. Senha real via `dotnet user-secrets` (dev) ou env var
+  // `IdentityDatabase__Password` (prod) — nunca em texto plano neste arquivo (ver
+  // .claude/rules/security.md).
   "IdentityDatabase": {
-    "Server": "localhost\\SQLEXPRESS",
+    "Server": "172.25.32.5,1433",
     "Database": "LayoutParserIdentity",
     "UserId": "",
     "Password": "",

--- a/tests/LayoutParserApi.Tests/Database/FiscalSchemaInitializerOrderTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/FiscalSchemaInitializerOrderTests.cs
@@ -26,10 +26,11 @@ namespace LayoutParserApi.Tests.Database
         private static readonly Regex CreateTableRegex = new(@"CREATE TABLE dbo\.(\w+)", RegexOptions.Compiled);
         private static readonly Regex ReferencesRegex = new(@"REFERENCES dbo\.(\w+)\(", RegexOptions.Compiled);
 
-        // Ordem real usada por FiscalSchemaInitializer.InitializeFiscalSchemaAsync — mesmo banco
-        // Database:* (ConnectUS_Macgyver/Sysmiddle). Mantida em sincronia manualmente com o initializer;
-        // qualquer divergência de ordem é pega pelo teste abaixo mesmo assim, porque a validação real
-        // é sobre "tabela criada antes de referenciada", não sobre esta lista em si.
+        // Ordem real usada por FiscalSchemaInitializer.InitializeAsync — desde a migração para o
+        // banco dedicado (IdentityDatabase:*), estes 3 stores não moram mais no ConnectUS_Macgyver.
+        // Mantida em sincronia manualmente com o initializer; qualquer divergência de ordem é pega
+        // pelo teste abaixo mesmo assim, porque a validação real é sobre "tabela criada antes de
+        // referenciada", não sobre esta lista em si.
         private static readonly string[] SysmiddleDbDdlInOrder =
         {
             SqlFiscalPackageStore.SchemaDdl,

--- a/tests/LayoutParserApi.Tests/Database/FiscalStoresUseIdentityDatabaseTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/FiscalStoresUseIdentityDatabaseTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+
+using LayoutParserApi.Services.Database;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LayoutParserApi.Tests.Database
+{
+    /// <summary>
+    /// Regressão da migração de banco (correção completa do bug de FK cross-database investigado
+    /// na PR #312): <see cref="SqlFiscalPackageStore"/>, <see cref="SqlMappingDraftStore"/> e
+    /// <see cref="SqlMappingReleaseStore"/> deixaram de usar o banco compartilhado <c>Database:*</c>
+    /// (ConnectUS_Macgyver) e passaram a usar o banco dedicado <c>IdentityDatabase:*</c>.
+    /// </summary>
+    /// <remarks>
+    /// Como não há SQL Server disponível no ambiente de teste (nem um jeito rápido/determinístico de
+    /// forçar uma <c>SqlException</c> com o hostname no texto — depende de resolução DNS/timeout de
+    /// rede, que variou entre <c>SqlException</c> e <c>TaskCanceledException</c> nesta máquina), a
+    /// verificação lê a connection string privada montada no construtor via reflection e confirma
+    /// que ela foi montada a partir de <c>IdentityDatabase:*</c>, nunca de <c>Database:*</c>.
+    /// </remarks>
+    public class FiscalStoresUseIdentityDatabaseTests
+    {
+        private const string DatabaseHost = "host-database-legado-teste.invalid";
+        private const string IdentityHost = "host-identity-dedicado-teste.invalid";
+
+        private static IConfiguration BuildConfiguration()
+        {
+            var configValues = new Dictionary<string, string?>
+            {
+                // Host distinto e claramente rotulado — se o store usar esta config por engano, a
+                // connection string lida via reflection vai conter "database-legado", não
+                // "identity-dedicado".
+                ["Database:Server"] = DatabaseHost,
+                ["Database:Database"] = "ConnectUS_Macgyver",
+                ["Database:UserId"] = "macgyver",
+                ["Database:Password"] = "pwd-fiscal-legado",
+
+                ["IdentityDatabase:Server"] = IdentityHost,
+                ["IdentityDatabase:Database"] = "LayoutParserIdentity",
+                ["IdentityDatabase:UserId"] = "identity-user",
+                ["IdentityDatabase:Password"] = "pwd-identity",
+            };
+            return new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+        }
+
+        private static string ReadConnectionString(object store)
+        {
+            var field = store.GetType().GetField("_connectionString", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            var value = field!.GetValue(store) as string;
+            Assert.NotNull(value);
+            return value!;
+        }
+
+        [Fact]
+        public void SqlFiscalPackageStore_usa_IdentityDatabase_nao_Database()
+        {
+            var store = new SqlFiscalPackageStore(NullLogger<SqlFiscalPackageStore>.Instance, BuildConfiguration());
+            var connectionString = ReadConnectionString(store);
+
+            Assert.Contains(IdentityHost, connectionString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(DatabaseHost, connectionString, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SqlMappingDraftStore_usa_IdentityDatabase_nao_Database()
+        {
+            var store = new SqlMappingDraftStore(NullLogger<SqlMappingDraftStore>.Instance, BuildConfiguration());
+            var connectionString = ReadConnectionString(store);
+
+            Assert.Contains(IdentityHost, connectionString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(DatabaseHost, connectionString, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SqlMappingReleaseStore_usa_IdentityDatabase_nao_Database()
+        {
+            var store = new SqlMappingReleaseStore(NullLogger<SqlMappingReleaseStore>.Instance, BuildConfiguration());
+            var connectionString = ReadConnectionString(store);
+
+            Assert.Contains(IdentityHost, connectionString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(DatabaseHost, connectionString, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## Contexto

A PR #312 (`fix/schema-fiscal-ordem-fk-cross-database`, já mergeada em `develop`) corrigiu o
sintoma de um bug de FK cross-database removendo a FK inválida `WorkspaceId REFERENCES
dbo.tbFiscalWorkspace(WorkspaceId)` — essa FK nunca funcionou, porque `tbFiscalWorkspace` nunca
existiu em banco nenhum (o workspace fiscal real, `tbLpFiscalWorkspace`, mora fisicamente em outro
servidor).

Esta PR corrige a **causa raiz de fundo**: as tabelas do pacote fiscal
(`tbFiscalProject`, `tbFiscalMappingPackage`, `tbFiscalMappingPackageRevision`,
`tbPackageArtifact`, `tbMappingDraft*`, `tbMappingRelease*`) estavam usando a config `Database:*`
— o SQL Server **compartilhado por ~231.890 times da NDD inteira** (`172.31.249.51`,
`ConnectUS_Macgyver`, credencial que não pode ser rotacionada por decisão já documentada em
`.claude/rules/security.md`) — quando deveriam estar no banco **DEDICADO** deste projeto
(`IdentityDatabase:*`), o mesmo já usado por `SqlIdentityWorkspaceStore` e `SqlAiUserSessionStore`.

## Por que isso é a correção completa (não só mais um remendo)

- Elimina a dependência deste projeto no banco compartilhado do Sysmiddle para dados que são
  **exclusivamente seus** (pacotes/drafts/releases de mapeamento fiscal não têm nenhuma relação
  com o domínio do Sysmiddle).
- Remove de vez a possibilidade da MESMA classe de bug (FK/JOIN cross-database) reaparecer nessas
  tabelas — agora que tudo mora fisicamente no mesmo servidor, uma FK real entre elas seria
  tecnicamente possível (deixada de fora por ora, ver comentário em `FiscalSchemaInitializer.cs`).
- **Achado colateral corrigido de brinde**: os `JOIN dbo.tbWorkspaceMembership` nos 3 stores
  apontavam para uma tabela que **nunca existiu em banco nenhum** (nenhum `SchemaDdl` a cria) —
  esses JOINs sempre retornaram conjunto vazio silenciosamente, mesmo com o WorkspaceId correto.
  Corrigido para `dbo.tbLpWorkspaceMembership` (a tabela real, criada por
  `SqlIdentityWorkspaceStore`, agora no MESMO banco).

## Mudanças

- `Services/Database/SqlFiscalPackageStore.cs`, `SqlMappingDraftStore.cs`,
  `SqlMappingReleaseStore.cs`: connection string agora montada de `IdentityDatabase:*` (mesmo
  padrão já usado por `SqlIdentityWorkspaceStore`/`SqlAiUserSessionStore`), não `Database:*`.
- `Services/Database/FiscalSchemaInitializer.cs`: simplificado para uma ÚNICA conexão
  (`IdentityDatabase`), já que os 5 stores agora moram no mesmo servidor físico. Ordem de FK
  preservada: `FiscalPackage → MappingDraft → MappingRelease → IdentityWorkspace →
  AiUserSession`.
- `appsettings.json`: `IdentityDatabase:Server` atualizado de `localhost\SQLEXPRESS` (resquício de
  config local de dev, nunca atualizado desde a introdução da seção — confirmado via
  `git log -S SQLEXPRESS`) para `172.25.32.5,1433`.

## ⚠️ Suposição que precisa de confirmação do dono

O valor `172.25.32.5,1433` para `IdentityDatabase:Server` é uma **suposição**, não uma
confirmação: baseei-me na descrição da tarefa (SQL Server em Docker na VM Ubuntu
`elson@172.25.32.5`, container `layoutparser-identity-sql`,
`mcr.microsoft.com/mssql/server:2022-latest`) e assumi a porta padrão publicada `1433:1433`.
**Não tive acesso para inspecionar o container real** (`docker port layoutparser-identity-sql` ou
equivalente) nesta sessão. Se a porta publicada for outra, ou se o `Database`/`UserId` também
precisarem mudar, ajustar antes do próximo deploy — a API degrada graciosamente (loga Warning, não
derruba o startup) se a conexão falhar, mas os endpoints fiscais ficarão fora do ar até corrigido.

## Testes

- Novo: `tests/LayoutParserApi.Tests/Database/FiscalStoresUseIdentityDatabaseTests.cs` — confirma
  via reflection (sem SQL Server disponível no ambiente de teste) que os 3 stores constroem a
  connection string a partir de `IdentityDatabase:*`, nunca `Database:*`.
- Atualizado: `FiscalSchemaInitializerOrderTests.cs` (comentários refletindo o novo banco).
- `dotnet build`: limpo (0 erros). `dotnet test`: **680/680 passando**, sem regressão.

## Push

Push feito por mim (`@lp-backend-dev`/Dex), **autorizado explicitamente pelo dono** nesta tarefa —
exceção pontual à regra de `git push`/`gh pr create` exclusivos de `@lp-devops`
(`.claude/rules/agent-authority.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)