### PR TITLE
feat(deploy): clean deploy seletivo + desbloqueio da migracao de config (issue #112)

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -447,6 +447,54 @@ jobs:
           Write-Warning "Falha ao verificar/encerrar processos orfaos em $API_DEST (best-effort, seguindo): $_"
         }
 
+        # -- Clean deploy: remove do destino o que NAO faz parte do publish atual --------------
+        # Mesma estrategia do deploy.yml (docs/architecture/clean-deploy-estrategia-2026-09-07.md):
+        # sem isso, um arquivo removido/renomeado no repo ficava para sempre em $API_DEST, de
+        # deploy em deploy. Preserva a pasta Logs/logs inteira (Logging:File:Directory aponta para
+        # dentro de $API_DEST\logs) e appsettings.json (ja tratado acima via $preserveAppSettings -
+        # aqui so garante que a limpeza generica nao o apague). Diff entre destino e publish atual,
+        # nao um rm -rf; falha ao remover um arquivo individual e best-effort.
+        if (Test-Path $API_DEST) {
+          $preservarPastasTopo = @('logs')
+          $preservarArquivos = @('appsettings.json')
+
+          $novosRelativos = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+          Get-ChildItem -Path $SRC -Recurse -File | ForEach-Object {
+            [void]$novosRelativos.Add($_.FullName.Substring($SRC.Length + 1))
+          }
+          foreach ($extra in @('LayoutParserDecrypt.exe', 'LayoutParserDecrypt.exe.config', 'LayoutParserLib.dll', 'LayoutParserLowCodeRunner.exe.config')) {
+            [void]$novosRelativos.Add($extra)
+          }
+
+          $removidos = 0
+          Get-ChildItem -Path $API_DEST -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+            $relExistente = $_.FullName.Substring($API_DEST.Length + 1)
+            $primeiraPasta = ($relExistente -split '[\\/]')[0]
+            $preservar = ($preservarPastasTopo -contains $primeiraPasta.ToLowerInvariant()) -or
+                         ($preservarArquivos -contains $relExistente.ToLowerInvariant()) -or
+                         ($relExistente -like 'appsettings.*.local.json') -or
+                         ($relExistente -eq 'appsettings.Local.json') -or
+                         ($novosRelativos.Contains($relExistente))
+            if (-not $preservar) {
+              try {
+                Remove-Item -Path $_.FullName -Force -ErrorAction Stop
+                $removidos++
+              } catch {
+                Write-Warning "Clean deploy: falha ao remover orfao $relExistente (best-effort, seguindo): $($_.Exception.Message)"
+              }
+            }
+          }
+          Write-Host "Clean deploy: $removidos arquivo(s) orfao(s) removido(s) de $API_DEST."
+
+          Get-ChildItem -Path $API_DEST -Recurse -Directory -ErrorAction SilentlyContinue |
+            Where-Object {
+              $preservarPastasTopo -notcontains $_.Name.ToLowerInvariant() -and
+              (Get-ChildItem -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue).Count -eq 0
+            } |
+            Sort-Object { $_.FullName.Length } -Descending |
+            ForEach-Object { Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue }
+        }
+
         Write-Host "Copiando publish-api -> $API_DEST (preservar appsettings: $preserveAppSettings)..."
         if ($preserveAppSettings) {
           Copy-Item -Path (Join-Path $SRC '*') -Destination $API_DEST -Recurse -Force -Exclude 'appsettings.json'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,9 +510,20 @@ jobs:
           }
         }
 
+        # Defesa em profundidade contra a causa raiz registrada em #112 (comentario de @lp-devops,
+        # 2026-09-06): o appsettings.json do repo teve comentarios `// ...` (commit 0a2162b) e
+        # ConvertFrom-Json nao aceita comentario - falhava silenciosamente sob continue-on-error,
+        # deixando $mapaRepo vazio e o relatorio de drift mentiroso. O arquivo do repo ja foi
+        # corrigido para JSON estrito (comentarios viraram chaves "_comment"), mas o parser aqui
+        # fica tolerante de qualquer forma - remove linha que comeca (so espacos antes) com `//`,
+        # o padrao usado neste repo. Nao mexe em `//` dentro de string de valor.
+        function RemoverComentarios($caminho) {
+          return ((Get-Content $caminho) | Where-Object { $_ -notmatch '^\s*//' }) -join "`n"
+        }
+
         $mapaRepo = @{}; $mapaDestino = @{}
-        Flatten (Get-Content $repo -Raw | ConvertFrom-Json) '' $mapaRepo
-        Flatten (Get-Content $destino -Raw | ConvertFrom-Json) '' $mapaDestino
+        Flatten (RemoverComentarios $repo | ConvertFrom-Json) '' $mapaRepo
+        Flatten (RemoverComentarios $destino | ConvertFrom-Json) '' $mapaDestino
 
         # NUNCA ecoar valor de chave sensivel: o destino carrega Database:Password em texto plano.
         function EhSensivel($chave) {
@@ -652,6 +663,7 @@ jobs:
         IDENTITY_DB_NAME: ${{ vars.IDENTITY_DB_NAME }}
         IDENTITY_DB_USERID: ${{ secrets.IDENTITY_DB_USERID }}
         IDENTITY_DB_PASSWORD: ${{ secrets.IDENTITY_DB_PASSWORD }}
+        DB_PASSWORD_PROD: ${{ secrets.DB_PASSWORD_PROD }}
       run: |
         $ErrorActionPreference = "Stop"
         $serviceName = "LayoutParserApi"
@@ -737,6 +749,28 @@ jobs:
           Write-Warning ("Secret IDENTITY_DB_PASSWORD ausente - IdentityDatabase:Password nao sera gerenciada (valor existente, se houver, fica preservado). " +
             "Sem ela e sem valor manual no destino, a API sobe fail-closed negando UserId. " +
             "Crie em: GitHub -> Settings -> Secrets and variables -> Actions -> aba Secrets.")
+        }
+
+        # Database__Password: fecha o pre-requisito #1 registrado na issue #112 (comentario de
+        # @lp-devops, 2026-09-06) para ativar vars.MIGRATE_CONFIG_TO_REPO=true. O guard-rail de
+        # segredo do step "Config drift" aborta a migracao enquanto Database:Password divergir do
+        # repo (repo tem "") e NAO existir Database__Password no Environment do servico - hoje a
+        # senha do SQL (172.31.249.51, credencial compartilhada org-wide, ver
+        # .claude/rules/security.md) so existe em texto plano no appsettings.json do disco.
+        #
+        # O valor NAO pode ser obtido por este workflow (host de producao sem SSH/WinRM/SMB) nem
+        # inventado por um agente - precisa ser o mesmo valor ja em uso, provisionado manualmente
+        # pelo dono do projeto como secret DB_PASSWORD_PROD. Enquanto o secret nao existir, esta
+        # chave simplesmente NAO entra em $managed (mesma semantica de upsert das demais acima) -
+        # nada muda no Environment e a senha continua vindo do appsettings.json ate a migracao
+        # ser desbloqueada.
+        if (-not [string]::IsNullOrWhiteSpace($env:DB_PASSWORD_PROD)) {
+          $managed['Database__Password'] = $env:DB_PASSWORD_PROD
+        } else {
+          Write-Warning ("Secret DB_PASSWORD_PROD ausente - Database__Password nao sera gerenciada. " +
+            "E pre-requisito para ativar vars.MIGRATE_CONFIG_TO_REPO=true (issue #112): crie o secret " +
+            "com o MESMO valor de senha ja em uso hoje (nao e rotacao) em GitHub -> Settings -> " +
+            "Secrets and variables -> Actions -> aba Secrets.")
         }
 
         # Kestrel__Endpoints__Http__Url: TRAVA DE REDE (2026-08-12, plano em
@@ -1010,6 +1044,78 @@ jobs:
           Write-Warning "Nenhum arquivo encontrado em: $DEPLOY_API_SOURCE"
           Write-Host "Conteudo do diretorio de origem:"
           Get-ChildItem -Path $DEPLOY_API_SOURCE -Recurse | Select-Object FullName | Format-Table
+        }
+
+        # -- Clean deploy: remove do destino o que NAO faz parte do publish atual --------------
+        #
+        # POR QUE ESTE BLOCO EXISTE: ate aqui o deploy so SOBRESCREVIA arquivos - um arquivo que
+        # saiu do repo (renomeado, movido, ou uma DLL de dependencia removida) continuava para
+        # sempre no `<deploy>\api` do servidor, de release em release. Decisao do dono
+        # (2026-09-07, ver docs/architecture/clean-deploy-estrategia-2026-09-07.md): o destino deve
+        # corresponder exatamente ao que o `dotnet publish` deste commit produz - reprodutivel,
+        # sem acumulo.
+        #
+        # O QUE E PRESERVADO DE PROPOSITO (nao e "limpo"): a pasta Logs/logs inteira (historico de
+        # log sobrevive a um redeploy - Logging:File:Directory aponta para
+        # `<deploy>\api\logs`, DENTRO desta pasta) e appsettings.json/appsettings.Production.json
+        # (canal de config local/migrado, ja tratado acima pela flag CONFIG_MIGRATED - aqui so
+        # garante que uma limpeza generica nao os apague por engano). Nao mexe em nada fora de
+        # `<deploy>\api` (backups/, MLData/, Exemplo/, xsd/, tcl/, xsl/, sysmiddle/, globalfolder/
+        # etc. sao pastas IRMAS de `api/`, fora do escopo deste bloco - ver o doc para o
+        # levantamento completo dos diretorios de runtime).
+        #
+        # NAO e um `rm -rf` seguido de copia: e um diff entre o que existe no destino e o que o
+        # publish atual contem, removendo so os arquivos ORFAOS (existem no destino, nao existem
+        # no publish nem estao na allowlist acima). Erro ao remover um arquivo individual e
+        # best-effort (nao aborta o deploy) - o objetivo e reduzir acumulo, nao e tao critico
+        # quanto a copia em si.
+        if (Test-Path $DEPLOY_API_PATH) {
+          $preservarPastasTopo = @('logs')  # comparado case-insensitive; cobre "Logs" e "logs"
+          $preservarArquivos = @('appsettings.json', 'appsettings.production.json')
+
+          $novosRelativos = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+          foreach ($file in $apiFiles) {
+            [void]$novosRelativos.Add($file.FullName.Substring($DEPLOY_API_SOURCE.Length + 1))
+          }
+          # LayoutParserDecrypt.exe/.config e LayoutParserLib.dll sao copiados por um passo
+          # separado logo abaixo (fora de $apiFiles) - registrados aqui tambem para nao virarem
+          # "orfaos" na mesma passada em que acabaram de ser publicados.
+          foreach ($extra in @('LayoutParserDecrypt.exe', 'LayoutParserDecrypt.exe.config', 'LayoutParserLib.dll')) {
+            [void]$novosRelativos.Add($extra)
+          }
+
+          $removidos = 0
+          $existentes = Get-ChildItem -Path $DEPLOY_API_PATH -Recurse -File -ErrorAction SilentlyContinue
+          foreach ($existente in $existentes) {
+            $relExistente = $existente.FullName.Substring($DEPLOY_API_PATH.Length + 1)
+            $primeiraPasta = ($relExistente -split '[\\/]')[0]
+            if ($preservarPastasTopo -contains $primeiraPasta.ToLowerInvariant()) { continue }
+            if ($preservarArquivos -contains $relExistente.ToLowerInvariant()) { continue }
+            if ($relExistente -like 'appsettings.*.local.json' -or $relExistente -eq 'appsettings.Local.json') { continue }
+            if ($novosRelativos.Contains($relExistente)) { continue }
+
+            try {
+              Remove-Item -Path $existente.FullName -Force -ErrorAction Stop
+              $removidos++
+            } catch {
+              Write-Warning "Clean deploy: falha ao remover orfao $relExistente (best-effort, seguindo): $($_.Exception.Message)"
+            }
+          }
+
+          if ($removidos -gt 0) {
+            Write-Host "Clean deploy: $removidos arquivo(s) orfao(s) removido(s) de $DEPLOY_API_PATH (fora do publish atual e fora da allowlist Logs/appsettings)."
+          } else {
+            Write-Host "Clean deploy: nenhum arquivo orfao encontrado em $DEPLOY_API_PATH."
+          }
+
+          # Diretorios vazios remanescentes (exceto os preservados) - cosmetico, best-effort.
+          Get-ChildItem -Path $DEPLOY_API_PATH -Recurse -Directory -ErrorAction SilentlyContinue |
+            Where-Object {
+              $preservarPastasTopo -notcontains $_.Name.ToLowerInvariant() -and
+              (Get-ChildItem -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue).Count -eq 0
+            } |
+            Sort-Object { $_.FullName.Length } -Descending |
+            ForEach-Object { Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue }
         }
         
         $copiedCount = 0

--- a/appsettings.json
+++ b/appsettings.json
@@ -90,6 +90,7 @@
     "LearningExamplesPath": "C:\\Users\\Elson\\source\\repos\\ExemplosDeXSLeTCL"
   },
   "Database": {
+    "_comment": "Senha real via dotnet user-secrets (dev) ou env var Database__Password (prod) - nunca em texto plano neste arquivo (ver .claude/rules/security.md).",
     "Server": "172.31.249.51",
     "Database": "ConnectUS_Macgyver",
     "UserId": "macgyver",
@@ -98,18 +99,8 @@
     "ConnectionTimeout": "30",
     "CommandTimeout": "30"
   },
-  // ✅ Banco DEDICADO da LayoutParserApi (identidade/workspace/pacotes fiscais/drafts/releases) —
-  // NÃO é o ConnectUS_Macgyver. SQL Server rodando em Docker na VM Ubuntu de produção
-  // (elson@172.25.32.5, container "layoutparser-identity-sql",
-  // mcr.microsoft.com/mssql/server:2022-latest, porta publicada 1433 — CONFIRMAR com o dono se a
-  // porta publicada do container é realmente 1433:1433 e não outra mapeada; não foi possível
-  // inspecionar o container diretamente nesta sessão). O valor anterior ("localhost\SQLEXPRESS")
-  // era um resquício de configuração local de dev (ver commit 0a2162b, que introduziu esta seção
-  // já com esse valor) — nunca foi atualizado para produção. Credencial separada da do Sysmiddle:
-  // nunca reusar "Database:Password" aqui. Senha real via `dotnet user-secrets` (dev) ou env var
-  // `IdentityDatabase__Password` (prod) — nunca em texto plano neste arquivo (ver
-  // .claude/rules/security.md).
   "IdentityDatabase": {
+    "_comment": "Banco DEDICADO da LayoutParserApi (identidade/workspace/pacotes fiscais/drafts/releases) - NAO e o ConnectUS_Macgyver. SQL Server rodando em Docker na VM Ubuntu de producao (elson@172.25.32.5, container 'layoutparser-identity-sql', mcr.microsoft.com/mssql/server:2022-latest, porta publicada 1433 - CONFIRMAR com o dono se a porta publicada do container e realmente 1433:1433 e nao outra mapeada; nao foi possivel inspecionar o container diretamente). O valor anterior ('localhost\\SQLEXPRESS') era um resquicio de configuracao local de dev (ver commit 0a2162b) - nunca foi atualizado para producao. Credencial separada da do Sysmiddle: nunca reusar Database:Password aqui. Senha real via dotnet user-secrets (dev) ou env var IdentityDatabase__Password (prod) - nunca em texto plano neste arquivo (ver .claude/rules/security.md).",
     "Server": "172.25.32.5,1433",
     "Database": "LayoutParserIdentity",
     "UserId": "",

--- a/docs/architecture/clean-deploy-estrategia-2026-09-07.md
+++ b/docs/architecture/clean-deploy-estrategia-2026-09-07.md
@@ -1,0 +1,168 @@
+# Clean deploy — estrategia e decisoes (2026-09-07)
+
+## Contexto / pedido
+
+O dono reportou que o deploy (`.github/workflows/deploy.yml` producao e
+`.github/workflows/ci-dev.yml` dev) so sobrescreve/atualiza arquivos — nunca limpa o
+diretorio de destino. Um arquivo removido/renomeado no repo (ex.: DLL de dependencia
+descartada, artefato de build antigo) fica para sempre em `<deploy>\api`, de release em
+release. Sintoma concreto usado como gatilho: o `appsettings.json` de producao tem
+`Database:Password` em texto plano no disco.
+
+## Investigacao
+
+### 1) Por que a senha do SQL esta em texto plano no disco de producao hoje
+
+**Nao e escrita nova do pipeline nem residuo de edicao manual — e o comportamento
+DOCUMENTADO do mecanismo de preservacao do `appsettings.json`.** Achado ja registrado
+em `.claude/rules/security.md` (secao 2026-08-15) e confirmado de novo nesta sessao lendo
+`deploy.yml`:
+
+- O step "Deploy to server (local)" copia com `-Exclude "appsettings.json"` por padrao —
+  o arquivo do servidor nunca e sobrescrito pelo do repo, a menos que
+  `vars.MIGRATE_CONFIG_TO_REPO=true` ja tenha rodado com sucesso (`CONFIG_MIGRATED=true`).
+- O `appsettings.json` do repo tem `Database:Password: ""` (sem segredo). O do servidor
+  tem o valor real, herdado de uma epoca em que a senha era escrita direto no arquivo
+  (antes da migracao para env var) e nunca foi limpo porque o arquivo nunca e tocado.
+- O comentario `@lp-devops` na issue `#112` (2026-09-06) ja confirmou isso lendo o
+  guard-rail do step "Config drift repo x destino": a migracao para
+  `appsettings.Production.json` + `Database__Password` no Environment do servico Windows
+  esta pronta no codigo, mas nunca foi executada — bloqueada por dois pre-requisitos (ver
+  secao seguinte).
+
+**Isso nao e um achado novo desta sessao**, e sim a explicacao factual do sintoma que
+motivou o pedido. Nao mudei o comportamento de preservacao do `appsettings.json` em si —
+ele continua correto pelo motivo documentado (nao pisar em config local antes da
+migracao) —, mas destravei os dois bloqueios que impediam a migracao de rodar.
+
+### 2) Os dois bloqueios da migracao (issue `#112`) — ambos endereçados nesta sessao
+
+1. **Parser do "Config drift" quebrado por comentarios `//` no `appsettings.json`.**
+   `ConvertFrom-Json` do PowerShell nao aceita comentario; o `appsettings.json` do repo
+   tinha `// ...` nas secoes `Database` e `IdentityDatabase` (commit `0a2162b`). O parse
+   falhava silenciosamente (`continue-on-error` + `$ErrorActionPreference = "Continue"`),
+   deixando o mapa do repo vazio e o relatorio de drift mentiroso.
+   **Corrigido:** os comentarios viraram chaves `"_comment"` (mesmo padrao ja usado na
+   secao `Authentication:ServiceClient`) — `appsettings.json` agora e JSON estrito
+   (validado com `json.load`). Como defesa em profundidade, o step de config drift em
+   `deploy.yml` tambem passou a filtrar linhas `^\s*//` antes do `ConvertFrom-Json`, caso
+   um comentario volte a ser introduzido no futuro.
+2. **`Database__Password` nunca provisionado no Environment do servico de producao.** O
+   guard-rail de segredo do step "Config drift" (deploy.yml) aborta a migracao enquanto
+   essa chave divergir do repo sem equivalente no Environment — hoje nao ha secret
+   `DB_PASSWORD_PROD`/`managed['Database__Password']` nenhum em `deploy.yml` (so existe o
+   equivalente `DB_PASSWORD_DEV` no `ci-dev.yml`, para a instancia de dev — banco
+   diferente do de producao).
+   **Adicionado:** o step "Configurar ambiente do servico" em `deploy.yml` passou a
+   aceitar o secret `DB_PASSWORD_PROD` (upsert, mesma semantica das demais chaves — se o
+   secret nao existir, a chave simplesmente nao e gerenciada, nada quebra). **Isto NAO e
+   rotacao** — a credencial do SQL `172.31.249.51` continua sendo compartilhada por
+   ~231.890 times na NDD e permanece fora de cogitacao para rotacao (ver
+   `.claude/rules/security.md`). O secret precisa conter o MESMO valor de senha ja em uso
+   hoje. **Acao pendente do dono** (fora do alcance deste agente, sem acesso ao host de
+   producao): criar o secret `DB_PASSWORD_PROD` em GitHub → Settings → Secrets and
+   variables → Actions, com o valor atual da senha. So depois disso faz sentido reativar
+   `vars.MIGRATE_CONFIG_TO_REPO=true`.
+
+Com os dois bloqueios endereçados, a issue `#112` deixa de estar travada por defeito de
+mecanismo — o unico passo restante e o dono provisionar o secret com o valor real.
+
+### 3) Diretorios de runtime que a API escreve fora do build (mapeados via `Program.cs` e `appsettings.json`)
+
+| Diretorio (config) | Caminho (producao) | Sobrevive a redeploy? |
+|---|---|---|
+| `Logging:File:Directory` | `<deploy>\api\logs` | **Sim** — DENTRO de `api\`, precisa de allowlist explicita |
+| `backups\` (deploy.yml/ci-dev.yml) | `<deploy>\backups` | Sim — IRMAO de `api\`, fora do escopo da limpeza |
+| `ML:LearningDataPath` / `ML:LowCodeTransformationsPath` | `<deploy>\MLData\...` | Sim — movido para fora de `api\` deliberadamente (ver comentario em `deploy.yml`) |
+| `Examples:Path` / `Learning:BasePath` | `<deploy>\Exemplo` | Sim — irmao de `api\` |
+| `XsdValidation:BasePath` / `PdfBasePath` | `<deploy>\xsd`, `<deploy>\pdf` | Sim — irmao de `api\` |
+| `TransformationPipeline:*` (tcl/xsl/Mapeamentro/Examples/LearningModels/ExpectedOutputs) | `<deploy>\tcl`, `\xsl`, etc. | Sim — irmaos de `api\` |
+| `LowCode:SysmiddleDir` / `GlobalFolder` | `<deploy>\sysmiddle`, `\globalfolder` | Sim — irmaos de `api\` |
+| `LayoutParserDecrypt:Path` / `LowCode:RunnerPath` | `<deploy>\api\LayoutParserDecrypt.exe`, `LayoutParserLowCodeRunner.exe` | Recriado a cada deploy (fazem parte do publish/step de runner) |
+| `appsettings.json` / `appsettings.Production.json` | `<deploy>\api\appsettings*.json` | Sim — ja preservado pelo mecanismo existente |
+
+**Conclusao:** quase todo o estado persistente ja vive FORA de `<deploy>\api` (irmaos
+como `backups\`, `MLData\`, `Exemplo\`, `xsd\`, `tcl\`, `xsl\`, `sysmiddle\`,
+`globalfolder\`). O unico item de estado persistente DENTRO de `api\` — a pasta de logs
+(`api\logs`, criada pelo proprio deploy como `api\Logs`) — precisa de allowlist
+explicita numa limpeza de `api\`. Isso simplifica MUITO a estrategia: nao ha diretorio de
+upload/cache oculto dentro de `api\` que precise de tratamento especial alem de
+logs/appsettings.
+
+## Decisao: limpeza seletiva (nao blue-green)
+
+Avaliei duas abordagens:
+
+- **(A) Publicar em staging + swap atomico (blue-green simples)** — mais seguro em
+  teoria (destino nunca fica em estado hibrido), mas exige reescrever o mecanismo de
+  Stop-Service/rollback/backup que ja existe e ja foi endurecido por incidente real
+  (`PR #114`, 2026-08-15 — rollback automatico por falha de smoke test). Trocar essa
+  logica testada por um swap de diretorio novo e um risco desproporcional ao problema
+  reportado (arquivo orfao acumulado), especialmente em producao.
+- **(B) Diff seletivo: remove do destino o que NAO faz parte do publish atual, preservando
+  uma allowlist explicita** — mantem toda a maquina de Stop-Service/backup/rollback
+  existente intacta; adiciona so um passo de limpeza ANTES da copia. Risco limitado ao
+  proprio passo (best-effort, nunca aborta o deploy por falha ao remover um arquivo).
+
+**Escolhida a opcao (B).** Implementada de forma identica nos dois workflows
+(`deploy.yml` e `ci-dev.yml`), no step de copia, logo antes de copiar os arquivos novos:
+
+1. Calcula o conjunto de caminhos relativos que o publish atual vai gravar (comparacao
+   case-insensitive).
+2. Enumera recursivamente os arquivos ja existentes em `<deploy>\api`.
+3. Remove qualquer arquivo existente que **nao** esteja no conjunto novo **e nao** esteja
+   na allowlist:
+   - pasta `Logs`/`logs` inteira (case-insensitive, primeiro nivel) — nunca examinada;
+   - `appsettings.json`, `appsettings.Production.json` (producao) — coerente com o
+     mecanismo de preservacao ja existente;
+   - `appsettings.*.local.json` / `appsettings.Local.json` — mesmo padrao do
+     `.gitignore`, caso alguem tenha colocado um manualmente no servidor.
+4. Remove diretorios vazios remanescentes (cosmetico).
+5. Falha ao remover um arquivo individual e **best-effort** (`Write-Warning`, nao aborta o
+   deploy) — o objetivo e reduzir acumulo, nao e um gate.
+
+Depois da limpeza, o restante do fluxo (copia, backup pre-deploy do binario para
+rollback, Stop/Start-Service, smoke test de readiness, rollback automatico) continua
+**exatamente como estava** — nenhuma dessas partes foi alterada.
+
+## O que NAO mudou (de proposito)
+
+- O mecanismo de preservacao do `appsettings.json` do destino (`-Exclude appsettings.json`
+  / `$preserveAppSettings`) continua o mesmo — a limpeza seletiva reforca essa mesma
+  politica, nao a substitui.
+- Nenhum diretorio irmao de `api\` (`backups\`, `MLData\`, `Exemplo\`, `xsd\`, `tcl\`,
+  `xsl\`, `sysmiddle\`, `globalfolder\` etc.) e tocado — a limpeza e escopada a
+  `<deploy>\api` apenas.
+- O backup pre-deploy do binario atual e o rollback automatico por falha de smoke test
+  (mecanismo do incidente `PR #114`) nao foram alterados.
+
+## Riscos residuais
+
+- A limpeza roda **antes** do backup pre-deploy do binario atual em `deploy.yml`? Nao —
+  o backup (`Backup pre-deploy do binario atual`) roda ANTES do step "Deploy to server
+  (local)" onde a limpeza foi inserida, entao o backup sempre captura o estado anterior
+  intacto, incluindo os arquivos que a limpeza esta prestes a remover. Ordem confirmada
+  lendo o workflow.
+- Se algum servico externo (fora do controle deste repo) gravar arquivos manualmente
+  dentro de `<deploy>\api` fora da allowlist (ex.: alguem copiou um `.exe` auxiliar a mao
+  para testar), a limpeza vai remove-lo no proximo deploy. Isso e o comportamento
+  DESEJADO (destino reprodutivel a partir do repo), mas e uma mudanca de comportamento em
+  relacao a hoje — vale avisar quem opera o host.
+- `ci-dev.yml` roda num runner de dev com menos supervisao — a mesma logica foi aplicada
+  la por consistencia, mas o impacto de um arquivo orfao removido por engano e menor
+  (ambiente de dev).
+
+## Issue #112 — status apos esta sessao
+
+Ambos os pre-requisitos que travavam a ativacao de `vars.MIGRATE_CONFIG_TO_REPO=true`
+foram endereçados no codigo:
+
+1. Parser do config drift tolerante a comentario + `appsettings.json` do repo corrigido
+   para JSON estrito — **feito**.
+2. Canal para provisionar `Database__Password` no Environment do servico de producao
+   (`secret DB_PASSWORD_PROD`) — **adicionado ao workflow**, mas o VALOR precisa ser
+   criado pelo dono (agente nao tem acesso ao host de producao para ler a senha atual).
+
+A ativacao de `MIGRATE_CONFIG_TO_REPO=true` continua sendo uma decisao do dono, a ser
+tomada depois de criar o secret `DB_PASSWORD_PROD` — comentario deixado na issue com este
+resumo.


### PR DESCRIPTION
## Contexto

O deploy hoje (dev e produção) não limpa a pasta de destino antes de implantar — só
sobrescreve/atualiza, deixando arquivos órfãos de versões antigas do repo. Sintoma
concreto: `appsettings.json` de produção tem a senha real do SQL `172.31.249.51`
(`Database:Password`) em texto plano no disco — **não é resíduo manual**, é efeito
documentado do mecanismo de preservação `-Exclude appsettings.json` já existente (a
mesma coisa que travava a #112).

## O que muda

- **Limpeza seletiva de órfãos** (diff-based, não `rm -rf`) em `deploy.yml` e
  `ci-dev.yml`. Investigação confirmou que quase todo estado de runtime já vive fora
  de `<deploy>\api` (`backups\`, `MLData\`, `Exemplo\`, `xsd\`, `tcl\`, `xsl\`,
  `sysmiddle\`, `globalfolder\`) — só foi preciso allowlist para `Logs\`/`logs` e
  `appsettings*.json` dentro de `api\`. O mecanismo de backup/rollback da PR #114
  fica intocado.
- **Corrige o `appsettings.json`**: comentários `//` viram chaves `_comment` — o
  parser de drift (PowerShell `ConvertFrom-Json`) não tolera comentário, então o
  diff calculado hoje é sempre não-confiável.
- **Adiciona suporte opcional ao secret `DB_PASSWORD_PROD`** — não é rotação, é
  provisionar o mesmo valor de senha já em uso como variável de ambiente do serviço.
  Isso destrava o 2º pré-requisito da #112. Provisionamento manual, fora do alcance
  de qualquer agente (precisa de acesso RDP/admin em produção).

Detalhe completo, riscos residuais e decisão documentada em
`docs/architecture/clean-deploy-estrategia-2026-09-07.md`.

## ⚠️ Requer revisão humana antes do merge

Esta PR mexe no pipeline de deploy de **produção**. Build local validado
(`dotnet build`, 0 erros), mas não é merge automático de rotina — pede revisão
explícita do dono antes de mergear, dado o raio de impacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)