### PR TITLE
fix(security): corrige crash de boot no CanaryCredentialDetectionMiddleware + configura M2M Entra

### DIFF
--- a/Services/Security/CanaryCredentialDetectionMiddleware.cs
+++ b/Services/Security/CanaryCredentialDetectionMiddleware.cs
@@ -31,21 +31,24 @@ namespace LayoutParserApi.Services.Security
     public sealed class CanaryCredentialDetectionMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly ICanaryAlertService _canaryAlert;
 
-        public CanaryCredentialDetectionMiddleware(RequestDelegate next, ICanaryAlertService canaryAlert)
+        public CanaryCredentialDetectionMiddleware(RequestDelegate next)
         {
             _next = next;
-            _canaryAlert = canaryAlert;
         }
 
-        public async Task InvokeAsync(HttpContext context)
+        // ICanaryAlertService é Scoped — middleware convencional é construído uma única vez no
+        // boot, resolvendo do provider raiz (Singleton). Injeção por parâmetro de InvokeAsync
+        // resolve corretamente por request, a partir do RequestServices (scope da requisição).
+        // Sem isso, o app falha ao subir (ValidateScopes) ou, pior, silenciosamente reusa a mesma
+        // instância entre requisições quando essa validação está desligada (ex.: Production).
+        public async Task InvokeAsync(HttpContext context, ICanaryAlertService canaryAlert)
         {
             var recebido = context.Request.Headers[CanaryConstants.LegacyCredentialHeader].ToString();
 
             if (!string.IsNullOrEmpty(recebido) && ValorConfere(recebido, CanaryConstants.LegacyCredentialValue))
             {
-                _canaryAlert.Raise(CanaryConstants.CredentialCanaryType, context);
+                canaryAlert.Raise(CanaryConstants.CredentialCanaryType, context);
             }
 
             // Sempre segue — nunca autentica, nunca bloqueia por conta própria. Ver remarks acima.

--- a/appsettings.json
+++ b/appsettings.json
@@ -20,9 +20,9 @@
   },
   "Authentication": {
     "ServiceClient": {
-      "_comment": "ADR M2M (docs/architecture/adr-autenticacao-m2m-e2e-cypress-2026-09-03.md). Authority/Audience são metadados públicos de config OIDC, não segredo — mas ficam vazios até o App Registration 'de serviço' ser criado no tenant Entra da NDD (dependência externa). Enquanto vazio, o esquema JWT Bearer fica desabilitado (degrade gracioso).",
-      "Authority": "",
-      "Audience": ""
+      "_comment": "ADR M2M (docs/architecture/adr-autenticacao-m2m-e2e-cypress-2026-09-03.md). Authority/Audience são metadados públicos de config OIDC, não segredo. App Registration 'de serviço' provisionado em 2026-09-06 no mesmo tenant Entra usado pelo BFF (LayoutParserReact) — API=LayoutParserApi (resource, App Role Service.E2E), client=LayoutParserE2EClient (consumidor M2M, client_secret nunca chega aqui, fica só do lado do Cypress/CI).",
+      "Authority": "https://login.microsoftonline.com/8de72b5f-31a7-44aa-831e-d60750ab55d7/v2.0",
+      "Audience": "api://f76c2598-4759-48a9-8145-8a967ec7ac96"
     }
   },
   "Cors": {

--- a/tests/LayoutParserApi.Tests/Security/CanaryHoneypotTests.cs
+++ b/tests/LayoutParserApi.Tests/Security/CanaryHoneypotTests.cs
@@ -96,13 +96,12 @@ namespace LayoutParserApi.Tests.Security
             var canaryAlert = new CanaryAlertService(logger);
             var proximoChamado = false;
             var middleware = new CanaryCredentialDetectionMiddleware(
-                next: _ => { proximoChamado = true; return Task.CompletedTask; },
-                canaryAlert: canaryAlert);
+                next: _ => { proximoChamado = true; return Task.CompletedTask; });
 
             var context = new DefaultHttpContext();
             context.Request.Headers[CanaryConstants.LegacyCredentialHeader] = CanaryConstants.LegacyCredentialValue;
 
-            await middleware.InvokeAsync(context);
+            await middleware.InvokeAsync(context, canaryAlert);
 
             Assert.True(proximoChamado); // pipeline sempre segue — nunca bloqueia por conta própria
             Assert.Single(logger.Messages);
@@ -117,13 +116,12 @@ namespace LayoutParserApi.Tests.Security
             var logger = new CapturingLogger<CanaryAlertService>();
             var canaryAlert = new CanaryAlertService(logger);
             var middleware = new CanaryCredentialDetectionMiddleware(
-                next: _ => Task.CompletedTask,
-                canaryAlert: canaryAlert);
+                next: _ => Task.CompletedTask);
 
             var context = new DefaultHttpContext();
             context.Request.Headers[CanaryConstants.LegacyCredentialHeader] = "qualquer-outro-valor-invalido";
 
-            await middleware.InvokeAsync(context);
+            await middleware.InvokeAsync(context, canaryAlert);
 
             Assert.Empty(logger.Messages);
         }
@@ -134,15 +132,14 @@ namespace LayoutParserApi.Tests.Security
             var logger = new CapturingLogger<CanaryAlertService>();
             var canaryAlert = new CanaryAlertService(logger);
             var middleware = new CanaryCredentialDetectionMiddleware(
-                next: _ => Task.CompletedTask,
-                canaryAlert: canaryAlert);
+                next: _ => Task.CompletedTask);
 
             // Requisição comum: sem X-Service-Credential, com um Authorization Bearer normal
             // (esquema ServiceClient da Parte 1) — não deveria acionar o canary.
             var context = new DefaultHttpContext();
             context.Request.Headers["Authorization"] = "Bearer eyJhbGciOi...";
 
-            await middleware.InvokeAsync(context);
+            await middleware.InvokeAsync(context, canaryAlert);
 
             Assert.Empty(logger.Messages);
         }
@@ -153,13 +150,12 @@ namespace LayoutParserApi.Tests.Security
             var logger = new CapturingLogger<CanaryAlertService>();
             var canaryAlert = new CanaryAlertService(logger);
             var middleware = new CanaryCredentialDetectionMiddleware(
-                next: _ => Task.CompletedTask,
-                canaryAlert: canaryAlert);
+                next: _ => Task.CompletedTask);
 
             var context = new DefaultHttpContext();
             context.Request.Headers[CanaryConstants.LegacyCredentialHeader] = string.Empty;
 
-            await middleware.InvokeAsync(context);
+            await middleware.InvokeAsync(context, canaryAlert);
 
             Assert.Empty(logger.Messages);
         }


### PR DESCRIPTION
## Problema

`CanaryCredentialDetectionMiddleware` (PR #308) injetava `ICanaryAlertService` (Scoped) via
construtor. Middleware convencional é construído uma única vez no boot, resolvendo do
provider raiz — isso é sempre inválido para serviço `Scoped` e derruba a aplicação inteira
na inicialização (`InvalidOperationException: Cannot resolve scoped service ... from root
provider`), reproduzido tanto em `Development` quanto em `Production`.

**Evidência:** todo deploy de dev desde o merge da PR #308 (2026-09-05 11:32) falhou no smoke
test (`/health/ready` sem resposta após restart). O que vinha sendo investigado como
instabilidade do SQL Server externo (`.51`, ver `docs/architecture/investigacao-instabilidade-sql-deploy-2026-09-05.md`)
era, na verdade, este crash de boot.

## Fix

Move `ICanaryAlertService` do construtor para parâmetro de `InvokeAsync` (injeção por
método, resolvida por request a partir do `RequestServices`). Testes unitários ajustados —
instanciavam o middleware manualmente sem passar pelo container DI real, por isso nunca
pegaram o bug.

Validado localmente: app sobe (`Now listening...`, sem exceção fatal) em `Development` e
`Production`; `dotnet build` limpo; `dotnet test --filter Canary` 8/8 verde.

## Configuração adicional (issues #218/#221)

Também configura `Authentication:ServiceClient:Authority`/`Audience` (Parte 1 do ADR M2M)
com os valores reais do App Registration provisionado no tenant Entra compartilhado com o
BFF (LayoutParserReact). Não são segredo — metadados públicos OIDC; o `client_secret` fica
só do lado do consumidor (Cypress/CI), nunca passa pela API.

- Authority: tenant Entra do App Registration `LayoutParserApi`
- Audience: `api://f76c2598-4759-48a9-8145-8a967ec7ac96`
- App Role `Service.E2E` concedida ao client `LayoutParserE2EClient` (admin consent confirmado)

Fecha o lado de código das #218/#221 — falta só o Cypress/CI usar o client credentials real
quando a suíte E2E for automatizada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)