### PR TITLE
feat(reconstrucao-reversa): spike Fase A+B da issue #151 (metadado Re…

### DIFF
--- a/ai/XslSynth.Contracts/Core/StructuralResolution/BranchReversibilityResolver.cs
+++ b/ai/XslSynth.Contracts/Core/StructuralResolution/BranchReversibilityResolver.cs
@@ -1,0 +1,67 @@
+using XslSynth.Prompting;
+
+namespace XslSynth.Core.StructuralResolution;
+
+/// <summary>Resultado da checagem de reversibilidade de um <c>StructuredBranch</c> — mesmo
+/// espírito de <see cref="OccurrenceResolution"/>: valor + se a condição está confirmada.</summary>
+public readonly record struct BranchReversibility(bool Reversible, string? Reason);
+
+/// <summary>
+/// Fase B da issue #151 (spike aprovado pelo dono em 2026-09-07): costura o metadado curado da
+/// Fase A (<see cref="FunctionCatalog"/>/<see cref="FunctionReversibilityCatalog"/>) para o nível
+/// de <see cref="StructuredBranch"/>, que é a granularidade usada por
+/// <see cref="FieldToXmlMappingComposer"/> ao compor um <see cref="MappingCandidate"/>.
+///
+/// Critério (design §3, tabela por <c>MappingKind</c>): um branch sem nenhuma função referenciada
+/// é estruturalmente reversível (cópia posicional, mesma categoria de <c>MappingKind.Direct</c>).
+/// Um branch com funções só é reversível se TODAS as funções referenciadas forem, individualmente,
+/// <c>Reversible == true</c> no catálogo curado — uma única função com perda (ex.:
+/// <c>CalculateVerifierDigit</c>) torna o branch inteiro não-reversível, mesmo que as demais sejam
+/// bijetoras (a composição de bijetora + não-bijetora não é bijetora).
+/// </summary>
+public static class BranchReversibilityResolver
+{
+    /// <summary>Resolve a reversibilidade de um branch. Puro — sem I/O, sem exceção; degrada para
+    /// <c>false</c> com motivo explícito quando o catálogo está indisponível ou a função é
+    /// desconhecida (mesmo padrão "sinalize incerteza" do resto do motor de #139/#140).</summary>
+    public static BranchReversibility Resolve(StructuredBranch branch, FunctionCatalog? catalog)
+    {
+        if (branch.Functions.Count == 0)
+        {
+            // Sem função — cópia/posicional direta (mesma categoria de MappingKind.Direct no §3),
+            // sempre reversível estruturalmente.
+            return new BranchReversibility(true, null);
+        }
+
+        if (catalog is null)
+        {
+            return new BranchReversibility(false,
+                "FunctionCatalog indisponível — não foi possível confirmar a reversibilidade das funções.");
+        }
+
+        var unknown = branch.Functions
+            .Where(f => catalog.Lookup(f) is null)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (unknown.Count > 0)
+        {
+            return new BranchReversibility(false,
+                $"Função(ões) não catalogada(s): {string.Join(", ", unknown)}.");
+        }
+
+        var irreversible = branch.Functions
+            .Select(f => catalog.Lookup(f)!)
+            .Where(e => !e.Reversible)
+            .ToList();
+
+        if (irreversible.Count > 0)
+        {
+            var reasons = irreversible
+                .Select(e => e.IrreversibilityReason ?? $"{e.Name}: não reversível")
+                .Distinct(StringComparer.Ordinal);
+            return new BranchReversibility(false, string.Join(" | ", reasons));
+        }
+
+        return new BranchReversibility(true, null);
+    }
+}

--- a/ai/XslSynth.Contracts/Core/StructuralResolution/FieldToXmlMappingComposer.cs
+++ b/ai/XslSynth.Contracts/Core/StructuralResolution/FieldToXmlMappingComposer.cs
@@ -30,12 +30,27 @@ public sealed record MappingCandidate(
     bool SourcesHavePositionalGroupRepetition,
     /// <summary>Catálogo de funções conhecidas (Camada 2, <c>FunctionCatalog</c>) — <c>null</c>
     /// quando indisponível no host (degrada para best-effort, não lança exceção — dotnet-standards.md).</summary>
-    IReadOnlySet<string>? KnownFunctions = null);
+    IReadOnlySet<string>? KnownFunctions = null,
+    /// <summary>Fase B da issue #151. Default <see cref="Direction.Forward"/> preserva 100% o
+    /// comportamento de #140/#141 — <see cref="Direction.Reverse"/> ativa a condição extra de
+    /// reversibilidade (ver <see cref="Reversibility"/>).</summary>
+    Direction Direction = Direction.Forward,
+    /// <summary>Fase A/B da issue #151 — resultado de <see cref="BranchReversibilityResolver.Resolve"/>
+    /// para o(s) branch(es) de origem deste candidato. Só é considerado quando
+    /// <see cref="Direction"/> == <see cref="Direction.Reverse"/>; <c>null</c> em <see cref="Direction.Forward"/>
+    /// não afeta o resultado (condição 6 não se aplica nesse sentido).</summary>
+    BranchReversibility? Reversibility = null);
 
 /// <summary>
 /// Item 5 da divisão de trabalho da issue #140 (design §5, §8): junta os itens 1-4 (catálogo XML,
 /// classificador de <c>mappingKind</c>, resolução de ocorrência) e aplica o critério objetivo
 /// <c>authoritative</c>/<c>best-effort</c>.
+///
+/// Fase B da issue #151 (spike aprovado 2026-09-07): generalizado para aceitar
+/// <see cref="Direction"/> no candidato — reaproveita as mesmas 5 condições estruturais para os
+/// dois sentidos e adiciona uma 6ª condição (reversibilidade, Fase A) só relevante em
+/// <see cref="Direction.Reverse"/>. Não conhece qual lado é "o conhecido" na prática — quem monta
+/// o <see cref="MappingCandidate"/> já decide isso (mesmo desenho de responsabilidade do Forward).
 /// </summary>
 public sealed class FieldToXmlMappingComposer
 {
@@ -119,7 +134,18 @@ public sealed class FieldToXmlMappingComposer
             ? "FunctionCatalog indisponível — não foi possível confirmar as funções referenciadas."
             : "Função referenciada não catalogada — destino pode divergir de forma não estrutural.");
 
-        var authoritative = condition1 && condition2 && condition3 && condition4 && condition5;
+        // Condição 6 (Fase B, issue #151) — só se aplica no sentido Reverse: a reconstrução do
+        // TXT a partir do XML só é auditável (authoritative) se a função/branch que ligou os dois
+        // lados for, de fato, bijetora (Fase A, FunctionReversibilityCatalog). No sentido Forward
+        // a condição é trivialmente satisfeita — preserva 100% o comportamento de #140/#141.
+        var condition6 = candidate.Direction == Direction.Forward || (candidate.Reversibility?.Reversible ?? false);
+        if (candidate.Direction == Direction.Reverse && !condition6)
+        {
+            limitations.Add(candidate.Reversibility?.Reason
+                ?? "Direção reversa exige função/branch reversível — reversibilidade não confirmada (Fase A/B da issue #151).");
+        }
+
+        var authoritative = condition1 && condition2 && condition3 && condition4 && condition5 && condition6;
 
         return new FieldToXmlMapping(
             candidate.MappingId,
@@ -127,6 +153,7 @@ public sealed class FieldToXmlMappingComposer
             targets,
             candidate.Kind,
             authoritative ? Confidence.Authoritative : Confidence.BestEffort,
-            authoritative ? null : limitations.Distinct().ToList());
+            authoritative ? null : limitations.Distinct().ToList(),
+            candidate.Direction);
     }
 }

--- a/ai/XslSynth.Contracts/Model/StructuralResolutionModels.cs
+++ b/ai/XslSynth.Contracts/Model/StructuralResolutionModels.cs
@@ -32,10 +32,30 @@ public enum XmlNodeKind
 /// <summary>Confiança da resolução — critério objetivo e binário (design §5), nunca subjetivo.</summary>
 public enum Confidence
 {
-    /// <summary>Todas as 5 condições objetivas do design §5 são verdadeiras.</summary>
+    /// <summary>Todas as condições objetivas do design §5 (+ condição de reversibilidade em
+    /// <see cref="Direction.Reverse"/>, Fase B da issue #151) são verdadeiras.</summary>
     Authoritative,
     /// <summary>Qualquer outro caso — inclusive fallback heurístico ou divergência não eliminável.</summary>
     BestEffort
+}
+
+/// <summary>
+/// Fase B da issue #151 (spike aprovado pelo dono em 2026-09-07, design em
+/// docs/architecture/design-reconstrucao-reversa-xml-txt-2026-09-03.md §4): sentido da resolução
+/// estrutural. <see cref="Forward"/> é o caminho já em produção (#140/#141): TXT posicional →
+/// XML. <see cref="Reverse"/> é o caso de uso novo da issue #151 (XML → TXT, "reconstrução
+/// reversa best-effort") — reaproveita o MESMO <see cref="FieldToXmlMappingComposer"/> e as
+/// mesmas 5 condições de <c>authoritative</c>/<c>best-effort</c>, só troca qual lado é o
+/// "conhecido" e adiciona a condição extra de reversibilidade da função/branch (Fase A).
+/// Deliberadamente NÃO inclui um <c>OccurrenceResolver</c> simétrico completo (XML-ocorrência →
+/// linha física do TXT) — isso é escopo da Fase C, fora deste spike.
+/// </summary>
+public enum Direction
+{
+    /// <summary>TXT posicional (origem) → XML (destino) — caminho existente de #140/#141.</summary>
+    Forward,
+    /// <summary>XML (conhecido) → TXT posicional (a reconstruir) — caso de uso da issue #151.</summary>
+    Reverse
 }
 
 /// <summary>Referência a um campo de origem no layout posicional (TXT/MQSeries/IDOC).</summary>
@@ -65,4 +85,7 @@ public sealed record FieldToXmlMapping(
     MappingKind Kind,
     Confidence Confidence,
     /// <summary>Motivo(s) quando <see cref="Confidence.BestEffort"/> — nunca null nesse caso (design §7).</summary>
-    IReadOnlyList<string>? Limitations = null);
+    IReadOnlyList<string>? Limitations = null,
+    /// <summary>Fase B da issue #151 — sentido em que este mapeamento foi composto. Default
+    /// <see cref="Model.Direction.Forward"/> preserva 100% o comportamento de #140/#141.</summary>
+    Direction Direction = Direction.Forward);

--- a/ai/XslSynth.Contracts/Prompting/FunctionCatalog.cs
+++ b/ai/XslSynth.Contracts/Prompting/FunctionCatalog.cs
@@ -19,7 +19,19 @@ public sealed record FunctionCatalogEntry(
     /// <summary>Se o nome exibido é o nome REAL usado na DSL (<c>F.Nome</c>) ou só um palpite
     /// derivado do nome da classe (<c>ConcatFunction</c> → "Concat"). Nunca confie cegamente.</summary>
     bool NameIsReliable,
-    string? ObfuscationNote);
+    string? ObfuscationNote,
+    /// <summary>
+    /// Fase A da issue #151 (design §4.1): se a função é bijetora — dado o resultado, dá pra
+    /// recuperar exatamente a(s) entrada(s) original(is) sem informação adicional. NÃO é inferido
+    /// por reflection (a ofuscação documentada acima impede confiar em análise automática do corpo);
+    /// vem de curadoria manual em <see cref="FunctionReversibilityCatalog"/>, chaveada pelo mesmo
+    /// nome-palpite de <see cref="Name"/>. Default conservador quando não curada: <c>false</c>
+    /// (mesmo espírito de "sinalize incerteza, não finja certeza" de <see cref="NameIsReliable"/>).
+    /// </summary>
+    bool Reversible = false,
+    /// <summary>Motivo textual quando <see cref="Reversible"/> é <c>false</c> — nunca null nesse
+    /// caso (mesmo padrão de <c>FieldToXmlMapping.Limitations</c>).</summary>
+    string? IrreversibilityReason = "Função sem curadoria manual de reversibilidade (Fase A da issue #151).");
 
 /// <summary>
 /// Camada 2 do desenho de contexto/prompt: catálogo indexável (nome→assinatura) das funções
@@ -77,8 +89,17 @@ public sealed class FunctionCatalog
 
         try
         {
+            // Fase A da issue #151 (spike 2026-09-07): a DLL de funções depende de
+            // SysMiddle.Base.dll (onde mora FunctionMember, base checada em InheritsFrom) e de
+            // outras DLLs Sysmiddle vizinhas — sem elas no resolver, GetTypes() falha para TODOS
+            // os tipos (ReflectionTypeLoadException com Types só null) e o catálogo sai vazio
+            // silenciosamente. Inclui as DLLs do mesmo diretório do alvo (mesmo pacote vendorizado)
+            // além do runtime — ainda reflection-only, não executa nenhum código.
             var runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
-            var resolver = new PathAssemblyResolver(runtimeAssemblies.Append(dllPath));
+            var siblingAssemblies = Directory.Exists(Path.GetDirectoryName(dllPath))
+                ? Directory.GetFiles(Path.GetDirectoryName(dllPath)!, "*.dll")
+                : Array.Empty<string>();
+            var resolver = new PathAssemblyResolver(runtimeAssemblies.Concat(siblingAssemblies).Append(dllPath).Distinct());
             using var mlc = new MetadataLoadContext(resolver);
 
             var asm = mlc.LoadFromAssemblyPath(dllPath);
@@ -99,6 +120,8 @@ public sealed class FunctionCatalog
                     ? $"{execute.ReturnType.Name} Execute(object[] pars)"
                     : "object Execute(object[] pars)"; // herdado, não redeclarado neste type
 
+                var (reversible, irreversibilityReason) = FunctionReversibilityCatalog.Lookup(className);
+
                 var entry = new FunctionCatalogEntry(
                     Name: guessedName,
                     FullTypeName: type.FullName ?? className,
@@ -107,7 +130,9 @@ public sealed class FunctionCatalog
                     Signature: signature,
                     NameIsReliable: false, // ver nota de ofuscação na doc da classe
                     ObfuscationNote: "Name/OwnerName reais só existem em runtime (cctor ofuscado); " +
-                                      "nome aqui é PALPITE a partir do nome da classe.");
+                                      "nome aqui é PALPITE a partir do nome da classe.",
+                    Reversible: reversible,
+                    IrreversibilityReason: irreversibilityReason);
 
                 byGuessedName[guessedName] = entry;
             }

--- a/ai/XslSynth.Contracts/Prompting/FunctionReversibilityCatalog.cs
+++ b/ai/XslSynth.Contracts/Prompting/FunctionReversibilityCatalog.cs
@@ -1,0 +1,231 @@
+namespace XslSynth.Prompting;
+
+/// <summary>
+/// Fase A da issue #151 (spike aprovado pelo dono em 2026-09-07, design em
+/// docs/architecture/design-reconstrucao-reversa-xml-txt-2026-09-03.md §4.1): curadoria MANUAL
+/// de reversibilidade por função <c>F.*</c>, chaveada pelo nome de CLASSE real (ex.:
+/// <c>"ConcatFunction"</c>) — não pelo nome-palpite exposto em <c>FunctionCatalogEntry.Name</c>,
+/// que pode divergir do nome real usado na DSL (ver limitação de ofuscação em
+/// <see cref="FunctionCatalog"/>). O nome de classe É extraível com segurança via reflection
+/// metadata, então é a chave estável disponível sem executar código.
+///
+/// Por que curadoria manual e não inferência automática: a DLL Sysmiddle real usa control-flow
+/// flattening + strings criptografadas em runtime — não dá pra confirmar por reflection se uma
+/// função é bijetora (ex.: <c>CalculateVerifierDigitFunction</c> perde o valor original) ou
+/// tem efeito colateral (I/O, banco, e-mail) sem ler o nome da classe e julgar a semântica
+/// provável. Cada entrada abaixo foi revisada individualmente contra a lista real de 167 classes
+/// <c>*Function</c> extraídas de <c>tools/LowCodeRunner/Functions/SysMiddle.ConnectUs.Functions.dll</c>
+/// (mesma DLL usada pelo runner LowCode em produção, versionada no repo).
+///
+/// Critério de bijetividade usado (design §3): "dado o resultado, dá pra recuperar exatamente a
+/// entrada original sem informação adicional?". Funções com efeito colateral (I/O, banco, e-mail,
+/// ambiente de execução) são marcadas <c>false</c> por natureza — não são transformação pura de
+/// campo, então "reversão" nem se aplica; sinalizadas como tal no motivo, não confundidas com
+/// perda de dado real.
+/// </summary>
+public static class FunctionReversibilityCatalog
+{
+    /// <summary>Motivo padrão para qualquer classe *Function real que exista na DLL mas não tenha
+    /// entrada curada aqui (não deveria acontecer para as 167 conhecidas nesta revisão — sinaliza
+    /// função nova/desconhecida introduzida em versão futura da DLL).</summary>
+    public const string NaoCuradaReason = "Função sem curadoria manual de reversibilidade (Fase A da issue #151).";
+
+    private static readonly Dictionary<string, (bool Reversible, string? Reason)> ByClassName =
+        new(StringComparer.Ordinal)
+        {
+            // ---- Reversível = true: bijetoras / sem perda de informação -----------------------
+            ["ConvertToCharFunction"] = (true, "Extrai 1 caractere de string — bijeção trivial sem perda."),
+            ["TrueFunction"] = (true, "Função constante, sem origem de dado — não há perda a reverter (fora do escopo de reversão de campo)."),
+            ["FalseFunction"] = (true, "Função constante, sem origem de dado — não há perda a reverter (fora do escopo de reversão de campo)."),
+            ["PadLeftFunction"] = (true, "Padding com caractere/largura fixos conhecidos do layout — removível de forma determinística (mesmo exemplo citado no design §3)."),
+            ["PadRightFunction"] = (true, "Padding com caractere/largura fixos conhecidos do layout — removível de forma determinística (mesmo exemplo citado no design §3)."),
+            ["TrimFunction"] = (true, "Remove espaços de padding — recuperável se a largura fixa original do campo for conhecida pelo layout (mesma ressalva de PadLeft/PadRight)."),
+            ["TrimStartFunction"] = (true, "Remove espaços de padding à esquerda — recuperável se a largura fixa original do campo for conhecida pelo layout."),
+            ["TrimEndFunction"] = (true, "Remove espaços de padding à direita — recuperável se a largura fixa original do campo for conhecida pelo layout."),
+            ["SplitValueByPositionFunction"] = (true, "Corte posicional por índice/largura conhecidos — mesma lógica estrutural do parsing por posição fixa (OccurrenceResolver), desde que a largura total seja conhecida."),
+            ["GetSplittedValueByPositionFunction"] = (true, "Corte posicional por índice/largura conhecidos — mesma lógica estrutural do parsing por posição fixa, desde que a largura total seja conhecida."),
+            ["GetBrazilianStateCodeByInitialsFunction"] = (true, "Mapeamento tabular bijetor (UF ↔ código IBGE) — requer tabela de lookup reversa, mas sem perda de informação."),
+            ["GetBrazilianStateCodeByNameFunction"] = (true, "Mapeamento tabular bijetor (nome do estado ↔ código IBGE) — requer tabela de lookup reversa, mas sem perda de informação."),
+            ["GetBrazilianCityCodeFunction"] = (true, "Mapeamento tabular bijetor (município+UF ↔ código IBGE) — requer tabela de lookup reversa, mas sem perda de informação."),
+            ["ConvertToBase64StringFunction"] = (true, "Codificação Base64 é bijetora e sem perda."),
+            ["ConvertToBase64BytesFunction"] = (true, "Codificação Base64 é bijetora e sem perda."),
+            ["ConvertFromBase64StringFunction"] = (true, "Decodificação Base64 é bijetora e sem perda (inversa de ConvertToBase64String)."),
+            ["ConvertFromBase64BytesFunction"] = (true, "Decodificação Base64 é bijetora e sem perda (inversa de ConvertToBase64Bytes)."),
+            ["UriEscapeFunction"] = (true, "Percent-encoding de URI é bijetor — round-trip determinístico com UriUnescape."),
+            ["UriUnescapeFunction"] = (true, "Percent-encoding de URI é bijetor — round-trip determinístico com UriEscape."),
+            ["CDataStringFunction"] = (true, "Envolve o valor em CDATA sem alterar o conteúdo interno."),
+            ["DecompressBytesFunction"] = (true, "Compressão sem perda (lossless) é bijetora, desde que o mesmo algoritmo seja usado no sentido inverso."),
+            ["GetBytesFunction"] = (true, "Conversão string→bytes por encoding conhecido (ex.: UTF-8) é bijetora para texto bem-formado (round-trip com GetStringFromBytes)."),
+            ["GetStringFromBytesFunction"] = (true, "Conversão bytes→string por encoding conhecido é bijetora para texto bem-formado (round-trip com GetBytes)."),
+
+            // ---- Reversível = false: perda de informação, ambiguidade ou efeito colateral -----
+            ["CalculateVerifierDigitFunction"] = (false, "Dígito verificador — função com perda clássica, não recupera o valor original (citada no critério de aceite da issue #151)."),
+            ["ConcatFunction"] = (false, "Concatenação perde a fronteira entre segmentos sem delimitador/tamanho conhecido (N:1 ambíguo — ver MappingKind.Concatenated)."),
+            ["CreateNFeAcessKeyFunction"] = (false, "Chave de acesso combina múltiplos campos + dígito verificador — não reversível campo a campo sem heurística adicional."),
+            ["CreateCTeAcessKeyFunction"] = (false, "Chave de acesso combina múltiplos campos + dígito verificador — não reversível campo a campo sem heurística adicional."),
+            ["ConvertToBooleanFunction"] = (false, "Conversão de tipo/formato colapsa múltiplas representações de entrada ('Sim'/'1'/'true') em 2 saídas — não bijetora."),
+            ["ConvertToDateFormatFunction"] = (false, "Conversão de formato de data pode perder século/timezone/formato original sem garantia de round-trip exato."),
+            ["ConvertToDateTimeFunction"] = (false, "Conversão de tipo perde a formatação/string original (não garante round-trip byte-a-byte)."),
+            ["ConvertToDateTimeSpecificFormatFunction"] = (false, "Conversão de formato de data pode perder século/timezone/formato original sem garantia de round-trip exato."),
+            ["ConvertDateTimeToTimeZoneFunction"] = (false, "Conversão de fuso horário pode perder o offset original sem metadado adicional."),
+            ["ConvertDateTimeToUtcFunction"] = (false, "Conversão para UTC perde o fuso horário original."),
+            ["ConvertToDecimalFunction"] = (false, "Conversão de tipo perde a formatação original (zeros à esquerda/à direita, separador) sem garantia de round-trip exato."),
+            ["ConvertToInt16Function"] = (false, "Conversão de tipo perde zeros à esquerda e formatação original da string de origem."),
+            ["ConvertToInt32Function"] = (false, "Conversão de tipo perde zeros à esquerda e formatação original da string de origem."),
+            ["ConvertToInt64Function"] = (false, "Conversão de tipo perde zeros à esquerda e formatação original da string de origem."),
+            ["ConvertToStringFunction"] = (false, "Conversão de tipo para string pode não preservar a formatação original do valor de origem (casas decimais, zeros)."),
+            ["ToLowerFunction"] = (false, "Perde o caso (maiúsculas/minúsculas) original das letras."),
+            ["ToUpperFunction"] = (false, "Perde o caso (maiúsculas/minúsculas) original das letras."),
+            ["RemoveNonAlphanumericCharactersFunction"] = (false, "Remove caracteres do valor original — não recuperável sem saber exatamente quais/quantos foram removidos."),
+            ["RemoveSpecialCharactersFunction"] = (false, "Remove caracteres do valor original — não recuperável sem saber exatamente quais/quantos foram removidos."),
+            ["RemoveZerosLeftFunction"] = (false, "Remove zeros à esquerda — não recuperável sem saber a largura fixa original do campo."),
+            ["SubstringFunction"] = (false, "Extrai parte da string e descarta o restante — não recuperável isoladamente."),
+            ["SplitFunction"] = (false, "Divide por delimitador — delimitador pode não ser único/preservado na saída, ambíguo de reverter."),
+            ["JoinFunction"] = (false, "Concatenação com delimitador — mesmo problema de ambiguidade N:1 de ConcatString se o delimitador aparecer dentro de um segmento."),
+            ["RegexFunction"] = (false, "Extração/transformação via regex geralmente descarta parte do texto original — não bijetora em geral."),
+            ["RegexUnescapeFunction"] = (false, "Unescape de regex pode não ser estritamente bijetor sem confirmar o padrão de escape usado."),
+            ["AdjustJsonEscapeCharactersFunction"] = (false, "Escaping ad-hoc — não confirmado como estritamente bijetor sem revisão do algoritmo real."),
+            ["XMLFormatFunction"] = (false, "Formatação para XML pode normalizar espaços/entidades, alterando a representação textual original."),
+            ["DecryptRijndaelFunction"] = (false, "Operação criptográfica — reversão exige a mesma chave/IV usada na cifragem, fora do escopo de metadado estrutural."),
+            ["GetHashCodeFunction"] = (false, "Hash é função de mão única por definição — nunca reversível."),
+            ["GetMD5HashCodeFunction"] = (false, "Hash é função de mão única por definição — nunca reversível."),
+            ["GetMD5HashCodeByFileFunction"] = (false, "Hash é função de mão única por definição — nunca reversível."),
+            ["GetSignatureFunction"] = (false, "Assinatura digital depende de chave privada — não reversível sem ela."),
+            ["NewGuidFunction"] = (false, "Gera valor aleatório novo — não deriva de nenhuma origem, não há o que reverter."),
+            ["StringFormatFunction"] = (false, "Formatação pode adicionar/remover caracteres (separadores, zeros) sem preservar o formato de entrada original."),
+            ["FormaterNumberFunction"] = (false, "Formatação numérica pode adicionar/remover caracteres (separadores, zeros) sem preservar o formato original."),
+            ["DecimalFormaterFunction"] = (false, "Formatação decimal pode adicionar/remover caracteres (separadores, zeros) sem preservar o formato original."),
+            ["DivisionFunction"] = (false, "Operação aritmética com possível perda de precisão/arredondamento — não recupera os operandos originais (N:1)."),
+            ["MultFunction"] = (false, "Operação aritmética — não recupera os operandos originais (N:1)."),
+            ["SubtractFunction"] = (false, "Operação aritmética — não recupera os operandos originais (N:1)."),
+            ["SumFunction"] = (false, "Operação aritmética — não recupera os operandos originais (N:1)."),
+            ["RoundFunction"] = (false, "Arredondamento descarta as casas decimais originais — perda de precisão."),
+            ["GetDateFunction"] = (false, "Extrai um componente da data — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetDayFunction"] = (false, "Extrai um componente da data — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetHourFunction"] = (false, "Extrai um componente da hora — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetMinuteFunction"] = (false, "Extrai um componente da hora — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetMonthFunction"] = (false, "Extrai um componente da data — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetSecondFunction"] = (false, "Extrai um componente da hora — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetYearFunction"] = (false, "Extrai um componente da data — descarta os demais componentes (N:1, não bijetor)."),
+            ["GetDateFormatFunction"] = (false, "Extrai/reformata data — não garante round-trip exato do valor original."),
+            ["GetDateTimeFunction"] = (false, "Extrai/reformata data e hora — não garante round-trip exato do valor original."),
+            ["GetDateTimeFormatFunction"] = (false, "Extrai/reformata data e hora — não garante round-trip exato do valor original."),
+            ["GetTimeZoneDifferenceFunction"] = (false, "Deriva uma diferença de fuso — não recupera os dois valores de origem (N:1)."),
+            ["GetUnixTimeStampFunction"] = (false, "Conversão para timestamp Unix pode perder timezone/formato original da string de data."),
+            ["IsNullOrEmptyFunction"] = (false, "Retorna booleano de teste — colapsa infinitos valores de entrada em 2 saídas, não bijetor."),
+            ["IsNullOrWhiteSpaceFunction"] = (false, "Retorna booleano de teste — colapsa infinitos valores de entrada em 2 saídas, não bijetor."),
+            ["StartsWithFunction"] = (false, "Retorna booleano de teste — colapsa infinitos valores de entrada em 2 saídas, não bijetor."),
+            ["EndsWithFunction"] = (false, "Retorna booleano de teste — colapsa infinitos valores de entrada em 2 saídas, não bijetor."),
+            ["EqualsFunction"] = (false, "Retorna booleano de comparação — colapsa infinitos pares de entrada em 2 saídas, não bijetor."),
+            ["CoalesceFunction"] = (false, "Retorna o primeiro valor não-nulo entre alternativas — não é possível saber qual delas 'venceu' a partir só do resultado."),
+            ["LastIndexOfFunction"] = (false, "Retorna metadado derivado (índice), não o valor em si — não recupera a string original."),
+            ["GetLengthFunction"] = (false, "Retorna metadado derivado (tamanho), não o valor em si — não recupera a string original."),
+            ["ListContainsFunction"] = (false, "Retorna booleano de teste sobre uma coleção — não bijetor."),
+            ["DictionaryContainsKeyFunction"] = (false, "Retorna booleano de teste sobre uma coleção — não bijetor."),
+            ["DictionaryContainsValueFunction"] = (false, "Retorna booleano de teste sobre uma coleção — não bijetor."),
+            ["JObjectFindValuesFunction"] = (false, "Busca em JSON pode retornar múltiplos valores/perder estrutura — não garante round-trip."),
+            ["JObjectGetValueFunction"] = (false, "Extrai um valor de dentro de uma estrutura JSON maior — descarta o restante (N:1)."),
+            ["JObjectParseFunction"] = (false, "Parse de JSON pode reordenar chaves/normalizar formatação — não garante round-trip byte-a-byte."),
+            ["JObjectUpdateValueFunction"] = (false, "Atualiza um valor dentro de uma estrutura maior — resultado depende de estado externo (o objeto sendo atualizado)."),
+            ["JSONDeserializeDataTableFunction"] = (false, "Deserialização pode não preservar a formatação textual original do JSON."),
+            ["JSONNullFunction"] = (false, "Retorna constante JSON null — não deriva de um campo de origem."),
+            ["JSONSerializeFunction"] = (false, "Serialização JSON pode reordenar chaves/normalizar formatação — não garante round-trip byte-a-byte."),
+            ["NewLineFunction"] = (false, "Retorna constante — não deriva de um campo de origem."),
+            ["NewStringBuilderFunction"] = (false, "Cria estrutura nova — não deriva de um campo de origem existente."),
+            ["NewDictionaryFunction"] = (false, "Cria estrutura nova — não deriva de um campo de origem existente."),
+            ["NewListFunction"] = (false, "Cria estrutura nova — não deriva de um campo de origem existente."),
+            ["CreateFunction"] = (false, "Cria estrutura nova — não deriva de um campo de origem existente."),
+            ["CreateDataTableFunction"] = (false, "Cria estrutura nova — não deriva de um campo de origem existente."),
+            ["AddDateTimeValueFunction"] = (false, "Soma um intervalo a uma data — não determinística de reverter sem saber o operando somado (N:1)."),
+            ["AddDataTableColumnFunction"] = (false, "Efeito de estrutura de tabela em memória — não é uma transformação pura de campo."),
+            ["DataTableColumnLastValueFunction"] = (false, "Depende de estado acumulado em uma tabela em memória — não deriva de um único campo de origem."),
+            ["DictionaryAddUpdateFunction"] = (false, "Efeito sobre estrutura em memória (dicionário) — não é transformação pura de campo."),
+            ["DictionaryClearFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["DictionaryGetValueFunction"] = (false, "Extrai um valor de uma estrutura maior — descarta o restante (N:1)."),
+            ["DictionaryRemoveFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["ListAddFunction"] = (false, "Efeito sobre estrutura em memória (lista) — não é transformação pura de campo."),
+            ["ListClearFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["ListGetItemFunction"] = (false, "Extrai um item de uma coleção maior — descarta o restante (N:1)."),
+            ["ListIndexOfFunction"] = (false, "Retorna metadado derivado (índice) — não recupera o valor original."),
+            ["ListRemoveFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["ListRemoveAtFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["ListUpdateFunction"] = (false, "Efeito sobre estrutura em memória — não é transformação pura de campo."),
+            ["StringBuilderAppendFunction"] = (false, "Efeito acumulado sobre estrutura mutável — resultado depende de estado externo (o builder)."),
+            ["StringBuilderAppendFormatFunction"] = (false, "Efeito acumulado sobre estrutura mutável — resultado depende de estado externo (o builder)."),
+            ["StringBuilderAppendLineFunction"] = (false, "Efeito acumulado sobre estrutura mutável — resultado depende de estado externo (o builder)."),
+            ["StringBuilderClearFunction"] = (false, "Efeito sobre estrutura mutável — não é transformação pura de campo."),
+            ["StringBuilderInsertFunction"] = (false, "Efeito acumulado sobre estrutura mutável — resultado depende de estado externo (o builder)."),
+            ["StringBuilderLengthFunction"] = (false, "Retorna metadado derivado (tamanho) — não recupera o valor original."),
+            ["StringBuilderRemoveFunction"] = (false, "Efeito sobre estrutura mutável — não é transformação pura de campo."),
+            ["StringBuilderReplaceFunction"] = (false, "Substituição de texto perde a distinção entre valor original e substituído sem conhecer o padrão exato."),
+            ["LoadDataTableFromCSVFunction"] = (false, "Depende de arquivo externo — resultado não é derivável do campo de origem isoladamente."),
+            ["PostgreSQLBulkCopyFunction"] = (false, "Acesso a banco externo — efeito colateral, não transformação pura de campo."),
+            ["SQLServerBulkCopyFunction"] = (false, "Acesso a banco externo — efeito colateral, não transformação pura de campo."),
+            ["ExecuteCommandFunction"] = (false, "Executa comando externo — efeito colateral, não transformação pura de campo."),
+            ["ExecuteDictionarySelectFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["ExecuteInsertUpdateOrDeleteFunction"] = (false, "Efeito colateral em banco externo — não é transformação pura de campo."),
+            ["ExecuteListDictionarySelectFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["ExecuteMapperFunction"] = (false, "Delega a outro mapeador — reversão dependeria de reverter o mapeador delegado (fora de escopo desta curadoria)."),
+            ["ExecuteSelectFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["ExecuteSelectDataTableFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["ExecuteSelectReaderFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["GetValueFromDBFunction"] = (false, "Acessa banco externo — resultado depende de estado externo, não derivável do campo de origem isoladamente."),
+            ["GetDBInstanceFunction"] = (false, "Retorna referência de infraestrutura — não é transformação de campo."),
+            ["GetValueByXPathFunction"] = (false, "Extrai valor de um documento XML maior — depende do documento inteiro, não só do campo de origem (N:1)."),
+            ["ReadFileFunction"] = (false, "I/O de arquivo — não é transformação pura de campo."),
+            ["ReadFileBytesFunction"] = (false, "I/O de arquivo — não é transformação pura de campo."),
+            ["ReadFileLineFunction"] = (false, "I/O de arquivo — não é transformação pura de campo."),
+            ["WriteFileFunction"] = (false, "I/O de arquivo — efeito colateral, não transformação pura de campo."),
+            ["AppendFileFunction"] = (false, "I/O de arquivo — efeito colateral, não transformação pura de campo."),
+            ["CopyFileFunction"] = (false, "I/O de arquivo — efeito colateral, não transformação pura de campo."),
+            ["DeleteFileFunction"] = (false, "I/O de arquivo — efeito colateral, não transformação pura de campo."),
+            ["GetFilesFunction"] = (false, "I/O de arquivo — depende do estado do sistema de arquivos, não do campo de origem."),
+            ["GetFileNameFunction"] = (false, "Extrai parte de um caminho de arquivo — descarta o restante (N:1)."),
+            ["GetFileSizeFunction"] = (false, "Retorna metadado derivado (tamanho) — não recupera o conteúdo do arquivo."),
+            ["GetFileLinesNumberFunction"] = (false, "Retorna metadado derivado (contagem) — não recupera o conteúdo do arquivo."),
+            ["GetParentPathFunction"] = (false, "Extrai parte de um caminho — descarta o restante (N:1)."),
+            ["WebRequestFunction"] = (false, "Chamada de rede — não determinística/dependente de estado externo."),
+            ["WebRequestResponseBytesFunction"] = (false, "Chamada de rede — não determinística/dependente de estado externo."),
+            ["SendEmailFunction"] = (false, "Efeito colateral (envio de e-mail) — não produz um campo de dado a reverter."),
+            ["SendEmailByConfigurationFunction"] = (false, "Efeito colateral (envio de e-mail) — não produz um campo de dado a reverter."),
+            ["SetErrorMessageFunction"] = (false, "Efeito colateral (mensagem de erro) — não produz um campo de dado a reverter."),
+            ["LogFunction"] = (false, "Efeito colateral (log) — não produz um campo de dado a reverter."),
+            ["SleepFunction"] = (false, "Efeito de temporização — não produz um campo de dado a reverter."),
+            ["KillFunction"] = (false, "Efeito colateral (encerra processo) — não produz um campo de dado a reverter."),
+            ["StartProcessFunction"] = (false, "Efeito colateral (inicia processo) — não produz um campo de dado a reverter."),
+            ["RestartServiceFunction"] = (false, "Efeito colateral (reinicia serviço) — não produz um campo de dado a reverter."),
+            ["GetCurrentExecutionFunction"] = (false, "Consulta de ambiente de execução — não é transformação de campo."),
+            ["GetServerEmailFunction"] = (false, "Consulta de configuração de ambiente — não deriva de um campo de origem."),
+            ["GetAppSettingFunction"] = (false, "Consulta de configuração de ambiente — não deriva de um campo de origem."),
+            ["WriteAppSettingFunction"] = (false, "Efeito colateral (grava configuração) — não produz um campo de dado a reverter."),
+            ["ConnectionStringNameFunction"] = (false, "Consulta de configuração de ambiente — não deriva de um campo de origem."),
+            ["WriteConnectionStringFunction"] = (false, "Efeito colateral (grava configuração) — não produz um campo de dado a reverter."),
+            ["GetWindowsServiceNameFunction"] = (false, "Consulta de ambiente de execução — não deriva de um campo de origem."),
+            ["GetMachineNameFunction"] = (false, "Consulta de ambiente de execução — não deriva de um campo de origem."),
+            ["GetProcessNameFunction"] = (false, "Consulta de ambiente de execução — não deriva de um campo de origem."),
+
+            // ---- Complemento de curadoria (2026-09-07): 8 classes reais encontradas só pela
+            // extração reflection-only (RemoveFunction/ReplaceFunction/InsertFunction/IndexOfFunction/
+            // ContainsFunction/NullFunction/SendEmail/ConnectionStringFunction têm nome de classe
+            // diferente do padrão "<Verbo><Coisa>Function" ou ficam em namespaces menos óbvios —
+            // não apareceram na varredura textual inicial por strings, só na extração real via DLL. ----
+            ["InsertFunction"] = (false, "Insere caractere(s) em posição da string — não recuperável sem saber exatamente o que foi inserido e onde."),
+            ["RemoveFunction"] = (false, "Remove caractere(s) da string — não recuperável sem saber exatamente o que foi removido e onde."),
+            ["ReplaceFunction"] = (false, "Substituição de texto perde a distinção entre valor original e substituído sem conhecer o padrão exato."),
+            ["IndexOfFunction"] = (false, "Retorna metadado derivado (índice) — não recupera a string original."),
+            ["ContainsFunction"] = (false, "Retorna booleano de teste — colapsa infinitos valores de entrada em 2 saídas, não bijetor."),
+            ["NullFunction"] = (false, "Retorna constante null — não deriva de um campo de origem."),
+            ["SendEmail"] = (false, "Efeito colateral (envio de e-mail) — não produz um campo de dado a reverter."),
+            ["ConnectionStringFunction"] = (false, "Consulta de configuração de ambiente — não deriva de um campo de origem."),
+        };
+
+    /// <summary>Busca a curadoria pelo nome de CLASSE real (ex.: <c>"ConcatFunction"</c>) — não pelo
+    /// nome-palpite pós-<c>GuessDslName</c>. Retorna o default conservador (<c>false</c>,
+    /// <see cref="NaoCuradaReason"/>) quando a classe não foi revisada nesta curadoria.</summary>
+    public static (bool Reversible, string? Reason) Lookup(string className) =>
+        ByClassName.TryGetValue(className, out var entry) ? entry : (false, NaoCuradaReason);
+
+    /// <summary>Quantas classes foram efetivamente curadas (para diagnósticos/relatório do spike) —
+    /// não confundir com o total de funções existentes na DLL (<see cref="FunctionCatalog.Count"/>).</summary>
+    public static int CuratedCount => ByClassName.Count;
+}

--- a/ai/XslSynth.Core.Tests/FunctionReversibilityCatalogTests.cs
+++ b/ai/XslSynth.Core.Tests/FunctionReversibilityCatalogTests.cs
@@ -1,0 +1,80 @@
+using XslSynth.Prompting;
+
+namespace XslSynth.Core.Tests;
+
+/// <summary>Testes da Fase A da issue #151 (curadoria manual de reversibilidade por função).</summary>
+public sealed class FunctionReversibilityCatalogTests
+{
+    [Fact]
+    public void Funcao_naoCurada_degrada_para_falso_com_motivo_explicito()
+    {
+        var (reversible, reason) = FunctionReversibilityCatalog.Lookup("AlgumaFuncaoNovaNuncaVista");
+
+        Assert.False(reversible);
+        Assert.Equal(FunctionReversibilityCatalog.NaoCuradaReason, reason);
+    }
+
+    [Fact]
+    public void CalculateVerifierDigit_curada_como_nao_reversivel()
+    {
+        // Citada explicitamente no critério de aceite da issue #151 como exemplo canônico de
+        // função com perda — não pode virar true por acidente numa curadoria futura sem intenção.
+        var (reversible, reason) = FunctionReversibilityCatalog.Lookup("CalculateVerifierDigitFunction");
+
+        Assert.False(reversible);
+        Assert.NotNull(reason);
+    }
+
+    [Fact]
+    public void ConcatFunction_curada_como_nao_reversivel_por_ambiguidade_de_delimitador()
+    {
+        var (reversible, reason) = FunctionReversibilityCatalog.Lookup("ConcatFunction");
+
+        Assert.False(reversible);
+        Assert.Contains("delimitador", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("ConvertToBase64StringFunction")]
+    [InlineData("ConvertFromBase64StringFunction")]
+    [InlineData("UriEscapeFunction")]
+    [InlineData("UriUnescapeFunction")]
+    public void Codificacoes_sem_perda_curadas_como_reversiveis(string className)
+    {
+        var (reversible, _) = FunctionReversibilityCatalog.Lookup(className);
+
+        Assert.True(reversible);
+    }
+
+    [Fact]
+    public void Toda_entrada_falsa_tem_motivo_nao_nulo()
+    {
+        // Mesmo padrão de FieldToXmlMapping.Limitations (design §7): nunca "false" silencioso.
+        foreach (var className in KnownIrreversibleSample)
+        {
+            var (reversible, reason) = FunctionReversibilityCatalog.Lookup(className);
+            Assert.False(reversible);
+            Assert.False(string.IsNullOrWhiteSpace(reason));
+        }
+    }
+
+    private static readonly string[] KnownIrreversibleSample =
+    {
+        "CalculateVerifierDigitFunction", "ConcatFunction", "CreateNFeAcessKeyFunction",
+        "ToUpperFunction", "ToLowerFunction", "GetHashCodeFunction", "NewGuidFunction",
+        "SendEmailFunction", "ReadFileFunction", "RoundFunction"
+    };
+
+    [Fact]
+    public void Curadoria_cobre_pelo_menos_as_173_classes_Function_reais_da_dll_vendorizada()
+    {
+        // Trava de regressão: se a curadoria diminuir sem querer (edição futura), o teste falha
+        // aqui em vez de silenciosamente voltar pro default conservador "não curada". 173 é o
+        // número de classes *Function reais confirmadas por reflection contra a DLL vendorizada
+        // (ver SpikeReversibilidadeMeasurementTests) — a curadoria tem 175 entradas porque inclui
+        // 2 nomes que não correspondem a nenhuma classe real encontrada (não fazem mal, só não
+        // são usados).
+        Assert.True(FunctionReversibilityCatalog.CuratedCount >= 173,
+            $"esperava >= 173 entradas curadas, achou {FunctionReversibilityCatalog.CuratedCount}");
+    }
+}

--- a/ai/XslSynth.Core.Tests/SpikeReversibilidadeMeasurementTests.cs
+++ b/ai/XslSynth.Core.Tests/SpikeReversibilidadeMeasurementTests.cs
@@ -1,0 +1,57 @@
+using XslSynth.Prompting;
+using Xunit.Abstractions;
+
+namespace XslSynth.Core.Tests;
+
+/// <summary>
+/// Medição real do spike da issue #151 (Fase A+B, aprovado pelo dono em 2026-09-07): quantas
+/// funções catalogadas por reflection-only na DLL Sysmiddle real (vendorizada no repo em
+/// <c>tools/LowCodeRunner/Functions/SysMiddle.ConnectUs.Functions.dll</c>) são de fato
+/// reversíveis, segundo a curadoria manual de <see cref="FunctionReversibilityCatalog"/>.
+///
+/// Este NÃO é um teste de comportamento no sentido usual — é o instrumento de medição que produz
+/// o número concreto usado em docs/architecture/spike-resultado-reconstrucao-reversa-2026-09-07.md.
+/// Roda contra o artefato real (não sintético), mas pula graciosamente se a DLL não existir na
+/// máquina (mesmo padrão de degradação de <see cref="XslSynth.Prompting.FunctionCatalog"/>).
+/// </summary>
+public sealed class SpikeReversibilidadeMeasurementTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SpikeReversibilidadeMeasurementTests(ITestOutputHelper output) => _output = output;
+
+    private static readonly string RealDllPath = Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+        "tools", "LowCodeRunner", "Functions", "SysMiddle.ConnectUs.Functions.dll");
+
+    [Fact]
+    public void MedicaoReal_QuantasFuncoesDaDllSaoReversiveis()
+    {
+        Assert.True(File.Exists(RealDllPath),
+            $"DLL vendorizada esperada em '{RealDllPath}' — sem ela o spike não tem número real pra reportar.");
+
+        var logs = new List<string>();
+        var catalog = FunctionCatalog.ExtractFromDll(RealDllPath, logs.Add);
+
+        Assert.True(catalog.Count > 0, "catálogo vazio — extração por reflection falhou.");
+
+        var reversible = catalog.All.Where(e => e.Reversible).ToList();
+        var irreversible = catalog.All.Where(e => !e.Reversible).ToList();
+        var naoCurada = catalog.All.Where(e => e.IrreversibilityReason == FunctionReversibilityCatalog.NaoCuradaReason).ToList();
+
+        var pct = 100.0 * reversible.Count / catalog.Count;
+
+        _output.WriteLine($"Total de funções extraídas (reflection, {Path.GetFileName(RealDllPath)}): {catalog.Count}");
+        _output.WriteLine($"Reversíveis (curadoria Fase A): {reversible.Count} ({pct:F1}%)");
+        _output.WriteLine($"Não-reversíveis (curadoria Fase A): {irreversible.Count}");
+        _output.WriteLine($"Sem curadoria manual (default conservador): {naoCurada.Count}");
+        _output.WriteLine("Reversíveis: " + string.Join(", ", reversible.Select(e => e.Name).OrderBy(n => n, StringComparer.Ordinal)));
+
+        // Trava de regressão do número reportado no spike — se a curadoria mudar, o documento do
+        // spike precisa ser atualizado junto (não deixar o número do doc ficar desatualizado
+        // silenciosamente).
+        Assert.Equal(173, catalog.Count);
+        Assert.Empty(naoCurada); // as 173 classes reais foram todas revisadas nesta curadoria
+        Assert.Equal(23, reversible.Count);
+    }
+}

--- a/ai/XslSynth.Core.Tests/StructuralResolution/BranchReversibilityResolverTests.cs
+++ b/ai/XslSynth.Core.Tests/StructuralResolution/BranchReversibilityResolverTests.cs
@@ -1,0 +1,94 @@
+using XslSynth.Core.StructuralResolution;
+using XslSynth.Prompting;
+
+namespace XslSynth.Core.Tests.StructuralResolution;
+
+/// <summary>Testes da Fase B da issue #151 (generalização do composer para <c>Direction</c>) —
+/// especificamente da costura entre a curadoria de reversibilidade da Fase A
+/// (<see cref="FunctionCatalog"/>) e o nível de <see cref="StructuredBranch"/>.</summary>
+public sealed class BranchReversibilityResolverTests
+{
+    private static StructuredBranch Branch(params string[] functions) =>
+        new(Condition: "true", Target: "T.Doc/Campo", Sources: new[] { "I.LINHA01/CAMPO_A" }, Functions: functions);
+
+    [Fact]
+    public void SemFuncoes_SempreReversivel()
+    {
+        var result = BranchReversibilityResolver.Resolve(Branch(), catalog: null);
+
+        Assert.True(result.Reversible);
+        Assert.Null(result.Reason);
+    }
+
+    [Fact]
+    public void CatalogoIndisponivel_DegradaParaNaoReversivel_SemLancar()
+    {
+        var branch = Branch("QualquerFuncao");
+
+        var result = BranchReversibilityResolver.Resolve(branch, catalog: null);
+
+        Assert.False(result.Reversible);
+        Assert.Contains("indisponível", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FuncaoNaoCatalogada_NaoReversivel()
+    {
+        var catalog = FunctionCatalog.ExtractFromDll(@"C:\caminho\que\nao\existe.dll"); // catálogo vazio
+        var branch = Branch("ConcatString");
+
+        var result = BranchReversibilityResolver.Resolve(branch, catalog);
+
+        Assert.False(result.Reversible);
+        Assert.Contains("não catalogada", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly string RealDllPath = Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+        "tools", "LowCodeRunner", "Functions", "SysMiddle.ConnectUs.Functions.dll");
+
+    [Fact]
+    public void FuncaoReversivelCatalogada_TornaBranchReversivel()
+    {
+        if (!File.Exists(RealDllPath)) return; // DLL vendorizada não encontrada nesta máquina — pula graciosamente.
+
+        var catalog = FunctionCatalog.ExtractFromDll(RealDllPath);
+        // "Concat" é o nome-palpite real (ConcatFunction -> Concat via GuessDslName) — mas
+        // Concat é curado como NÃO reversível (ambiguidade de delimitador), então o branch some
+        // como não-reversível mesmo estando catalogado. Já "UriEscape" é curado como reversível.
+        var branch = Branch("UriEscape");
+
+        var result = BranchReversibilityResolver.Resolve(branch, catalog);
+
+        Assert.True(result.Reversible);
+        Assert.Null(result.Reason);
+    }
+
+    [Fact]
+    public void FuncaoComPerdaCatalogada_TornaBranchNaoReversivel()
+    {
+        if (!File.Exists(RealDllPath)) return;
+
+        var catalog = FunctionCatalog.ExtractFromDll(RealDllPath);
+        var branch = Branch("Concat"); // ConcatFunction -> "Concat", curado como false
+
+        var result = BranchReversibilityResolver.Resolve(branch, catalog);
+
+        Assert.False(result.Reversible);
+        Assert.Contains("delimitador", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UmaFuncaoIrreversivelEntreVariasReversiveis_TornaBranchInteiroNaoReversivel()
+    {
+        if (!File.Exists(RealDllPath)) return;
+
+        var catalog = FunctionCatalog.ExtractFromDll(RealDllPath);
+        // UriEscape (true) + Concat (false) juntos — composição não é bijetora.
+        var branch = Branch("UriEscape", "Concat");
+
+        var result = BranchReversibilityResolver.Resolve(branch, catalog);
+
+        Assert.False(result.Reversible);
+    }
+}

--- a/ai/XslSynth.Core.Tests/StructuralResolution/FieldToXmlMappingComposerTests.cs
+++ b/ai/XslSynth.Core.Tests/StructuralResolution/FieldToXmlMappingComposerTests.cs
@@ -256,4 +256,125 @@ public sealed class FieldToXmlMappingComposerTests
         Assert.Single(result.Targets); // resolveu (nome único), mas não é authoritative
         Assert.Contains(result.Limitations!, l => l.Contains("heurística de nome"));
     }
+
+    // ---- Fase B da issue #151 — Direction ---------------------------------------------------
+
+    [Fact]
+    public void Direction_Default_EhForward_ComportamentoIdenticoAoExistente()
+    {
+        var candidate = new MappingCandidate(
+            MappingId: "M12",
+            Sources: new[] { Src("CAMPO_A") },
+            Kind: MappingKind.Direct,
+            TargetPath: "Doc/Cabecalho/CampoA",
+            TargetPathIsFullPath: true,
+            Functions: Array.Empty<string>(),
+            LoopType: null,
+            AllSourcesResolvedFromOriginLayout: true,
+            SourcesHavePositionalGroupRepetition: false,
+            KnownFunctions: new HashSet<string>());
+
+        var result = Composer().Compose(candidate);
+
+        Assert.Equal(Direction.Forward, result.Direction);
+        Assert.Equal(Confidence.Authoritative, result.Confidence);
+    }
+
+    [Fact]
+    public void Direction_Reverse_SemFuncao_AuthoritativeIgualForward()
+    {
+        // Direct (sem função) é reversível por natureza (design §3) — condição 6 satisfeita
+        // trivialmente mesmo em Reverse.
+        var candidate = new MappingCandidate(
+            MappingId: "M13",
+            Sources: new[] { Src("CAMPO_A") },
+            Kind: MappingKind.Direct,
+            TargetPath: "Doc/Cabecalho/CampoA",
+            TargetPathIsFullPath: true,
+            Functions: Array.Empty<string>(),
+            LoopType: null,
+            AllSourcesResolvedFromOriginLayout: true,
+            SourcesHavePositionalGroupRepetition: false,
+            KnownFunctions: new HashSet<string>(),
+            Direction: Direction.Reverse,
+            Reversibility: new BranchReversibility(true, null));
+
+        var result = Composer().Compose(candidate);
+
+        Assert.Equal(Direction.Reverse, result.Direction);
+        Assert.Equal(Confidence.Authoritative, result.Confidence);
+    }
+
+    [Fact]
+    public void Direction_Reverse_SemReversibilidadeConfirmada_CaiEmBestEffort()
+    {
+        // Mesmo candidato que seria Authoritative em Forward — em Reverse, sem confirmar que a
+        // função é bijetora (Fase A), cai em best-effort (condição 6 nova).
+        var candidate = new MappingCandidate(
+            MappingId: "M14",
+            Sources: new[] { Src("CAMPO_A") },
+            Kind: MappingKind.Transformed,
+            TargetPath: "Doc/Chave",
+            TargetPathIsFullPath: true,
+            Functions: new[] { "CalculateVerifierDigit" },
+            LoopType: null,
+            AllSourcesResolvedFromOriginLayout: true,
+            SourcesHavePositionalGroupRepetition: false,
+            KnownFunctions: new HashSet<string> { "CalculateVerifierDigit" },
+            Direction: Direction.Reverse,
+            Reversibility: new BranchReversibility(false, "Dígito verificador — perde o valor original."));
+
+        var result = Composer().Compose(candidate);
+
+        Assert.Equal(Confidence.BestEffort, result.Confidence);
+        Assert.Contains(result.Limitations!, l => l.Contains("Dígito verificador"));
+    }
+
+    [Fact]
+    public void Direction_Reverse_ComFuncaoBijetoraConfirmada_ResolveAuthoritative()
+    {
+        var candidate = new MappingCandidate(
+            MappingId: "M15",
+            Sources: new[] { Src("CAMPO_A") },
+            Kind: MappingKind.Transformed,
+            TargetPath: "Doc/Cabecalho/CampoA",
+            TargetPathIsFullPath: true,
+            Functions: new[] { "UriEscape" },
+            LoopType: null,
+            AllSourcesResolvedFromOriginLayout: true,
+            SourcesHavePositionalGroupRepetition: false,
+            KnownFunctions: new HashSet<string> { "UriEscape" },
+            Direction: Direction.Reverse,
+            Reversibility: new BranchReversibility(true, null));
+
+        var result = Composer().Compose(candidate);
+
+        Assert.Equal(Confidence.Authoritative, result.Confidence);
+        Assert.Null(result.Limitations);
+    }
+
+    [Fact]
+    public void Direction_Reverse_ReversibilityNaoInformada_TrataComoNaoReversivel()
+    {
+        // Reversibility null em Reverse não deve ser interpretado como "confia por padrão" —
+        // mesma filosofia conservadora da Fase A (default false quando não curado/confirmado).
+        var candidate = new MappingCandidate(
+            MappingId: "M16",
+            Sources: new[] { Src("CAMPO_A") },
+            Kind: MappingKind.Direct,
+            TargetPath: "Doc/Cabecalho/CampoA",
+            TargetPathIsFullPath: true,
+            Functions: Array.Empty<string>(),
+            LoopType: null,
+            AllSourcesResolvedFromOriginLayout: true,
+            SourcesHavePositionalGroupRepetition: false,
+            KnownFunctions: new HashSet<string>(),
+            Direction: Direction.Reverse,
+            Reversibility: null);
+
+        var result = Composer().Compose(candidate);
+
+        Assert.Equal(Confidence.BestEffort, result.Confidence);
+        Assert.NotNull(result.Limitations);
+    }
 }

--- a/docs/architecture/spike-resultado-reconstrucao-reversa-2026-09-07.md
+++ b/docs/architecture/spike-resultado-reconstrucao-reversa-2026-09-07.md
@@ -1,0 +1,137 @@
+# Resultado do spike A+B — Reconstrução reversa XML→TXT (Issue #151)
+
+Autor: `@lp-parser-llm` (Lia). Escopo aprovado pelo dono em 2026-09-07 (comentário na issue #151):
+Fase A (metadado `Reversible` no `FunctionCatalog`) + Fase B (generalizar
+`FieldToXmlMappingComposer` para `Direction: Forward|Reverse`), medindo contra a DLL real
+Sysmiddle vendorizada no repo — sem prometer Fase C/D até ver o número.
+
+Design de referência: `design-reconstrucao-reversa-xml-txt-2026-09-03.md`.
+
+## 1. O que foi implementado
+
+### Fase A — metadado `Reversible` por função
+
+- `ai/XslSynth.Contracts/Prompting/FunctionCatalog.cs`: `FunctionCatalogEntry` ganhou
+  `bool Reversible` + `string? IrreversibilityReason`, default conservador
+  (`false`, "sem curadoria manual") quando uma classe `*Function` não tem entrada curada.
+- `ai/XslSynth.Contracts/Prompting/FunctionReversibilityCatalog.cs` (novo): curadoria manual,
+  chaveada pelo **nome de classe real** (ex.: `"ConcatFunction"`, não o nome-palpite pós-
+  `GuessDslName`), com motivo textual em cada entrada. 175 entradas — cobrindo as 173 classes
+  reais confirmadas por reflection na DLL vendorizada (2 nomes na curadoria não bateram com
+  nenhuma classe real, harmless).
+- **Bug real corrigido durante o spike:** `FunctionCatalog.ExtractFromDll` montava o
+  `MetadataLoadContext`/`PathAssemblyResolver` só com as DLLs do runtime .NET + a própria DLL de
+  funções — sem incluir `SysMiddle.Base.dll` (onde mora `FunctionMember`, a base checada por
+  `InheritsFrom`) nem as demais DLLs Sysmiddle vizinhas. Sem elas, `GetTypes()` falhava para
+  **todos** os tipos e o catálogo saía vazio silenciosamente (nunca detectado antes porque o
+  único teste que exercitava a DLL real gate-ava em `.claude/tmp/sysmiddle/`, caminho que nunca
+  existiu nas máquinas onde os testes rodaram até agora). Corrigido incluindo as DLLs do mesmo
+  diretório do alvo no resolver — ainda 100% reflection-only, não executa nenhum código.
+
+### Fase B — `Direction: Forward | Reverse`
+
+- `ai/XslSynth.Contracts/Model/StructuralResolutionModels.cs`: novo enum `Direction`
+  (`Forward`/`Reverse`); `FieldToXmlMapping` ganhou `Direction Direction = Direction.Forward`.
+- `ai/XslSynth.Contracts/Core/StructuralResolution/FieldToXmlMappingComposer.cs`:
+  `MappingCandidate` ganhou `Direction Direction = Direction.Forward` e
+  `BranchReversibility? Reversibility = null`. `Compose(...)` ganhou uma **6ª condição**,
+  só relevante em `Reverse`: a reconstrução só é `Authoritative` se a função/branch envolvida for
+  confirmada bijetora (Fase A). Em `Forward`, a condição é trivialmente satisfeita — 100% do
+  comportamento de #140/#141 preservado (todos os 12 testes originais de
+  `FieldToXmlMappingComposerTests` continuam passando sem alteração).
+- `ai/XslSynth.Contracts/Core/StructuralResolution/BranchReversibilityResolver.cs` (novo): resolve
+  a reversibilidade de um `StructuredBranch` inteiro a partir das funções que ele referencia —
+  sem função = sempre reversível (cópia posicional); com função = reversível só se **todas** as
+  funções referenciadas forem `Reversible = true` no catálogo curado (uma função com perda torna
+  o branch inteiro não-reversível, mesmo com outras bijetoras).
+- **Deliberadamente fora de escopo** (confirmado pelo pedido do dono): `OccurrenceResolver`
+  simétrico completo (XML-ocorrência → linha física do TXT) e qualquer serviço/endpoint novo —
+  isso é Fase C/D.
+
+## 2. Medição real (não estimativa)
+
+Executada em `ai/XslSynth.Core.Tests/SpikeReversibilidadeMeasurementTests.cs`, contra
+`tools/LowCodeRunner/Functions/SysMiddle.ConnectUs.Functions.dll` (DLL Sysmiddle real, já
+versionada no repo — mesma usada pelo LowCode runner em produção). Reflection-only
+(`MetadataLoadContext`), sem executar nenhum código da DLL.
+
+```
+Total de funções extraídas (reflection, SysMiddle.ConnectUs.Functions.dll): 173
+Reversíveis (curadoria Fase A): 23 (13,3%)
+Não-reversíveis (curadoria Fase A): 150
+Sem curadoria manual (default conservador): 0
+```
+
+As 23 funções reversíveis: `CDataString`, `ConvertFromBase64Bytes`, `ConvertFromBase64String`,
+`ConvertToBase64Bytes`, `ConvertToBase64String`, `ConvertToChar`, `DecompressBytes`, `False`,
+`GetBrazilianCityCode`, `GetBrazilianStateCodeByInitials`, `GetBrazilianStateCodeByName`,
+`GetBytes`, `GetSplittedValueByPosition`, `GetStringFromBytes`, `PadLeft`, `PadRight`,
+`SplitValueByPosition`, `Trim`, `TrimEnd`, `TrimStart`, `True`, `UriEscape`, `UriUnescape`.
+
+**Leitura honesta do número:** 13,3% é a fração de funções *individualmente* bijetoras no
+catálogo completo de 173 — não é a fração de **regras de mapeamento reais do corpus de produção**
+que seriam reversíveis. As duas coisas divergem em dois sentidos:
+
+1. **Para pior:** funções puramente estruturais (sem função nenhuma, `MappingKind.Direct`) são
+   sempre reversíveis e não aparecem nesta contagem — muitos campos do mapeamento real não usam
+   função alguma, então a taxa real de campos reversíveis tende a ser **maior** que 13,3%.
+2. **Para pior ainda:** a curadoria conta ~40% do catálogo (70 das 173 classes) como funções de
+   I/O/efeito colateral/ambiente (banco, arquivo, e-mail, processo) que **nunca** deveriam
+   aparecer numa regra de transformação de campo fiscal — não é realista que essas funções sejam
+   usadas nas regras `Rules`/`StructuredBranch` reais do domínio NF-e/CT-e. Elas inflam o
+   denominador sem representar risco real.
+3. **Para melhor (risco real):** a função mais citada no critério de aceite da própria issue
+   #151 (`CalculateVerifierDigit`) e a mais estruturalmente central (`Concat`/`ConcatString`,
+   base de `MappingKind.Concatenated`) estão **ambas** na lista de não-reversíveis — são,
+   supostamente, duas das funções mais usadas em regras fiscais reais (dígito verificador de
+   chave de acesso, concatenação de campos). Sem acesso ao corpus real de `Rules`/
+   `StructuredBranch` de produção nesta sessão (não disponível no ambiente — ver §3), não foi
+   possível medir a frequência de uso real dessas funções especificamente, que é o dado que
+   realmente decide o ROI de C/D.
+
+## 3. Limitação da medição (transparência sobre o que NÃO foi possível medir)
+
+O pedido original do spike era medir contra "uma amostra real do corpus" de pares `Rules`/
+`StructuredBranch` de produção. Essa amostra **não estava disponível no ambiente desta sessão**
+(diretórios de corpus mencionados em memória de sessões anteriores — `.claude/tmp/exemplos`,
+datasets de fine-tuning — não existem neste ambiente). A medição real que foi possível é sobre o
+**catálogo de funções em si** (população de 173 classes da DLL real), não sobre a frequência de
+uso dessas funções nas regras de produção. Isso é uma limitação real da medição, não um resultado
+inflado — o número de 13,3% caracteriza "quão bijetora é a biblioteca de funções Sysmiddle como
+um todo", não "quão reversível é o corpus de mapeamentos fiscais reais".
+
+## 4. Recomendação
+
+**Não avançar direto para Fase C/D com este número isolado.** A medição de população de funções
+(13,3%) é baixa, mas é um indicador fraco do ROI real — o que decide o ROI de C/D é a frequência
+de uso das ~10-15 funções mais comuns em `Rules`/`StructuredBranch` de produção, não a fração do
+catálogo inteiro (que é dominado por funções de I/O irrelevantes ao domínio fiscal). O sinal mais
+concreto encontrado neste spike é qualitativo, não quantitativo: as duas funções citadas no
+próprio critério de aceite da issue (`CalculateVerifierDigit`, `Concat`) — supostamente centrais
+em regras fiscais reais — são ambas não-reversíveis, o que sugere que o **caminho puro** ("reverter
+a regra sem o TXT original") vai cobrir uma fração pequena dos campos reais mesmo que o resto do
+catálogo fosse 100% reversível.
+
+**Próximo passo recomendado, antes de comprometer Fase C/D:** medir a frequência de uso real de
+`CalculateVerifierDigit`/`ConcatString`/demais funções nas `Rules` de produção (não disponível
+nesta sessão) — se essas duas dominarem o uso real, o valor de negócio de C/D cai ainda mais,
+reforçando a estratégia já registrada no design (§1): quando o TXT original existir na sessão do
+usuário, usá-lo como fonte de verdade e a regra reversível como **validação**, não como única via
+de reconstrução. Fase C/D só valem a pena isoladamente (sem o TXT original disponível) se essa
+medição de frequência real mostrar uso majoritário de funções estruturais/bijetoras — o que este
+spike não conseguiu confirmar nem refutar por falta de acesso ao corpus real nesta sessão.
+
+## 5. Arquivos alterados
+
+- `ai/XslSynth.Contracts/Prompting/FunctionCatalog.cs` — metadado `Reversible`/`IrreversibilityReason` + fix do resolver de assemblies.
+- `ai/XslSynth.Contracts/Prompting/FunctionReversibilityCatalog.cs` (novo) — curadoria manual.
+- `ai/XslSynth.Contracts/Model/StructuralResolutionModels.cs` — enum `Direction`, `FieldToXmlMapping.Direction`.
+- `ai/XslSynth.Contracts/Core/StructuralResolution/FieldToXmlMappingComposer.cs` — `MappingCandidate.Direction`/`Reversibility`, condição 6.
+- `ai/XslSynth.Contracts/Core/StructuralResolution/BranchReversibilityResolver.cs` (novo).
+- `ai/XslSynth.Core.Tests/FunctionReversibilityCatalogTests.cs` (novo).
+- `ai/XslSynth.Core.Tests/StructuralResolution/BranchReversibilityResolverTests.cs` (novo).
+- `ai/XslSynth.Core.Tests/StructuralResolution/FieldToXmlMappingComposerTests.cs` — 5 casos novos de `Direction.Reverse`.
+- `ai/XslSynth.Core.Tests/SpikeReversibilidadeMeasurementTests.cs` (novo) — instrumento de medição, roda contra a DLL real vendorizada.
+
+`dotnet build`/`dotnet test` (solução completa e `ai/XslSynth.Core.Tests` isolado) limpos — 80/80
+testes verdes em `XslSynth.Core.Tests`, incluindo os 15 novos desta issue.


### PR DESCRIPTION
…versible + Direction)

Fase A: FunctionCatalogEntry ganha Reversible/IrreversibilityReason; curadoria manual em FunctionReversibilityCatalog cobrindo as 173 classes *Function reais da DLL Sysmiddle vendorizada (tools/LowCodeRunner/Functions/SysMiddle.ConnectUs.Functions.dll). Corrige de quebra um bug real em FunctionCatalog.ExtractFromDll: o resolver de assemblies não incluia SysMiddle.Base.dll (dependencia de FunctionMember) nem DLLs vizinhas, fazendo GetTypes() falhar silenciosamente e o catalogo sair sempre vazio contra a DLL real.

Fase B: MappingCandidate/FieldToXmlMapping ganham Direction (Forward|Reverse, default Forward preserva 100% o comportamento de #140/#141); Compose() ganha condicao 6 (reversibilidade, so relevante em Reverse). BranchReversibilityResolver (novo) costura a curadoria da Fase A no nivel de StructuredBranch.

Medicao real (SpikeReversibilidadeMeasurementTests, contra a DLL real): 23/173 (13,3%) das funcoes sao reversiveis. CalculateVerifierDigit e Concat/ConcatString - citadas no criterio de aceite da issue e centrais em regras fiscais - sao ambas nao-reversiveis. Recomendacao documentada em docs/architecture/spike-resultado-reconstrucao-reversa-2026-09-07.md: nao avancar direto pra Fase C/D sem medir frequencia de uso real no corpus de producao (corpus nao disponivel nesta sessao).

80/80 testes em ai/XslSynth.Core.Tests, 680/680 em tests/LayoutParserApi.Tests.

Refs #151