### PR TITLE
Promove develop -> master: endpoint field-correction (issue #345)

### DIFF
--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -19,6 +19,7 @@ using LayoutParserApi.Services.Filters;
 using LayoutParserApi.Models.Database;
 using LayoutParserApi.Models.Transformation;
 using LayoutParserApi.Models.Parsing;
+using LayoutParserApi.Models.Fiscal;
 
 using XslSynth.Core;
 
@@ -57,6 +58,7 @@ namespace LayoutParserApi.Controllers
         private readonly FieldMappingCompositionService _fieldMappingComposition;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly Services.Security.ICanaryAlertService _canaryAlert;
+        private readonly IFieldCorrectionStore _fieldCorrectionStore;
 
         public TransformationExecutionController(
             ILogger<TransformationExecutionController> logger,
@@ -77,7 +79,8 @@ namespace LayoutParserApi.Controllers
             ILayoutParserService layoutParser,
             FieldMappingCompositionService fieldMappingComposition,
             IServiceScopeFactory scopeFactory,
-            Services.Security.ICanaryAlertService canaryAlert)
+            Services.Security.ICanaryAlertService canaryAlert,
+            IFieldCorrectionStore fieldCorrectionStore)
         {
             _logger = logger;
             _pipelineService = pipelineService;
@@ -98,6 +101,7 @@ namespace LayoutParserApi.Controllers
             _fieldMappingComposition = fieldMappingComposition;
             _scopeFactory = scopeFactory;
             _canaryAlert = canaryAlert;
+            _fieldCorrectionStore = fieldCorrectionStore;
         }
 
         // Issue #92: chave de particionamento da AiCandidateStore. ICurrentUser.Name é null quando
@@ -387,6 +391,11 @@ namespace LayoutParserApi.Controllers
                 ?? layoutRecord.LayoutGuid.ToString();
             var documentId = DocumentIdCalculator.Calculate(request.InputContent, resolvedLayoutGuidForDocumentId);
 
+            // tbFieldCorrectionContext (issue #345, ADR §4/§7): gravação best-effort, fire-and-forget —
+            // nunca atrasa nem derruba esta resposta. Habilita o futuro POST field-correction a
+            // resolver documentId -> contexto do documento.
+            TryPersistFieldCorrectionContext(request, layoutRecord, candidates, documentId, resolvedLayoutGuidForDocumentId);
+
             return Ok(new TransformationExecutionCandidatesResponse
             {
                 Success = true,
@@ -398,6 +407,144 @@ namespace LayoutParserApi.Controllers
                 PathwayDiagnostics = pathwayDiagnostics.ToList(),
                 CorrelationId = Services.Logging.CorrelationContext.CurrentId,
                 DocumentId = documentId
+            });
+        }
+
+        /// <summary>
+        /// Best-effort (issue #345, ADR §4/§7): grava <c>tbFieldCorrectionContext</c> com o
+        /// documentId já calculado, o gabarito sysmiddle quando existir (primeiro candidato do
+        /// pathway sysmiddle) e o LayoutGuid/Name resolvidos. Mapper/GroundTruth ficam <c>null</c>
+        /// quando a request não produziu candidato sysmiddle (ex.: entrada XML) — reporte de
+        /// correção continua possível, só sem o gabarito ao lado. Fire-and-forget: qualquer falha
+        /// (IdentityDatabase indisponível etc.) vira log, nunca afeta a resposta síncrona já calculada.
+        /// </summary>
+        private void TryPersistFieldCorrectionContext(
+            TransformationRequest request, LayoutRecord layoutRecord, List<TransformationCandidate> candidates,
+            string documentId, string resolvedLayoutGuid)
+        {
+            var sysmiddleCandidate = candidates.FirstOrDefault(c => c.Pathway == "sysmiddle" && !string.IsNullOrEmpty(c.TransformedXml));
+            var mapperGuid = sysmiddleCandidate != null && sysmiddleCandidate.CandidateId.StartsWith("sysmiddle-", StringComparison.Ordinal)
+                ? sysmiddleCandidate.CandidateId["sysmiddle-".Length..]
+                : null;
+            var groundTruthXml = sysmiddleCandidate?.TransformedXml;
+            var layoutName = request.LayoutName;
+            var inputContent = request.InputContent;
+            var safeLayoutNameForLog = Services.Logging.LogMessageSanitizer.Sanitize(layoutName);
+
+            // ✅ Mesmo padrão de TryEnqueueAiCandidate: Task.Run + CancellationToken.None, sobrevive
+            // ao fim da request HTTP; IFieldCorrectionStore é Scoped, então precisa de scope próprio.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var scopedStore = scope.ServiceProvider.GetRequiredService<IFieldCorrectionStore>();
+                    await scopedStore.SaveContextAsync(
+                        new FieldCorrectionContext(
+                            documentId,
+                            mapperGuid,
+                            MapperName: null, // não disponível neste ponto sem consulta SQL adicional — best-effort, campo aditivo.
+                            resolvedLayoutGuid,
+                            layoutName,
+                            inputContent,
+                            groundTruthXml,
+                            DateTimeOffset.UtcNow),
+                        CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Falha ao persistir tbFieldCorrectionContext (best-effort) para documentId={DocumentId} layout={LayoutName}",
+                        documentId, safeLayoutNameForLog);
+                }
+            }, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Issue #345 (ADR docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md §3/§5/§7):
+        /// reporte de correção humana de um campo divergente. Assíncrono por design — não
+        /// re-executa nenhum pathway nem chama Ollama no request; só valida, resolve o contexto
+        /// via <c>documentId</c> e persiste com <c>Status = pending</c> (curadoria humana é a Issue 2,
+        /// fora do escopo aqui). Fail-closed via <c>_currentUser.UserId</c>, mesmo padrão de
+        /// <see cref="MappingGovernanceController"/> — sem identidade resolvida, <c>404</c> (não
+        /// <c>401</c>), para não distinguir "recurso inexistente" de "sem permissão".
+        /// </summary>
+        /// <param name="request">
+        /// <c>documentId</c>/<c>candidateId</c>/<c>fieldPath</c>/<c>observedValue</c>/<c>expectedValue</c>
+        /// obrigatórios; <c>justification</c> e <c>documentType</c> (só telemetria) opcionais.
+        /// </param>
+        /// <response code="202">Reporte registrado — <c>{ reportId, status: "queued", message }</c>.</response>
+        /// <response code="400">Campo obrigatório ausente.</response>
+        /// <response code="404">
+        /// Sem identidade resolvida, OU <c>documentId</c> não resolve contexto persistido (mensagem
+        /// pede para reenviar o parse — contexto pode ter expirado, gravação best-effort pode ter
+        /// falhado, ou o id nunca existiu).
+        /// </response>
+        [Authorize]
+        [HttpPost("field-correction")]
+        public async Task<IActionResult> ReportFieldCorrection([FromBody] FieldCorrectionRequest request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound(); // fail-closed, mesmo padrão de MappingGovernanceController.
+
+            if (request == null || string.IsNullOrWhiteSpace(request.DocumentId))
+                return BadRequest(new { success = false, error = "documentId é obrigatório" });
+            if (string.IsNullOrWhiteSpace(request.CandidateId))
+                return BadRequest(new { success = false, error = "candidateId é obrigatório" });
+            if (string.IsNullOrWhiteSpace(request.FieldPath))
+                return BadRequest(new { success = false, error = "fieldPath é obrigatório" });
+            if (string.IsNullOrWhiteSpace(request.ObservedValue))
+                return BadRequest(new { success = false, error = "observedValue é obrigatório" });
+            if (string.IsNullOrWhiteSpace(request.ExpectedValue))
+                return BadRequest(new { success = false, error = "expectedValue é obrigatório" });
+
+            FieldCorrectionContext? context;
+            try
+            {
+                context = await _fieldCorrectionStore.GetContextAsync(request.DocumentId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Diferente da gravação (best-effort, nunca falha), a LEITURA aqui é o caminho crítico
+                // do endpoint — se o IdentityDatabase estiver fora do ar, não há como resolver o
+                // documentId, então degrada para 404 (mesma mensagem do caso "nunca existiu"), nunca
+                // deixa a exceção subir.
+                _logger.LogWarning(ex, "Falha ao consultar tbFieldCorrectionContext para documentId={DocumentId}", request.DocumentId);
+                context = null;
+            }
+
+            if (context == null)
+                return NotFound(new { success = false, error = "contexto do documento expirado — reenvie o parse para reportar uma correção" });
+
+            Guid reportId;
+            try
+            {
+                reportId = await _fieldCorrectionStore.CreateReportAsync(
+                    new FieldCorrectionReportInput(
+                        request.DocumentId,
+                        request.CandidateId,
+                        request.FieldPath,
+                        request.ObservedValue,
+                        request.ExpectedValue,
+                        request.Justification),
+                    userId,
+                    cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao persistir tbFieldCorrectionReport para documentId={DocumentId}", request.DocumentId);
+                return StatusCode(500, new { success = false, error = "Falha de infraestrutura ao registrar a correção" });
+            }
+
+            _logger.LogInformation(
+                "Correção humana registrada: reportId={ReportId} documentId={DocumentId} candidateId={CandidateId} usuario={UserId}",
+                reportId, request.DocumentId, Services.Logging.LogMessageSanitizer.Sanitize(request.CandidateId), userId);
+
+            return Accepted(new
+            {
+                reportId,
+                status = "queued",
+                message = "Correção registrada. Será usada para refinar o modelo em treinos futuros."
             });
         }
 
@@ -1453,5 +1600,21 @@ namespace LayoutParserApi.Controllers
         public string? Package { get; set; }
         public string? GlobalFolder { get; set; }
         public string? SysmiddleDir { get; set; }
+    }
+
+    /// <summary>
+    /// Request de <c>POST field-correction</c> (issue #345, ADR §7). <c>documentId</c>/<c>candidateId</c>
+    /// vêm da resposta de <c>execute-candidates</c>; <c>documentType</c> é opcional e usado só para
+    /// telemetria — nunca prevalece sobre o <c>layoutGuid</c> resolvido no contexto persistido.
+    /// </summary>
+    public class FieldCorrectionRequest
+    {
+        public string DocumentId { get; set; } = "";
+        public string CandidateId { get; set; } = "";
+        public string FieldPath { get; set; } = "";
+        public string ObservedValue { get; set; } = "";
+        public string ExpectedValue { get; set; } = "";
+        public string? Justification { get; set; }
+        public string? DocumentType { get; set; }
     }
 }

--- a/Models/Fiscal/FieldCorrection.cs
+++ b/Models/Fiscal/FieldCorrection.cs
@@ -1,0 +1,44 @@
+namespace LayoutParserApi.Models.Fiscal
+{
+    /// <summary>
+    /// Contexto mínimo de um documento processado por <c>execute-candidates</c>, persistido
+    /// best-effort para permitir um reporte de correção humana posterior (ADR
+    /// docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md §4/§7, issue #345).
+    /// <c>MapperGuid</c>/<c>MapperName</c>/<c>GroundTruthXml</c> são nulos quando a request não
+    /// produziu candidato sysmiddle (ex.: entrada XML, ou layout sem mapper cadastrado) — o
+    /// reporte de correção ainda é possível, só sem o gabarito sysmiddle ao lado.
+    /// </summary>
+    public sealed record FieldCorrectionContext(
+        string DocumentId,
+        string? MapperGuid,
+        string? MapperName,
+        string LayoutGuid,
+        string LayoutName,
+        string InputXml,
+        string? GroundTruthXml,
+        DateTimeOffset CreatedAtUtc);
+
+    /// <summary>
+    /// Dados de entrada para <see cref="LayoutParserApi.Services.Interfaces.IFieldCorrectionStore.CreateReportAsync"/> —
+    /// já validados pelo controller, autoria (<c>ReportedByUserId</c>) resolvida separadamente via
+    /// <c>ICurrentUser</c>.
+    /// </summary>
+    public sealed record FieldCorrectionReportInput(
+        string DocumentId,
+        string CandidateId,
+        string FieldPath,
+        string ObservedValue,
+        string ExpectedValue,
+        string? Justification);
+
+    /// <summary>
+    /// Status do ciclo de vida de um reporte (ADR §6): nunca vira dado de treino direto —
+    /// exige curadoria humana (issue 2, fora do escopo desta issue #345).
+    /// </summary>
+    public static class FieldCorrectionReportStatus
+    {
+        public const string Pending = "pending";
+        public const string ReviewedAccepted = "reviewed_accepted";
+        public const string ReviewedRejected = "reviewed_rejected";
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -507,6 +507,9 @@ try
     // Lab. Mesmo banco/padrão ADO.NET; compile/test-run reaproveitam CanonicalDiffer/XsdValidationService
     // (já registrados/disponíveis via DI) sem I/O externo/Ollama.
     builder.Services.AddScoped<IMappingReleaseStore, SqlMappingReleaseStore>();
+    // ✅ Issue #345 (ADR docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md):
+    // contexto de documento + reporte de correção humana — mesmo banco/padrão ADO.NET.
+    builder.Services.AddScoped<LayoutParserApi.Services.Interfaces.IFieldCorrectionStore, LayoutParserApi.Services.Database.SqlFieldCorrectionStore>();
     // ✅ Investigação PR #310 (2026-09-05): schema fiscal criado em ordem de dependência de FK no
     // startup, em vez de depender de qual store acima uma requisição real exercita primeiro. Ver
     // <see cref="LayoutParserApi.Services.Database.FiscalSchemaInitializer"/> para o grafo completo.

--- a/Services/Database/FiscalSchemaInitializer.cs
+++ b/Services/Database/FiscalSchemaInitializer.cs
@@ -75,6 +75,9 @@ namespace LayoutParserApi.Services.Database
                 await SqlMappingReleaseStore.EnsureSchemaAsync(connection, cancellationToken);
                 await SqlIdentityWorkspaceStore.EnsureSchemaAsync(connection, cancellationToken);
                 await SqlAiUserSessionStore.EnsureSchemaAsync(connection, cancellationToken);
+                // ✅ Issue #345: tbFieldCorrectionContext/tbFieldCorrectionReport — autossuficientes
+                // (sem FK para as tabelas acima, ver comentário em SqlFieldCorrectionStore.SchemaDdl).
+                await SqlFieldCorrectionStore.EnsureSchemaAsync(connection, cancellationToken);
 
                 _logger.LogInformation("Schema fiscal e de identidade (IdentityDatabase:*) inicializado com sucesso no startup, em ordem de dependência de FK.");
             }

--- a/Services/Database/SqlFieldCorrectionStore.cs
+++ b/Services/Database/SqlFieldCorrectionStore.cs
@@ -1,0 +1,168 @@
+using LayoutParserApi.Models.Fiscal;
+using LayoutParserApi.Services.Interfaces;
+
+using Microsoft.Data.SqlClient;
+
+namespace LayoutParserApi.Services.Database
+{
+    /// <summary>
+    /// Implementação SQL de <see cref="IFieldCorrectionStore"/> — issue #345, ADR
+    /// docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md. Banco DEDICADO do
+    /// projeto (<c>IdentityDatabase:*</c>), mesmo padrão ADO.NET cru de <see cref="SqlMappingDraftStore"/>.
+    /// </summary>
+    public sealed class SqlFieldCorrectionStore : IFieldCorrectionStore
+    {
+        private readonly ILogger<SqlFieldCorrectionStore> _logger;
+        private readonly string _connectionString;
+
+        private static bool _schemaEnsured;
+        private static readonly SemaphoreSlim _schemaLock = new(1, 1);
+
+        public SqlFieldCorrectionStore(ILogger<SqlFieldCorrectionStore> logger, IConfiguration configuration)
+        {
+            _logger = logger;
+            var server = configuration["IdentityDatabase:Server"];
+            var database = configuration["IdentityDatabase:Database"];
+            var userId = configuration["IdentityDatabase:UserId"];
+            var password = configuration["IdentityDatabase:Password"];
+
+            _connectionString = $"Server={server};Database={database};User Id={userId};Password={password};TrustServerCertificate=True;";
+        }
+
+        public async Task SaveContextAsync(FieldCorrectionContext context, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            // Idempotente por DocumentId (determinístico — ver DocumentIdCalculator): reenviar o
+            // mesmo documento não sobrescreve a linha já gravada (preserva o primeiro contexto visto).
+            using var command = new SqlCommand(
+                @"IF NOT EXISTS (SELECT 1 FROM dbo.tbFieldCorrectionContext WHERE DocumentId = @DocumentId)
+                  INSERT INTO dbo.tbFieldCorrectionContext
+                      (DocumentId, MapperGuid, MapperName, LayoutGuid, LayoutName, InputXml, GroundTruthXml, CreatedAtUtc)
+                  VALUES
+                      (@DocumentId, @MapperGuid, @MapperName, @LayoutGuid, @LayoutName, @InputXml, @GroundTruthXml, SYSUTCDATETIME());",
+                connection);
+            command.Parameters.AddWithValue("@DocumentId", context.DocumentId);
+            command.Parameters.AddWithValue("@MapperGuid", (object?)context.MapperGuid ?? DBNull.Value);
+            command.Parameters.AddWithValue("@MapperName", (object?)context.MapperName ?? DBNull.Value);
+            command.Parameters.AddWithValue("@LayoutGuid", context.LayoutGuid);
+            command.Parameters.AddWithValue("@LayoutName", context.LayoutName);
+            command.Parameters.AddWithValue("@InputXml", context.InputXml);
+            command.Parameters.AddWithValue("@GroundTruthXml", (object?)context.GroundTruthXml ?? DBNull.Value);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        public async Task<FieldCorrectionContext?> GetContextAsync(string documentId, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var command = new SqlCommand(
+                @"SELECT DocumentId, MapperGuid, MapperName, LayoutGuid, LayoutName, InputXml, GroundTruthXml, CreatedAtUtc
+                  FROM dbo.tbFieldCorrectionContext WHERE DocumentId = @DocumentId;",
+                connection);
+            command.Parameters.AddWithValue("@DocumentId", documentId);
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+                return null;
+
+            return new FieldCorrectionContext(
+                reader.GetString(reader.GetOrdinal("DocumentId")),
+                reader.IsDBNull(reader.GetOrdinal("MapperGuid")) ? null : reader.GetString(reader.GetOrdinal("MapperGuid")),
+                reader.IsDBNull(reader.GetOrdinal("MapperName")) ? null : reader.GetString(reader.GetOrdinal("MapperName")),
+                reader.GetString(reader.GetOrdinal("LayoutGuid")),
+                reader.GetString(reader.GetOrdinal("LayoutName")),
+                reader.GetString(reader.GetOrdinal("InputXml")),
+                reader.IsDBNull(reader.GetOrdinal("GroundTruthXml")) ? null : reader.GetString(reader.GetOrdinal("GroundTruthXml")),
+                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("CreatedAtUtc")), TimeSpan.Zero));
+        }
+
+        public async Task<Guid> CreateReportAsync(FieldCorrectionReportInput input, Guid reportedByUserId, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            var reportId = Guid.NewGuid();
+            using var command = new SqlCommand(
+                @"INSERT INTO dbo.tbFieldCorrectionReport
+                    (ReportId, DocumentId, CandidateId, FieldPath, ObservedValue, ExpectedValue, Justification, ReportedByUserId, Status, CreatedAtUtc)
+                  VALUES
+                    (@ReportId, @DocumentId, @CandidateId, @FieldPath, @ObservedValue, @ExpectedValue, @Justification, @ReportedByUserId, @Status, SYSUTCDATETIME());",
+                connection);
+            command.Parameters.AddWithValue("@ReportId", reportId);
+            command.Parameters.AddWithValue("@DocumentId", input.DocumentId);
+            command.Parameters.AddWithValue("@CandidateId", input.CandidateId);
+            command.Parameters.AddWithValue("@FieldPath", input.FieldPath);
+            command.Parameters.AddWithValue("@ObservedValue", (object?)input.ObservedValue ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ExpectedValue", (object?)input.ExpectedValue ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Justification", (object?)input.Justification ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ReportedByUserId", reportedByUserId);
+            command.Parameters.AddWithValue("@Status", FieldCorrectionReportStatus.Pending);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+
+            return reportId;
+        }
+
+        // ✅ Sem FK entre tbFieldCorrectionReport.DocumentId e tbFieldCorrectionContext.DocumentId
+        // (deliberado): o ADR já prevê um cron futuro de retenção/TTL sobre o contexto (§4, "fora de
+        // escopo deste ADR") — uma FK travaria essa limpeza. O controller já garante a existência do
+        // contexto (404 se ausente) antes de criar o reporte, então a integridade é aplicada em
+        // aplicação, não em schema.
+        public static readonly string SchemaDdl = @"
+IF OBJECT_ID('dbo.tbFieldCorrectionContext', 'U') IS NULL
+CREATE TABLE dbo.tbFieldCorrectionContext (
+    DocumentId NVARCHAR(32) NOT NULL PRIMARY KEY,
+    MapperGuid NVARCHAR(64) NULL,
+    MapperName NVARCHAR(256) NULL,
+    LayoutGuid NVARCHAR(64) NOT NULL,
+    LayoutName NVARCHAR(256) NOT NULL,
+    InputXml NVARCHAR(MAX) NOT NULL,
+    GroundTruthXml NVARCHAR(MAX) NULL,
+    CreatedAtUtc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);
+
+IF OBJECT_ID('dbo.tbFieldCorrectionReport', 'U') IS NULL
+CREATE TABLE dbo.tbFieldCorrectionReport (
+    ReportId UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
+    DocumentId NVARCHAR(32) NOT NULL,
+    CandidateId NVARCHAR(128) NOT NULL,
+    FieldPath NVARCHAR(1024) NOT NULL,
+    ObservedValue NVARCHAR(MAX) NULL,
+    ExpectedValue NVARCHAR(MAX) NULL,
+    Justification NVARCHAR(2000) NULL,
+    ReportedByUserId UNIQUEIDENTIFIER NOT NULL,
+    Status NVARCHAR(24) NOT NULL DEFAULT 'pending',
+    CreatedAtUtc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    ReviewedByUserId UNIQUEIDENTIFIER NULL,
+    ReviewedAtUtc DATETIME2 NULL
+);
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbFieldCorrectionReport_DocumentId' AND object_id = OBJECT_ID('dbo.tbFieldCorrectionReport'))
+CREATE INDEX IX_tbFieldCorrectionReport_DocumentId ON dbo.tbFieldCorrectionReport(DocumentId);";
+
+        internal static async Task EnsureSchemaAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            if (_schemaEnsured)
+                return;
+
+            await _schemaLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_schemaEnsured)
+                    return;
+
+                using var command = new SqlCommand(SchemaDdl, connection);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+                _schemaEnsured = true;
+            }
+            finally
+            {
+                _schemaLock.Release();
+            }
+        }
+    }
+}

--- a/Services/Interfaces/IFieldCorrectionStore.cs
+++ b/Services/Interfaces/IFieldCorrectionStore.cs
@@ -1,0 +1,26 @@
+using LayoutParserApi.Models.Fiscal;
+
+namespace LayoutParserApi.Services.Interfaces
+{
+    /// <summary>
+    /// Persistência do contrato de correção guiada por humano (ADR
+    /// docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md, issue #345):
+    /// contexto de documento (gravado best-effort em <c>execute-candidates</c>) + reportes de
+    /// campo divergente (gravados por <c>POST field-correction</c>). Banco <c>IdentityDatabase:*</c>
+    /// — nunca <c>Database:*</c>/172.31.249.51 (ver .claude/rules/security.md).
+    /// </summary>
+    public interface IFieldCorrectionStore
+    {
+        /// <summary>
+        /// Grava o contexto do documento — idempotente por <c>DocumentId</c> (determinístico):
+        /// reenviar o mesmo documento não sobrescreve nem duplica a linha já gravada.
+        /// </summary>
+        Task SaveContextAsync(FieldCorrectionContext context, CancellationToken cancellationToken);
+
+        /// <summary>Retorna <c>null</c> quando o contexto nunca foi gravado ou já expirou (fora de escopo desta issue).</summary>
+        Task<FieldCorrectionContext?> GetContextAsync(string documentId, CancellationToken cancellationToken);
+
+        /// <summary>Cria o reporte com <c>Status = pending</c> (ADR §6) e retorna o <c>ReportId</c> gerado.</summary>
+        Task<Guid> CreateReportAsync(FieldCorrectionReportInput input, Guid reportedByUserId, CancellationToken cancellationToken);
+    }
+}

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
@@ -142,7 +142,8 @@ namespace LayoutParserApi.Tests.Controllers
                 fieldMappingComposition: null!,
                 scopeFactory: scopeProvider.GetRequiredService<IServiceScopeFactory>(),
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
-                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance));
+                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
+                fieldCorrectionStore: null!);
 
             var request = new TransformationRequest
             {

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
@@ -1,0 +1,308 @@
+using System.Reflection;
+
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Models;
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Fiscal;
+using LayoutParserApi.Models.Transformation;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.Ai;
+using LayoutParserApi.Services.Transformation.LowCode;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Controllers
+{
+    /// <summary>
+    /// Issue #345 (ADR docs/architecture/adr-contrato-correcao-guiada-humano-2026-09-08.md): cobre
+    /// (1) a gravação best-effort de <c>tbFieldCorrectionContext</c> em <c>execute-candidates</c>
+    /// (via reflection sobre o método privado, mesma técnica já usada por
+    /// <see cref="TransformationExecutionControllerUserIsolationTests"/> para
+    /// <c>TryEnqueueAiCandidate</c> — rodar o método público inteiro exigiria o runner x86 real) e
+    /// (2) o endpoint público <c>POST field-correction</c> ponta-a-ponta contra um
+    /// <see cref="IFieldCorrectionStore"/> fake em memória.
+    /// </summary>
+    public class TransformationExecutionControllerFieldCorrectionTests
+    {
+        private sealed class FakeCurrentUser : ICurrentUser
+        {
+            public string? Name { get; set; } = "tester";
+            public IReadOnlyList<string> Roles { get; set; } = Array.Empty<string>();
+            public bool IsAuthenticated => UserId != null;
+            public bool IsInRole(string role) => Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+            public Guid? UserId { get; set; } = Guid.NewGuid();
+        }
+
+        /// <summary>Fake em memória — nunca toca em SQL real, cobre os 3 métodos de <see cref="IFieldCorrectionStore"/>.</summary>
+        private sealed class FakeFieldCorrectionStore : IFieldCorrectionStore
+        {
+            public FieldCorrectionContext? SavedContext { get; private set; }
+            public bool ThrowOnGetContext { get; set; }
+            public List<(FieldCorrectionReportInput Input, Guid ReportedByUserId)> CreatedReports { get; } = new();
+
+            public Task SaveContextAsync(FieldCorrectionContext context, CancellationToken cancellationToken)
+            {
+                SavedContext = context;
+                return Task.CompletedTask;
+            }
+
+            public Task<FieldCorrectionContext?> GetContextAsync(string documentId, CancellationToken cancellationToken)
+            {
+                if (ThrowOnGetContext)
+                    throw new InvalidOperationException("IdentityDatabase indisponível (simulado)");
+
+                return Task.FromResult(SavedContext != null && SavedContext.DocumentId == documentId ? SavedContext : null);
+            }
+
+            public Task<Guid> CreateReportAsync(FieldCorrectionReportInput input, Guid reportedByUserId, CancellationToken cancellationToken)
+            {
+                CreatedReports.Add((input, reportedByUserId));
+                return Task.FromResult(Guid.NewGuid());
+            }
+        }
+
+        private static (TransformationExecutionController Controller, FakeFieldCorrectionStore Store, FakeCurrentUser User) BuildController()
+        {
+            var store = new FakeFieldCorrectionStore();
+            var user = new FakeCurrentUser();
+
+            // scopeFactory real (necessário: TryPersistFieldCorrectionContext abre um IServiceScope
+            // próprio dentro do Task.Run, mesmo padrão de TryEnqueueAiCandidate) resolvendo o MESMO
+            // fake singleton, para o teste poder inspecionar o que foi gravado.
+            var services = new ServiceCollection();
+            services.AddSingleton<IFieldCorrectionStore>(store);
+            var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+            var controller = new TransformationExecutionController(
+                NullLogger<TransformationExecutionController>.Instance,
+                pipelineService: null!,
+                validatorService: null!,
+                learningService: null!,
+                autoGenerator: null!,
+                lowCode: null!,
+                lowCodeAuto: null!,
+                layoutDb: null!,
+                lowCodeOptions: Options.Create(new LowCodeRunnerOptions()),
+                aiCandidateService: new NoopAiCandidateService(),
+                aiFallbackGate: new NoopAiFallbackSuppressionGate(),
+                aiUserInstructionStore: new AiUserInstructionStore(),
+                aiUserSessionStore: null!,
+                currentUser: user,
+                mapperDb: null!,
+                layoutParser: null!,
+                fieldMappingComposition: null!,
+                scopeFactory: scopeFactory,
+                canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
+                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
+                fieldCorrectionStore: store);
+
+            return (controller, store, user);
+        }
+
+        private sealed class NoopAiCandidateService : IAiTransformationCandidateService
+        {
+            public Task EnqueueAsync(
+                string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
+                string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
+                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
+
+            public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
+                Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });
+        }
+
+        private sealed class NoopAiFallbackSuppressionGate : IAiFallbackSuppressionGate
+        {
+            public bool IsInCooldown(Guid layoutGuid, out DateTimeOffset retryAt)
+            {
+                retryAt = default;
+                return false;
+            }
+
+            public void RegisterFailure(Guid layoutGuid, TimeSpan cooldown) { }
+            public void ClearCooldown(Guid layoutGuid) { }
+        }
+
+        // --- TryPersistFieldCorrectionContext (best-effort, chamado de dentro de execute-candidates) ---
+
+        [Fact]
+        public async Task TryPersistFieldCorrectionContext_grava_gabarito_sysmiddle_quando_existe()
+        {
+            var (controller, store, _) = BuildController();
+
+            var request = new TransformationRequest { InputContent = "linha-txt", LayoutName = "LAYOUT_X" };
+            var layoutGuid = Guid.NewGuid();
+            var layoutRecord = new LayoutRecord { LayoutGuid = layoutGuid, Name = request.LayoutName };
+            var mapperGuid = Guid.NewGuid().ToString();
+            var candidates = new List<TransformationCandidate>
+            {
+                new TransformationCandidate
+                {
+                    CandidateId = $"sysmiddle-{mapperGuid}",
+                    Pathway = "sysmiddle",
+                    TransformedXml = "<xml>gabarito</xml>"
+                }
+            };
+            var documentId = DocumentIdCalculator.Calculate(request.InputContent, layoutGuid.ToString());
+
+            var method = typeof(TransformationExecutionController)
+                .GetMethod("TryPersistFieldCorrectionContext", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Método TryPersistFieldCorrectionContext não encontrado.");
+
+            method.Invoke(controller, new object?[] { request, layoutRecord, candidates, documentId, layoutGuid.ToString() });
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (store.SavedContext == null && DateTime.UtcNow < deadline)
+                await Task.Delay(10);
+
+            Assert.NotNull(store.SavedContext);
+            Assert.Equal(documentId, store.SavedContext!.DocumentId);
+            Assert.Equal(mapperGuid, store.SavedContext.MapperGuid);
+            Assert.Equal("<xml>gabarito</xml>", store.SavedContext.GroundTruthXml);
+            Assert.Equal(layoutGuid.ToString(), store.SavedContext.LayoutGuid);
+            Assert.Equal("LAYOUT_X", store.SavedContext.LayoutName);
+        }
+
+        [Fact]
+        public async Task TryPersistFieldCorrectionContext_sem_candidato_sysmiddle_grava_sem_gabarito()
+        {
+            var (controller, store, _) = BuildController();
+
+            var request = new TransformationRequest { InputContent = "<xml/>", LayoutName = "LAYOUT_Y" };
+            var layoutGuid = Guid.NewGuid();
+            var layoutRecord = new LayoutRecord { LayoutGuid = layoutGuid, Name = request.LayoutName };
+            var candidates = new List<TransformationCandidate>(); // entrada XML — sem pathway sysmiddle
+            var documentId = DocumentIdCalculator.Calculate(request.InputContent, layoutGuid.ToString());
+
+            var method = typeof(TransformationExecutionController)
+                .GetMethod("TryPersistFieldCorrectionContext", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            method.Invoke(controller, new object?[] { request, layoutRecord, candidates, documentId, layoutGuid.ToString() });
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (store.SavedContext == null && DateTime.UtcNow < deadline)
+                await Task.Delay(10);
+
+            Assert.NotNull(store.SavedContext);
+            Assert.Null(store.SavedContext!.MapperGuid);
+            Assert.Null(store.SavedContext.GroundTruthXml);
+        }
+
+        // --- POST field-correction ---
+
+        [Fact]
+        public async Task ReportFieldCorrection_documento_valido_retorna_202_e_grava_pending()
+        {
+            var (controller, store, user) = BuildController();
+            var context = new FieldCorrectionContext(
+                "doc_abc123", "mapper-1", "MeuMapper", "layout-guid-1", "LAYOUT_X",
+                "<xml>entrada</xml>", "<xml>gabarito</xml>", DateTimeOffset.UtcNow);
+            await store.SaveContextAsync(context, CancellationToken.None);
+
+            var request = new FieldCorrectionRequest
+            {
+                DocumentId = "doc_abc123",
+                CandidateId = "tclxsl-1",
+                FieldPath = "/nfeProc/NFe/infNFe/ide/nNF",
+                ObservedValue = "001",
+                ExpectedValue = "1",
+                Justification = "Não deveria ter zero à esquerda"
+            };
+
+            var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
+
+            var accepted = Assert.IsType<AcceptedResult>(result);
+            Assert.Single(store.CreatedReports);
+            var (input, reportedBy) = store.CreatedReports[0];
+            Assert.Equal("doc_abc123", input.DocumentId);
+            Assert.Equal("001", input.ObservedValue);
+            Assert.Equal("1", input.ExpectedValue);
+            Assert.Equal(user.UserId, reportedBy);
+        }
+
+        [Fact]
+        public async Task ReportFieldCorrection_documentId_sem_contexto_retorna_404()
+        {
+            var (controller, _, _) = BuildController();
+            var request = new FieldCorrectionRequest
+            {
+                DocumentId = "doc_inexistente",
+                CandidateId = "tclxsl-1",
+                FieldPath = "/a/b",
+                ObservedValue = "x",
+                ExpectedValue = "y"
+            };
+
+            var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ReportFieldCorrection_sem_identidade_resolvida_retorna_404_failclosed()
+        {
+            var (controller, _, user) = BuildController();
+            user.UserId = null; // identidade não resolvida (TrustedIdentityMiddleware não confiou na origem)
+
+            var request = new FieldCorrectionRequest
+            {
+                DocumentId = "doc_qualquer",
+                CandidateId = "tclxsl-1",
+                FieldPath = "/a/b",
+                ObservedValue = "x",
+                ExpectedValue = "y"
+            };
+
+            var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result); // sem corpo — distinto do 404 "contexto expirado" acima
+        }
+
+        [Theory]
+        [InlineData("", "cand", "/a", "obs", "exp")]
+        [InlineData("doc_1", "", "/a", "obs", "exp")]
+        [InlineData("doc_1", "cand", "", "obs", "exp")]
+        [InlineData("doc_1", "cand", "/a", "", "exp")]
+        [InlineData("doc_1", "cand", "/a", "obs", "")]
+        public async Task ReportFieldCorrection_campo_obrigatorio_ausente_retorna_400(
+            string documentId, string candidateId, string fieldPath, string observedValue, string expectedValue)
+        {
+            var (controller, _, _) = BuildController();
+            var request = new FieldCorrectionRequest
+            {
+                DocumentId = documentId,
+                CandidateId = candidateId,
+                FieldPath = fieldPath,
+                ObservedValue = observedValue,
+                ExpectedValue = expectedValue
+            };
+
+            var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ReportFieldCorrection_IdentityDatabase_indisponivel_degrada_para_404_sem_lancar()
+        {
+            var (controller, store, _) = BuildController();
+            store.ThrowOnGetContext = true;
+
+            var request = new FieldCorrectionRequest
+            {
+                DocumentId = "doc_qualquer",
+                CandidateId = "tclxsl-1",
+                FieldPath = "/a/b",
+                ObservedValue = "x",
+                ExpectedValue = "y"
+            };
+
+            // Não pode lançar — resiliência (dotnet-standards.md): dependência externa indisponível
+            // degrada para uma resposta clara, nunca derruba o request.
+            var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
@@ -297,7 +297,8 @@ namespace LayoutParserApi.Tests.Controllers
                 fieldMappingComposition: BuildFieldMappingComposition(),
                 scopeFactory: scopeFactory,
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
-                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance));
+                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
+                fieldCorrectionStore: null!);
 
             return (controller, parserFake, runner);
         }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -171,7 +171,8 @@ namespace LayoutParserApi.Tests.Controllers
                 fieldMappingComposition: null!,
                 scopeFactory: services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
-                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance));
+                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
+                fieldCorrectionStore: null!);
 
             return (controller, aiSpy, tclDir);
         }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -116,7 +116,8 @@ namespace LayoutParserApi.Tests.Controllers
                 fieldMappingComposition: null!,
                 scopeFactory: null!,
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
-                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance));
+                    NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
+                fieldCorrectionStore: null!);
 
             return (controller, spy, user);
         }


### PR DESCRIPTION
## Promoção develop -> master

Conteúdo novo: PR #349 — endpoint `POST /api/transformation/field-correction` + persistência
(`tbFieldCorrectionContext`/`tbFieldCorrectionReport`, `IdentityDatabase:*`). Fecha o restante
da issue #345 (o `DocumentId` já estava em produção desde PR #347).

`dotnet build`/`dotnet test` verdes na PR original (703/703, sem regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)