### PR TITLE
feat(transformation): DocumentId estável em execute-candidates (ADR correção humana)

### DIFF
--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -377,6 +377,16 @@ namespace LayoutParserApi.Controllers
                 recommendedId = bestScored?.CandidateId ?? candidates[0].CandidateId;
             }
 
+            // DocumentId (ADR docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md §4,
+            // Gap 1): identificador estável derivado de hash, mesma resolução de LayoutGuid já usada
+            // pelo pathway sysmiddle (request.LayoutGuid tem precedência sobre o catálogo, que pode
+            // vir Guid.Empty). Quando nenhum dos dois resolve, cai no LayoutGuid cru do catálogo —
+            // ainda determinístico, nunca lança.
+            var resolvedLayoutGuidForDocumentId =
+                LowCodeLayoutGuidResolver.Resolve(request.LayoutGuid, layoutRecord.LayoutGuid)
+                ?? layoutRecord.LayoutGuid.ToString();
+            var documentId = DocumentIdCalculator.Calculate(request.InputContent, resolvedLayoutGuidForDocumentId);
+
             return Ok(new TransformationExecutionCandidatesResponse
             {
                 Success = true,
@@ -386,7 +396,8 @@ namespace LayoutParserApi.Controllers
                 // pathwayDiagnostics (Issue #86): populado na origem por cada pathway (sysmiddle,
                 // tcl-xsl, ai-fallback) — ver docs/architecture/diagnostico-issue-86-*.md §4.
                 PathwayDiagnostics = pathwayDiagnostics.ToList(),
-                CorrelationId = Services.Logging.CorrelationContext.CurrentId
+                CorrelationId = Services.Logging.CorrelationContext.CurrentId,
+                DocumentId = documentId
             });
         }
 

--- a/Models/Transformation/TransformationCandidate.cs
+++ b/Models/Transformation/TransformationCandidate.cs
@@ -84,5 +84,13 @@ namespace LayoutParserApi.Models.Transformation
         /// <summary>CorrelationId da request (<see cref="LayoutParserApi.Services.Logging.CorrelationContext.CurrentId"/>),
         /// permite ao suporte cruzar com o log estruturado completo (não sanitizado) desta chamada.</summary>
         public string? CorrelationId { get; set; }
+
+        /// <summary>Identificador estável do documento (ADR docs/architecture/adr-contrato-correcao-
+        /// guiada-humano-2026-09-08.md §4, Gap 1) — "doc_" + SHA256(InputContent + "|" +
+        /// resolvedLayoutGuid) truncado a 16 hex. Determinístico: mesmo InputContent + mesmo
+        /// LayoutGuid resolvido sempre produzem o mesmo valor. Usado pelo front para futuramente
+        /// referenciar este documento num reporte de correção humana (endpoint ainda não
+        /// implementado — só o identificador, campo aditivo).</summary>
+        public string? DocumentId { get; set; }
     }
 }

--- a/Services/Transformation/LowCode/DocumentIdCalculator.cs
+++ b/Services/Transformation/LowCode/DocumentIdCalculator.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LayoutParserApi.Services.Transformation.LowCode
+{
+    /// <summary>
+    /// Calcula o <c>DocumentId</c> estável descrito no ADR de correção guiada por humano
+    /// (docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md §4, Gap 1).
+    /// Determinístico: mesmo <c>InputContent</c> + mesmo <c>resolvedLayoutGuid</c> sempre produzem
+    /// o mesmo id — reenviar o mesmo documento não cria identificadores diferentes.
+    /// </summary>
+    public static class DocumentIdCalculator
+    {
+        /// <summary>
+        /// <c>DocumentId = "doc_" + SHA256(InputContent + "|" + resolvedLayoutGuid)[:16]</c> (hex minúsculo).
+        /// </summary>
+        public static string Calculate(string inputContent, string resolvedLayoutGuid)
+        {
+            var raw = (inputContent ?? string.Empty) + "|" + (resolvedLayoutGuid ?? string.Empty);
+            var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+            var hex = Convert.ToHexString(hashBytes).ToLowerInvariant();
+            return "doc_" + hex[..16];
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Transformation/DocumentIdCalculatorTests.cs
+++ b/tests/LayoutParserApi.Tests/Transformation/DocumentIdCalculatorTests.cs
@@ -1,0 +1,48 @@
+using LayoutParserApi.Services.Transformation.LowCode;
+
+namespace LayoutParserApi.Tests.Transformation
+{
+    /// <summary>
+    /// Cobre o contrato do ADR docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md
+    /// §4 (Gap 1): DocumentId precisa ser determinístico por (InputContent, resolvedLayoutGuid).
+    /// </summary>
+    public class DocumentIdCalculatorTests
+    {
+        [Fact]
+        public void Mesmo_conteudo_e_layoutGuid_produz_sempre_o_mesmo_DocumentId()
+        {
+            var first = DocumentIdCalculator.Calculate("conteudo-do-documento", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+            var second = DocumentIdCalculator.Calculate("conteudo-do-documento", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void DocumentId_tem_prefixo_doc_e_16_caracteres_hex_apos_o_prefixo()
+        {
+            var documentId = DocumentIdCalculator.Calculate("conteudo", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+
+            Assert.StartsWith("doc_", documentId);
+            Assert.Equal(20, documentId.Length); // "doc_" (4) + 16 hex chars
+            Assert.Matches("^doc_[0-9a-f]{16}$", documentId);
+        }
+
+        [Fact]
+        public void InputContent_diferente_produz_DocumentId_diferente()
+        {
+            var first = DocumentIdCalculator.Calculate("conteudo-A", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+            var second = DocumentIdCalculator.Calculate("conteudo-B", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+
+            Assert.NotEqual(first, second);
+        }
+
+        [Fact]
+        public void LayoutGuid_diferente_produz_DocumentId_diferente()
+        {
+            var first = DocumentIdCalculator.Calculate("conteudo", "LAY_4f7c625a-a089-4b42-a874-48da13b0d88b");
+            var second = DocumentIdCalculator.Calculate("conteudo", "LAY_0000625a-a089-4b42-a874-48da13b0d88b");
+
+            Assert.NotEqual(first, second);
+        }
+    }
+}


### PR DESCRIPTION
Sub-entrega da issue #345 (contrato de correção humana, ADR `docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md`) — só o `DocumentId`, item que bloqueia diretamente `LayoutParserReact#234`.

## O que faz
- `DocumentIdCalculator` (novo): `doc_` + SHA256(InputContent + "|" + resolvedLayoutGuid), truncado a 16 hex — determinístico, reusa `LowCodeLayoutGuidResolver` (mesma resolução já usada no pathway sysmiddle).
- Campo aditivo `DocumentId` em `TransformationExecutionCandidatesResponse` — não muda nenhum comportamento existente.
- `ExecuteTransformationCandidates` calcula e inclui no response.

## Testes
4/4 novos (`DocumentIdCalculatorTests.cs`) — determinismo (mesmo input+layout = mesmo id) e variação (input ou layout diferentes = id diferente). `dotnet build` limpo.

## Escopo
Só o `DocumentId` — endpoint `POST /api/transformation/field-correction` e persistência `tbFieldCorrectionContext` (resto da #345) ficam para PR separada.

Já avisado ao time do React (`LayoutParserReact#234`) que a implementação está pronta, aguardando merge/deploy antes de confiarem no campo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)