### PR TITLE
Promove develop -> master: métrica de convergência real (repair-batch, issue #352)

### DIFF
--- a/Scripts/vm/run-model-benchmark-comparison.sh
+++ b/Scripts/vm/run-model-benchmark-comparison.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fase A (POC) do plano docs/architecture/plano-eval-benchmark-ia-2026-09-08.md.
+#
+# Roda `dotnet XslSynth.dll --mode=metrics-batch` uma vez por modelo (mesma dataset/--limit),
+# reaproveitando 100% do binário/infra já publicados na VM (ver
+# docs/architecture/plano-metricas-ia-servidor-producao.md §6) — nenhum código C# novo.
+# Agrega o "Resumo do lote" (já impresso por MetricsBatchRunner.LogResumo) de cada modelo numa
+# tabela markdown única em stdout, para não depender de grep manual em N blocos de log.
+#
+# NÃO fecha G2 (CPU/RAM) nem G3 (convergência do loop de reparo) — só a comparação lado-a-lado
+# da similaridade estrutural/textual (mesma métrica que o metrics-batch já usa).
+#
+# Uso:
+#   MODELS="qwen2.5-coder:7b qwen2.5-coder:14b layoutparser-sysmiddle-dsl:1.5b" \
+#   DATASET=~/layoutparser-ai-metrics/dataset_pairs_filtered_v2.jsonl \
+#   LIMIT=10 \
+#   ./run-model-benchmark-comparison.sh
+#
+# LIMITAÇÃO HONESTA: não foi executado contra a VM real nesta sessão (sem acesso SSH nem Ollama
+# local com os modelos grandes) — esqueleto revisável, valide antes de confiar no resultado.
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-$HOME/layoutparser-ai-metrics}"
+DATASET="${DATASET:-$APP_DIR/dataset_pairs_filtered_v2.jsonl}"
+LIMIT="${LIMIT:-10}"
+LOG_DIR="${LOG_DIR:-$APP_DIR/Logs/benchmark-comparison-$(date +%Y%m%d-%H%M%S)}"
+MODELS="${MODELS:?defina MODELS=\"modelo1 modelo2 ...\"}"
+
+mkdir -p "$LOG_DIR"
+
+echo "# Benchmark comparativo de modelos — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+echo "Dataset: \`$DATASET\` · limit=$LIMIT · logs em \`$LOG_DIR\`"
+echo
+echo "| Modelo | Casos | Sucesso | Falhas | Tok/s médio | Duração média/caso (s) | TagOverlap médio | TextSim médio |"
+echo "|---|---|---|---|---|---|---|---|"
+
+for MODEL in $MODELS; do
+  SAFE_NAME="$(echo "$MODEL" | tr '/:' '__')"
+  OUT_FILE="$LOG_DIR/$SAFE_NAME.log"
+
+  echo "── Rodando modelo: $MODEL ──" >&2
+  if ! (cd "$APP_DIR" && dotnet XslSynth.dll --mode=metrics-batch \
+        --dataset "$DATASET" --model "$MODEL" --limit "$LIMIT" \
+        --log-dir "$LOG_DIR" --log-file "$SAFE_NAME.jsonl" > "$OUT_FILE" 2>&1); then
+    echo "| $MODEL | — | — | — | — | — | — | (FALHOU — ver $OUT_FILE) |"
+    continue
+  fi
+
+  # Extrai o bloco "Resumo agregado do lote" já impresso por MetricsBatchRunner.LogResumo.
+  CASOS=$(grep -oP 'Casos\s+:\s+\K[0-9]+(?= \()' "$OUT_FILE" || echo "?")
+  SUCESSO=$(grep -oP 'Casos\s+:\s+[0-9]+ \(\K[0-9]+(?= sucesso)' "$OUT_FILE" || echo "?")
+  FALHA=$(grep -oP '[0-9]+ sucesso, \K[0-9]+(?= falha\))' "$OUT_FILE" || echo "?")
+  TOKS=$(grep -oP 'Throughput médio\s+:\s+\K[0-9.]+' "$OUT_FILE" || echo "-")
+  DUR=$(grep -oP 'Duração média/caso\s+:\s+\K[0-9.]+' "$OUT_FILE" || echo "-")
+  TAG=$(grep -oP 'Tag overlap médio\s+:\s+\K[0-9.]+' "$OUT_FILE" || echo "-")
+  TXT=$(grep -oP 'Text similarity média:\s+\K[0-9.]+' "$OUT_FILE" || echo "-")
+
+  echo "| $MODEL | $CASOS | $SUCESSO | $FALHA | $TOKS | $DUR | $TAG | $TXT |"
+done
+
+echo
+echo "Logs completos por modelo em: $LOG_DIR"

--- a/ai/XslSynth.Core.Tests/RepairBatchSummaryTests.cs
+++ b/ai/XslSynth.Core.Tests/RepairBatchSummaryTests.cs
@@ -1,0 +1,124 @@
+using XslSynth.Metrics;
+
+namespace XslSynth.Core.Tests;
+
+/// <summary>
+/// Cobertura do critério de aceite do #352: "resumo agregado ao final do lote reporta a taxa de
+/// convergência real (%) por modelo". Testa a agregação PURA (<see cref="RepairBatchRunner.Summarize"/>)
+/// a partir de <see cref="RepairCaseResult"/> simulados — sem Ollama, sem I/O, sem Serilog.
+/// </summary>
+public class RepairBatchSummaryTests
+{
+    private static RepairCaseResult Medido(string id, bool converged, int iterations, int diffs, bool? xsdValid = true) =>
+        new(id, InstanceMatched: true, Converged: converged, Iterations: iterations,
+            FinalDiffsCount: diffs, XsdValid: xsdValid, Fixture: "instancia.txt", Erro: null);
+
+    private static RepairCaseResult SemInstancia(string id) =>
+        new(id, InstanceMatched: false, Converged: false, Iterations: 0, FinalDiffsCount: -1,
+            XsdValid: null, Fixture: null, Erro: "sem instância");
+
+    [Fact]
+    public void Summarize_ComTodosConvergindo_TaxaCemPorCento()
+    {
+        var resultados = new[]
+        {
+            Medido("caso1", converged: true, iterations: 1, diffs: 0),
+            Medido("caso2", converged: true, iterations: 3, diffs: 0),
+        };
+
+        var s = RepairBatchRunner.Summarize(resultados);
+
+        Assert.Equal(2, s.TotalCasos);
+        Assert.Equal(2, s.Medidos);
+        Assert.Equal(0, s.SemInstancia);
+        Assert.Equal(2, s.Convergidos);
+        Assert.Equal(1.0, s.TaxaConvergenciaReal);
+        Assert.Equal(2.0, s.IteracoesMediasConvergidos); // média de (1, 3)
+    }
+
+    [Fact]
+    public void Summarize_ComMistoConvergeENaoConverge_TaxaFracionaria()
+    {
+        var resultados = new[]
+        {
+            Medido("caso1", converged: true, iterations: 2, diffs: 0),
+            Medido("caso2", converged: false, iterations: 5, diffs: 3),
+            Medido("caso3", converged: true, iterations: 4, diffs: 0),
+            Medido("caso4", converged: false, iterations: 5, diffs: 1),
+        };
+
+        var s = RepairBatchRunner.Summarize(resultados);
+
+        Assert.Equal(4, s.Medidos);
+        Assert.Equal(2, s.Convergidos);
+        Assert.Equal(0.5, s.TaxaConvergenciaReal);
+        Assert.Equal(3.0, s.IteracoesMediasConvergidos); // média de (2, 4), NÃO conta os que falharam
+    }
+
+    [Fact]
+    public void Summarize_CasosSemInstancia_NaoEntramNoDenominadorDaTaxa()
+    {
+        // 1 medido (converge) + 3 sem instância: a taxa tem que ser 100% sobre o MEDIDO,
+        // não 25% sobre o total — é a regra central que evita falso-negativo sistemático
+        // (issue #352, "Taxa calculada sobre os casos MEDIDOS, não sobre o total").
+        var resultados = new[]
+        {
+            Medido("caso1", converged: true, iterations: 1, diffs: 0),
+            SemInstancia("caso2"),
+            SemInstancia("caso3"),
+            SemInstancia("caso4"),
+        };
+
+        var s = RepairBatchRunner.Summarize(resultados);
+
+        Assert.Equal(4, s.TotalCasos);
+        Assert.Equal(1, s.Medidos);
+        Assert.Equal(3, s.SemInstancia);
+        Assert.Equal(1, s.Convergidos);
+        Assert.Equal(1.0, s.TaxaConvergenciaReal);
+    }
+
+    [Fact]
+    public void Summarize_NenhumCasoMedido_TaxaENullNaoZero()
+    {
+        // Divisão por zero disfarçada de "0% de convergência" seria enganosa — null sinaliza
+        // "não medido", diferente de "medido e falhou tudo".
+        var resultados = new[] { SemInstancia("caso1"), SemInstancia("caso2") };
+
+        var s = RepairBatchRunner.Summarize(resultados);
+
+        Assert.Equal(0, s.Medidos);
+        Assert.Null(s.TaxaConvergenciaReal);
+        Assert.Null(s.IteracoesMediasConvergidos);
+    }
+
+    [Fact]
+    public void Summarize_MedidoMasNenhumConverge_TaxaZeroIteracoesMediaNull()
+    {
+        var resultados = new[]
+        {
+            Medido("caso1", converged: false, iterations: 5, diffs: 2),
+            Medido("caso2", converged: false, iterations: 5, diffs: 1),
+        };
+
+        var s = RepairBatchRunner.Summarize(resultados);
+
+        Assert.Equal(2, s.Medidos);
+        Assert.Equal(0, s.Convergidos);
+        Assert.Equal(0.0, s.TaxaConvergenciaReal);
+        Assert.Null(s.IteracoesMediasConvergidos); // nenhum convergiu — não há iteração média a reportar
+    }
+
+    [Fact]
+    public void Summarize_ListaVazia_TudoZeroOuNull()
+    {
+        var s = RepairBatchRunner.Summarize(Array.Empty<RepairCaseResult>());
+
+        Assert.Equal(0, s.TotalCasos);
+        Assert.Equal(0, s.Medidos);
+        Assert.Equal(0, s.SemInstancia);
+        Assert.Equal(0, s.Convergidos);
+        Assert.Null(s.TaxaConvergenciaReal);
+        Assert.Null(s.IteracoesMediasConvergidos);
+    }
+}

--- a/ai/XslSynth.Core.Tests/XslSynth.Core.Tests.csproj
+++ b/ai/XslSynth.Core.Tests/XslSynth.Core.Tests.csproj
@@ -26,6 +26,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XslSynth.Core\XslSynth.Core.csproj" />
+    <!-- RepairBatchRunner.Summarize (issue #352) — agregação da taxa de convergência real. -->
+    <ProjectReference Include="..\XslSynth\XslSynth.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ai/XslSynth/Metrics/MetricsBatchRunner.cs
+++ b/ai/XslSynth/Metrics/MetricsBatchRunner.cs
@@ -348,7 +348,10 @@ public static class MetricsBatchRunner
         }
     }
 
-    private static string BuildPrompt(DatasetPair caso, IReadOnlyList<DatasetFewShotMatch> recuperados)
+    /// <summary>Interno (não privado) — reaproveitado por <see cref="RepairBatchRunner"/> para
+    /// montar o prompt inicial do modo <c>--mode=repair-batch</c> (mesmo prompt few-shot,
+    /// candidato de partida do loop de reparo completo).</summary>
+    internal static string BuildPrompt(DatasetPair caso, IReadOnlyList<DatasetFewShotMatch> recuperados)
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("Você é um especialista em XSLT 1.0 e nos leiautes fiscais brasileiros (NFe/CTe/MDFe).");
@@ -372,7 +375,8 @@ public static class MetricsBatchRunner
         return sb.ToString();
     }
 
-    private static string ExtractXml(string raw)
+    /// <summary>Interno (não privado) — reaproveitado por <see cref="RepairBatchRunner"/>.</summary>
+    internal static string ExtractXml(string raw)
     {
         var fenced = System.Text.RegularExpressions.Regex.Match(raw, "```(?:xml|xslt)?\\s*(.*?)```",
             System.Text.RegularExpressions.RegexOptions.Singleline);

--- a/ai/XslSynth/Metrics/RepairBatchRunner.cs
+++ b/ai/XslSynth/Metrics/RepairBatchRunner.cs
@@ -1,0 +1,369 @@
+using System.Xml.Linq;
+using Serilog;
+using Serilog.Context;
+using XslSynth.Core;
+using XslSynth.Model;
+using XslSynth.Synthesis;
+
+namespace XslSynth.Metrics;
+
+/// <summary>Opções do modo <c>--mode=repair-batch</c> (issue #352 — Fase B do plano de
+/// eval/benchmark, docs/architecture/plano-eval-benchmark-ia-2026-09-08.md).</summary>
+public sealed record RepairBatchOptions(
+    string DatasetPath, string Model, int FewShotK, int? Limit, string LogDirectory, string LogFileName,
+    string? InstancesDirectory, string? NfeXsdPath, int MaxIterations = 5);
+
+/// <summary>Resultado de UM caso do lote de convergência real. Público (não interno) para ser
+/// testável em isolamento — ver <see cref="RepairBatchRunner.Summarize"/>.</summary>
+public sealed record RepairCaseResult(
+    string Layout, bool InstanceMatched, bool Converged, int Iterations, int FinalDiffsCount,
+    bool? XsdValid, string? Fixture, string? Erro);
+
+/// <summary>Resumo agregado do lote — separado em tipo próprio para ser testável sem depender
+/// de captura de stdout/Serilog (issue #352, critério de aceite "resumo agregado ao final").</summary>
+public sealed record RepairBatchSummary(
+    int TotalCasos, int Medidos, int SemInstancia, int Convergidos,
+    double? TaxaConvergenciaReal, double? IteracoesMediasConvergidos);
+
+/// <summary>
+/// Fase B do plano de eval/benchmark (issue #352, Gap G3): eleva o critério de "acertou" do
+/// benchmark de similaridade tolerante (<see cref="OutputValidator"/>, usado pelo
+/// <c>--mode=metrics-batch</c>) para o critério REAL que decide correção fiscal em produção —
+/// diff==0 (<see cref="CanonicalDiffer"/>) + XSD válido — rodando o mesmo tipo de loop que
+/// <see cref="RepairOrchestrator"/> usa no fluxo <c>--generate</c>, só que em LOTE contra o
+/// dataset held-out, por modelo.
+///
+/// LIMITAÇÃO HONESTA (documentada, não escondida): <see cref="RepairOrchestrator.RunAsync"/> não
+/// pôde ser reaproveitado tal como está — ele exige um <see cref="MapperVo"/> (LinkMappings/Rules
+/// estruturados) + XML de INSTÂNCIA real de entrada, e o dataset held-out
+/// (<c>dataset_pairs_filtered_v2.jsonl</c>) só tem pares (schema TCL de texto, XSLT-alvo de
+/// texto) — não tem MapperVO nem instância de entrada pareada (ver
+/// docs/architecture/plano-eval-benchmark-ia-2026-09-08.md, achado "não vamos reconstruir" +
+/// memória finetuning-poc-fase1-dataset.md). Diff==0 real só é COMPUTÁVEL quando existe, em
+/// <see cref="RepairBatchOptions.InstancesDirectory"/>, um TXT de instância que estruturalmente
+/// case com o schema TCL do caso (via <see cref="TclRootBuilder"/> — mesmo mecanismo do
+/// <see cref="CandidateXmlFactory"/>, mas SEM o filtro de elegibilidade Pollux: aqui o objetivo é
+/// medir convergência técnica, não submissibilidade). Hoje isso cobre uma fração pequena dos 54
+/// pares (principalmente NFe, ver Examples/ no servidor) — os demais casos entram no relatório
+/// como "sem instância" (não contam nem a favor nem contra a taxa de convergência, para não
+/// produzir falso-negativo sistemático). A taxa de convergência reportada é sobre os casos
+/// MEDIDOS, não sobre os 54 — isso fica explícito no resumo agregado.
+/// </summary>
+public static class RepairBatchRunner
+{
+    public static async Task<int> RunAsync(RepairBatchOptions opts, Action<string> log, CancellationToken ct = default)
+    {
+        if (OperatingSystem.IsLinux() && Environment.IsPrivilegedProcess)
+        {
+            log("❌ Recusando rodar como root (mesmo motivo do metrics-batch — ver MetricsBatchRunner).");
+            return 3;
+        }
+
+        if (!File.Exists(opts.DatasetPath))
+        {
+            log($"❌ Dataset não encontrado: {opts.DatasetPath}");
+            return 2;
+        }
+
+        Directory.CreateDirectory(opts.LogDirectory);
+        Serilog.Log.Logger = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Information()
+            .Enrich.FromLogContext()
+            .WriteTo.Console(outputTemplate:
+                "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}] [{Level:u3}] [Src:{Source}] [Corr:{CorrelationId}] {Message:lj}{NewLine}{Exception}")
+            .WriteTo.File(
+                Path.Combine(opts.LogDirectory, opts.LogFileName),
+                rollingInterval: Serilog.RollingInterval.Day,
+                rollOnFileSizeLimit: true,
+                outputTemplate:
+                    "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}] [{Level:u3}] [Src:{Source}] [Corr:{CorrelationId}] {Message:lj}{NewLine}{Exception}",
+                shared: true)
+            .CreateLogger();
+
+        try
+        {
+            var pares = DatasetPair.Load(opts.DatasetPath, log);
+            log($"[repair-batch] dataset carregado: {pares.Count} pares.");
+            if (pares.Count == 0)
+            {
+                log("❌ Dataset vazio ou 100% ilegível — nada a rodar.");
+                return 1;
+            }
+
+            var index = DatasetFewShotIndex.Build(pares);
+            var client = new OllamaClient(log, model: opts.Model);
+            var synthesizer = new OllamaXslSynthesizer(log);
+            var modelo = client.Model;
+
+            if (!await client.IsReachableAsync(ct))
+            {
+                log($"❌ Ollama indisponível em {client.Url} — repair-batch não pode rodar (mede o LLM real, sem fallback mock).");
+                return 1;
+            }
+
+            var instancias = opts.InstancesDirectory is not null && Directory.Exists(opts.InstancesDirectory)
+                ? Directory.EnumerateFiles(opts.InstancesDirectory)
+                    .Where(f => !f.EndsWith(".gitkeep", StringComparison.Ordinal))
+                    .OrderBy(f => f, StringComparer.Ordinal).ToList()
+                : new List<string>();
+            log($"[repair-batch] instâncias disponíveis: {instancias.Count}"
+                + (instancias.Count == 0 ? " — NENHUM caso terá diff==0 real computável (todos entram como 'sem instância')." : ""));
+
+            var casos = opts.Limit is { } lim && lim > 0 ? pares.Take(lim).ToList() : pares;
+            log($"[repair-batch] modelo={modelo} · few-shot k={opts.FewShotK} · max iterações/caso={opts.MaxIterations} "
+                + $"· casos nesta rodada={casos.Count}"
+                + (opts.Limit is not null ? $" (LIMITADO de {pares.Count})" : ""));
+            log("");
+
+            var resultados = new List<RepairCaseResult>();
+            var n = 0;
+            foreach (var caso in casos)
+            {
+                n++;
+                ct.ThrowIfCancellationRequested();
+                log($"[{n}/{casos.Count}] {caso.Id}");
+
+                RepairCaseResult resultado;
+                try
+                {
+                    resultado = await RunCaseAsync(caso, index, client, synthesizer, opts, log, ct);
+                }
+                catch (Exception ex)
+                {
+                    log($"   ❌ falha inesperada neste caso (lote SEGUE): {ex.Message}");
+                    resultado = new RepairCaseResult(caso.Id, false, false, 0, -1, null, null, ex.Message);
+                }
+
+                resultados.Add(resultado);
+                LogCaso(resultado, modelo);
+            }
+
+            LogResumo(resultados, modelo);
+            return resultados.Any(r => r.InstanceMatched) ? 0 : 1;
+        }
+        finally
+        {
+            Serilog.Log.CloseAndFlush();
+        }
+    }
+
+    private static async Task<RepairCaseResult> RunCaseAsync(DatasetPair caso, DatasetFewShotIndex index,
+        OllamaClient client, OllamaXslSynthesizer synthesizer, RepairBatchOptions opts, Action<string> log, CancellationToken ct)
+    {
+        var map = TclLayoutMap.TryParse(caso.InputMapTcl);
+        if (map is null)
+        {
+            log("   [repair-batch] schema TCL do par ilegível ou sem <LINE> — sem instância possível.");
+            return new RepairCaseResult(caso.Id, false, false, 0, -1, null, null, "schema TCL ilegível");
+        }
+
+        var instanciasDisponiveis = opts.InstancesDirectory is not null && Directory.Exists(opts.InstancesDirectory)
+            ? Directory.EnumerateFiles(opts.InstancesDirectory).Where(f => !f.EndsWith(".gitkeep", StringComparison.Ordinal)).ToList()
+            : new List<string>();
+        var (root, fixture, motivo) = ResolveInstancia(caso.Id, map, instanciasDisponiveis);
+        if (root is null)
+        {
+            log($"   [repair-batch] sem instância real compatível — caso não entra na taxa de convergência ({motivo}).");
+            return new RepairCaseResult(caso.Id, false, false, 0, -1, null, null, motivo);
+        }
+
+        XDocument gabaritoXslt;
+        try { gabaritoXslt = XDocument.Parse(caso.OutputXslt); }
+        catch (Exception ex)
+        {
+            log($"   [repair-batch] XSLT gabarito do dataset não é XML bem-formado — caso descartado: {ex.Message}");
+            return new RepairCaseResult(caso.Id, false, false, 0, -1, null, fixture, "gabarito malformado: " + ex.Message);
+        }
+
+        var applier = new XsltApplier();
+        string expectedOutput;
+        try { expectedOutput = applier.Apply(gabaritoXslt, root); }
+        catch (Exception ex)
+        {
+            log($"   [repair-batch] gabarito não aplicou sobre a instância '{fixture}' — caso descartado: {ex.Message}");
+            return new RepairCaseResult(caso.Id, false, false, 0, -1, null, fixture, "gabarito não aplicou: " + ex.Message);
+        }
+
+        log($"   instância casada: {fixture}");
+
+        var recuperados = index.Retrieve(caso, opts.FewShotK);
+        var prompt = MetricsBatchRunner.BuildPrompt(caso, recuperados);
+        var (respostaBruta, metrics) = await client.GenerateWithMetricsAsync(prompt, ct);
+        if (!metrics.Success || string.IsNullOrWhiteSpace(respostaBruta))
+        {
+            log("   ❌ Ollama sem resposta utilizável na geração inicial.");
+            return new RepairCaseResult(caso.Id, true, false, 0, -1, null, fixture, "sem resposta do LLM");
+        }
+
+        var candidatoTexto = MetricsBatchRunner.ExtractXml(respostaBruta);
+        var briefing = new SynthesisBriefing { Mapper = new MapperVo(), TargetRootName = root.Root?.Name.LocalName ?? "ROOT" };
+
+        var differ = new CanonicalDiffer();
+        var iterations = 0;
+        IReadOnlyList<NodeDiff> diffs = [new NodeDiff("nao-avaliado", "/", null, null)];
+        bool? xsdValid = null;
+
+        while (iterations < opts.MaxIterations)
+        {
+            iterations++;
+
+            string atual;
+            try
+            {
+                var xslt = XDocument.Parse(candidatoTexto);
+                atual = applier.Apply(xslt, root);
+                diffs = differ.Diff(expectedOutput, atual);
+                xsdValid = opts.NfeXsdPath is not null ? ValidaXsdNfe(atual, opts.NfeXsdPath, log) : null;
+            }
+            catch (Exception ex)
+            {
+                // XSLT candidato não compila/não aplica: trata como divergência total,
+                // repassa o erro para o LLM consertar na próxima iteração (mesmo espírito
+                // do Passo 6 do RepairOrchestrator — nenhuma saída inválida é aceita).
+                diffs = [new NodeDiff("erro-aplicacao", "/", null, ex.Message)];
+                xsdValid = null;
+            }
+
+            log($"   iteração {iterations}/{opts.MaxIterations}: diffs={diffs.Count} · xsdValido={(xsdValid?.ToString() ?? "null")}");
+
+            if (diffs.Count == 0 && xsdValid != false)
+                break;
+
+            if (iterations >= opts.MaxIterations) break;
+            candidatoTexto = await synthesizer.RepairFromDiffAsync(candidatoTexto, diffs, briefing, ct);
+        }
+
+        var converged = diffs.Count == 0 && xsdValid != false;
+        log(converged ? "   ✅ CONVERGIU (diff==0 + XSD válido/indisponível)." : $"   ❌ não convergiu ({diffs.Count} diff(s) residual(is)).");
+        return new RepairCaseResult(caso.Id, true, converged, iterations, diffs.Count, xsdValid, fixture, null);
+    }
+
+    /// <summary>Mesma lógica de casamento do <see cref="CandidateXmlFactory"/>, mas SEM o
+    /// filtro de elegibilidade Pollux — aqui qualquer docType/operação com instância real
+    /// compatível entra na medição de convergência técnica.</summary>
+    private static (XDocument? Root, string? Fixture, string Motivo) ResolveInstancia(
+        string layoutId, TclLayoutMap map, IReadOnlyList<string> instancias)
+    {
+        if (instancias.Count == 0)
+            return (null, null, "nenhum diretório de instâncias configurado/existente");
+
+        var stem = layoutId.Split('\\', '/').LastOrDefault() ?? layoutId;
+        var ordenadas = instancias
+            .OrderByDescending(f => Path.GetFileNameWithoutExtension(f).Contains(stem, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var melhorTaxa = 0.0;
+        string? melhorMotivo = null;
+        foreach (var arquivo in ordenadas)
+        {
+            var r = TclRootBuilder.TryBuild(arquivo, map);
+            if (r.Root is not null) return (r.Root, Path.GetFileName(arquivo), "");
+            if (r.TaxaCasamento >= melhorTaxa)
+            {
+                melhorTaxa = r.TaxaCasamento;
+                melhorMotivo = $"{Path.GetFileName(arquivo)}: {r.Motivo}";
+            }
+        }
+
+        return (null, null,
+            $"nenhuma das {instancias.Count} instância(s) casa com o schema TCL deste par "
+            + $"(melhor casamento {melhorTaxa:P0}) — {melhorMotivo}");
+    }
+
+    /// <summary>Oráculo XSD do leiaute NF-e (mesmo escopo do <see cref="CandidateXmlFactory"/>):
+    /// só se aplica quando a saída tem forma de NF-e; fora disso fica null, nunca false por
+    /// ausência de cobertura.</summary>
+    private static bool? ValidaXsdNfe(string xmlSaida, string nfeXsdPath, Action<string> log)
+    {
+        if (!File.Exists(nfeXsdPath)) return null;
+        try
+        {
+            var raiz = XDocument.Parse(xmlSaida).Root;
+            if (raiz is null || raiz.Name.LocalName != "NFe") return null; // fora do escopo do oráculo
+
+            XNamespace ns = PolluxEligibility.NfeNamespace;
+            var comNs = raiz.Name.NamespaceName == ns.NamespaceName ? raiz : ComNamespace(raiz, ns);
+            var res = new XsdValidator().Validate(comNs.ToString(), nfeXsdPath);
+            var reais = res.Errors.Count(e => !e.Contains("Signature", StringComparison.Ordinal));
+            return reais == 0;
+        }
+        catch (Exception ex)
+        {
+            log($"   [xsd] validação indisponível para esta iteração ({ex.Message}) — xsdValid=null.");
+            return null;
+        }
+    }
+
+    private static XElement ComNamespace(XElement el, XNamespace ns)
+    {
+        var novo = new XElement(ns + el.Name.LocalName);
+        foreach (var a in el.Attributes().Where(a => !a.IsNamespaceDeclaration))
+            novo.Add(new XAttribute(a.Name.LocalName, a.Value));
+        foreach (var n in el.Nodes())
+            novo.Add(n is XElement c ? ComNamespace(c, ns) : n);
+        return novo;
+    }
+
+    /// <summary>Log estruturado por caso — Source=AiMetrics (mesma série do metrics-batch),
+    /// campos NOVOS de convergência real (issue #352): Converged/Iterations/FinalDiffsCount/
+    /// XsdValidoReal. InstanceMatched=false ⇒ caso não entrou na taxa (sem dado de instância).</summary>
+    private static void LogCaso(RepairCaseResult r, string modelo)
+    {
+        using (LogContext.PushProperty("Source", "AiMetrics"))
+        {
+            Serilog.Log.Information(
+                "Convergencia real avaliada (repair-batch). Layout={Layout} Modelo={Model} "
+                + "InstanceMatched={InstanceMatched} Converged={Converged} Iterations={Iterations} "
+                + "FinalDiffsCount={FinalDiffsCount} XsdValidoReal={XsdValidoReal} Fixture={Fixture} Erro={Erro}",
+                r.Layout, modelo, r.InstanceMatched, r.Converged, r.Iterations, r.FinalDiffsCount,
+                r.XsdValid, r.Fixture, r.Erro);
+        }
+    }
+
+    /// <summary>Agregação PURA (sem I/O) — testável em isolamento a partir de uma lista de
+    /// <see cref="RepairCaseResult"/> simulados. É o coração do critério de aceite do #352:
+    /// taxa de convergência real (%) por modelo, sobre os casos MEDIDOS (com instância real),
+    /// nunca sobre o total do dataset (evita falso-negativo sistemático nos casos sem instância).</summary>
+    public static RepairBatchSummary Summarize(IReadOnlyList<RepairCaseResult> resultados)
+    {
+        var medidos = resultados.Where(r => r.InstanceMatched).ToList();
+        var convergidos = medidos.Count(r => r.Converged);
+        var semInstancia = resultados.Count - medidos.Count;
+        var taxaConvergencia = medidos.Count > 0 ? (double)convergidos / medidos.Count : (double?)null;
+        var convergidosLista = medidos.Where(r => r.Converged).ToList();
+        var iteracoesMedias = convergidosLista.Count > 0 ? convergidosLista.Average(r => r.Iterations) : (double?)null;
+
+        return new RepairBatchSummary(resultados.Count, medidos.Count, semInstancia, convergidos,
+            taxaConvergencia, iteracoesMedias);
+    }
+
+    private static void LogResumo(List<RepairCaseResult> resultados, string modelo)
+    {
+        var s = Summarize(resultados);
+
+        using (LogContext.PushProperty("Source", "AiMetrics"))
+        {
+            Serilog.Log.Information(
+                "Resumo do lote de convergencia real (repair-batch). Modelo={Model} TotalCasos={TotalCasos} "
+                + "Medidos={Medidos} SemInstancia={SemInstancia} Convergidos={Convergidos} "
+                + "TaxaConvergenciaReal={TaxaConvergenciaReal} IteracoesMediasConvergidos={IteracoesMediasConvergidos}",
+                modelo, s.TotalCasos, s.Medidos, s.SemInstancia, s.Convergidos,
+                s.TaxaConvergenciaReal, s.IteracoesMediasConvergidos);
+        }
+
+        Console.WriteLine("");
+        Console.WriteLine("── Resumo agregado — taxa de convergência REAL (diff==0 + XSD) ────");
+        Console.WriteLine($"   Modelo                       : {modelo}");
+        Console.WriteLine($"   Casos no lote                : {s.TotalCasos}");
+        Console.WriteLine($"   Sem instância (não medidos)  : {s.SemInstancia}"
+            + (s.SemInstancia == s.TotalCasos ? "  ⚠️ NENHUM caso medido — configure --instances." : ""));
+        Console.WriteLine($"   Medidos (com instância real) : {s.Medidos}");
+        if (s.Medidos > 0)
+        {
+            Console.WriteLine($"   Convergiram (diff==0+XSD)    : {s.Convergidos}/{s.Medidos} ({s.TaxaConvergenciaReal:P1})");
+            Console.WriteLine($"   Iterações médias (convergiu) : {(s.IteracoesMediasConvergidos is { } im ? im.ToString("F1") : "n/a")}");
+        }
+        Console.WriteLine("   ⚠️ Taxa calculada sobre os casos MEDIDOS, não sobre o total do dataset —");
+        Console.WriteLine("      diff==0 real exige instância TXT compatível (ver limitação documentada em RepairBatchRunner.cs).");
+    }
+}

--- a/ai/XslSynth/Program.cs
+++ b/ai/XslSynth/Program.cs
@@ -29,6 +29,12 @@ using XslSynth.Synthesis;
 //                                RAG (TF-IDF) → Ollama → validação estrutural → Serilog Source=AiMetrics
 //                                + publica o RUN DIR do Job 2 (manifest.json + candidates/*.xml)
 //                                quando --run-dir / LP_METRICS_RUN_DIR / METRICS_HOME é dado.
+//   dotnet run -- --mode=repair-batch [--dataset <jsonl>] [--model <nome>] [--fewshot-k <n>]
+//                                      [--limit <n>] [--max-iterations <n>] [--instances <dir>]
+//                                      [--nfe-xsd <xsd>]
+//                              → issue #352 (Fase B): taxa de convergência REAL (diff==0 + XSD
+//                                válido, critério de produção) por modelo, rodando o loop de
+//                                reparo completo — mais caro que metrics-batch, nightly/semanal.
 //
 // Arquitetura: docs/architecture/ia-xslt-synthesis.md · poc-excel-generator.md
 //              docs/architecture/plano-metricas-ia-servidor-producao.md (metrics-batch)
@@ -43,6 +49,9 @@ Log("");
 
 if (args.Any(a => a.StartsWith("--mode=metrics-batch", StringComparison.Ordinal)) || args.Contains("--metrics-batch"))
     return await RunMetricsBatchAsync();
+
+if (args.Any(a => a.StartsWith("--mode=repair-batch", StringComparison.Ordinal)) || args.Contains("--repair-batch"))
+    return await RunRepairBatchAsync();
 
 if (args.Contains("--xsd-diff"))
     return RunXsdDiff();
@@ -818,6 +827,53 @@ async Task<int> RunMetricsBatchAsync()
         RunDirectory: runDir, RunId: runId, InstancesDirectory: instancesDir,
         NfeXsdPath: File.Exists(nfeXsd) ? nfeXsd : null, DryRun: dryRun);
     return await MetricsBatchRunner.RunAsync(opts, Log);
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Fluxo REPAIR-BATCH (issue #352 — Fase B do plano de eval/benchmark): eleva o
+// critério de "acertou" para o mesmo usado em produção (diff==0 + XSD válido,
+// via RepairOrchestrator/CanonicalDiffer), em vez da similaridade tolerante do
+// metrics-batch. Mais caro (várias chamadas de LLM por caso, não 1) — pensado
+// para rodar nightly/semanal, não em CI a cada PR. Ver limitação de cobertura
+// documentada em RepairBatchRunner.cs (só mede convergência real quando há
+// instância TXT real compatível com o schema TCL do caso).
+// ══════════════════════════════════════════════════════════════════════════
+async Task<int> RunRepairBatchAsync()
+{
+    var claudeTmp = Path.GetDirectoryName(ResolveExportDir())!; // …/.claude/tmp
+    var datasetPath = FindArgAfter("--dataset")
+        ?? Path.Combine(claudeTmp, "dataset-finetuning", "dataset_pairs_filtered_v2.jsonl");
+    var model = FindArgAfter("--model") ?? Environment.GetEnvironmentVariable("OLLAMA_MODEL") ?? "qwen2.5-coder:7b";
+    var fewShotK = int.TryParse(FindArgAfter("--fewshot-k"), out var k) ? k : 3;
+    var limit = int.TryParse(FindArgAfter("--limit"), out var lim) ? lim : (int?)null;
+    var maxIterations = int.TryParse(FindArgAfter("--max-iterations"), out var mi) ? mi : 5;
+
+    var instancesDir = FindArgAfter("--instances")
+        ?? Environment.GetEnvironmentVariable("LP_METRICS_INSTANCES_DIR")
+        ?? (Directory.Exists(Path.Combine(claudeTmp, "metrics-instances"))
+            ? Path.Combine(claudeTmp, "metrics-instances")
+            : null);
+    var nfeXsd = FindArgAfter("--nfe-xsd") ?? Path.Combine(claudeTmp, "servidor", "layoutparser",
+        "xsd", "PL_010b_NT2025_002_v1.30", "nfe_v4.00.xsd");
+
+    var repoRoot = new DirectoryInfo(claudeTmp).Parent;
+    var logDir = FindArgAfter("--log-dir")
+        ?? (repoRoot?.Parent is { } raiz && Directory.Exists(Path.Combine(raiz.FullName, "Logs"))
+            ? Path.Combine(raiz.FullName, "Logs")
+            : Path.Combine(AppContext.BaseDirectory, "Logs"));
+
+    Log("Modo      : REPAIR-BATCH (RAG → Ollama → loop de reparo diff==0/XSD → Serilog Source=AiMetrics)");
+    Log($"Dataset   : {datasetPath}");
+    Log($"Modelo    : {model}");
+    Log($"Few-shot k: {fewShotK}  ·  máx. iterações/caso: {maxIterations}");
+    Log($"Instâncias: {instancesDir ?? "(não configurado — nenhum caso terá convergência real medida)"}");
+    Log($"Log dir   : {logDir}" + (limit is not null ? $"  ·  LIMITE de teste: {limit} caso(s)" : ""));
+    Log("");
+
+    var opts = new RepairBatchOptions(datasetPath, model, fewShotK, limit, logDir, "layoutparserapi.log",
+        InstancesDirectory: instancesDir, NfeXsdPath: File.Exists(nfeXsd) ? nfeXsd : null,
+        MaxIterations: maxIterations);
+    return await RepairBatchRunner.RunAsync(opts, Log);
 }
 
 // ══════════════════════════════════════════════════════════════════════════

--- a/docs/architecture/plano-eval-benchmark-ia-2026-09-08.md
+++ b/docs/architecture/plano-eval-benchmark-ia-2026-09-08.md
@@ -1,0 +1,151 @@
+# Plano — Eval-test, benchmark de modelos e análise estática da IA (2026-09-08)
+
+> Pedido do dono: fundamentar com dado real a decisão de escalamento (inclusive a comparação
+> RAG-vs-fine-tuning que `@lp-architect` está reavaliando em paralelo). Este documento é **fase de
+> design** — só uma parte pequena (item 4) já foi implementada como POC.
+
+## 0. O que já existe hoje (não duplicar)
+
+Antes de desenhar qualquer coisa nova, o achado mais importante desta investigação: **os itens 1 e
+2 do pedido (eval-test repetível + benchmark de múltiplos modelos) já existem, em produção,
+rodando semanalmente.** O gap real é mais estreito do que parecia.
+
+| Peça | Onde | O que faz |
+|---|---|---|
+| Eval-test repetível | `ai/XslSynth/Metrics/MetricsBatchRunner.cs` (`--mode=metrics-batch`) | Roda o dataset held-out (54 pares NFe/CTe/MDFe) contra **qualquer** modelo Ollama (`--model <nome>`), few-shot RAG (TF-IDF) → geração → validação → log estruturado `Source=AiMetrics`. Já é o "rodar contra qualquer modelo configurado", item 1 do pedido. |
+| Métrica objetiva | `ai/XslSynth/Metrics/OutputValidator.cs` | `WellFormedXml`, `TagOverlapRatio` (Jaccard de nomes de elemento), `TextSimilarityRatio` (LCS, aproxima `difflib.SequenceMatcher.ratio`). `XsdValid` fica `null` fora do caso NFe emissão (sem oráculo XSD por operação). |
+| Custo/latência real | `ai/XslSynth.Core/Synthesis/OllamaClient.cs` | tokens/s e duração vêm das métricas nativas do Ollama (`eval_count`/`eval_duration`), não estimadas. |
+| Execução recorrente | `docs/architecture/plano-metricas-ia-servidor-producao.md` §6 | cron na VM `172.25.32.31`, sábado 00:00, já validado em produção desde 2026-07-30. |
+| Comparação estrita 1:1 | `ai/XslSynth.Core/Core/CanonicalDiffer.cs` + `RepairOrchestrator.cs` | diff canônico node-a-node entre XML gerado e gabarito — usado no loop de reparo em produção, **não** no `metrics-batch` (que usa a métrica mais tolerante do `OutputValidator`, deliberadamente, porque mede o modelo cru sem o loop de reparo). |
+| Suíte de transformação (pathway TCL/XSL clássico) | `Services/Testing/AutomatedTransformationTestService.cs` | Compara TXT→XML contra `expected_output.xml`, mas por **contagem de elementos + presença de elementos críticos** — não é diff estrito. Serve outro propósito (regressão do pathway legado), não é o alvo deste plano. |
+| Análise estática de segurança | `security-code-scan-baseline.json` + `ci-dev.yml` | Já cobre SAST C# (não domínio de IA/XSLT). |
+
+**Conclusão prática:** não vamos reconstruir "rodar eval contra N modelos" — já existe e roda. O
+trabalho de design daqui pra frente é (a) fechar os gaps reais listados abaixo, (b) decidir onde
+cada gap se encaixa no ciclo de vida (CI / nightly / manual).
+
+## 1. Gaps reais (o que falta, priorizado)
+
+### G1 — Nenhum mecanismo compara N modelos **na mesma rodada** e produz um veredito lado-a-lado
+`--model` roda um modelo por invocação; hoje comparar 2 modelos exige rodar duas vezes e ler dois
+blocos de log manualmente. Sem tabela agregada, "aumentar o modelo base" vira leitura manual de
+log — exatamente o oposto de "decisão com dado real". **→ POC implementado nesta sessão (item 4).**
+
+### G2 — Custo de recurso (CPU/RAM) não é medido, só tempo/tokens
+O pedido pede "custo de recurso (CPU/RAM/tempo por inferência) — dado real, medido na mesma VM".
+Hoje só duração e tokens/s existem. Modelo maior pode ganhar em qualidade e ainda ser inviável por
+RAM (VM é CPU-only, sem GPU — RAM é o teto real de qual modelo cabe). Sem esse dado, a decisão de
+"aumentar o modelo" fica coxa mesmo com o benchmark de qualidade pronto.
+
+### G3 — O critério de "acertou" do benchmark não é o mesmo do sistema em produção
+`OutputValidator` mede similaridade textual/estrutural tolerante (Jaccard de tags, LCS) — correto
+para o cenário do `metrics-batch` (medir o modelo cru, sem loop de reparo). Mas o critério que
+**decide correção fiscal** em produção é o diff estrito (`CanonicalDiffer`, `diff==0`) dentro do
+`RepairOrchestrator`. Hoje não existe um número consolidado de "quantos casos convergem
+(diff==0 + XSD válido) em N iterações, por modelo" — só "quão parecido ficou o XSLT cru". Para uma
+decisão de escalamento, a métrica que importa de verdade é a de convergência do loop completo, não
+a similaridade do primeiro palpite. Rodar o `RepairOrchestrator` (não só o `OllamaClient` cru) em
+lote, por modelo, é o benchmark que faltava — mais caro (múltiplas chamadas por caso), por isso
+não foi o que o `metrics-batch` original implementou.
+
+### G4 — Casos sintéticos por categoria (copy/concat/lookup/conditional) não existem como suíte
+O dataset de 54 pares é real e reflete a distribuição de produção (bom para benchmark realista),
+mas não isola "o modelo entende `lookup`?" de "o modelo entende layout de CT-e inteiro?" — quando
+um modelo falha, o dataset real não diz **qual operação** ele não sabe fazer. O teste manual de 4
+prompts feito nesta sessão (copy/concat/conditional/lookup) tinha esse poder diagnóstico, só que
+sem repetibilidade. Uma suíte pequena e sintética (10-20 casos, 1 por categoria de operação DSL:
+copy, concat, conditional, lookup, date-format, numeric-format) complementa o dataset real —
+não substitui, serve de "unit test" enquanto o dataset é o "integration test".
+
+### G5 — Nenhum linting/validação estrutural do XSLT **antes** de aplicar
+O `OutputValidator` só checa bem-formação depois de gerado. Falta uma checagem rápida e barata
+(sem custo de LLM) reutilizável em CI: XSLT gerado é XML válido, tem `xsl:stylesheet` como raiz,
+não referencia namespace incorreto — hoje isso só aparece indiretamente via `WellFormedXml=false`
+no log, não como gate de CI que bloqueia PR.
+
+### G6 — Sem gate de CI para regressão de qualidade de geração
+Hoje nada impede um PR em `ai/XslSynth.Core` (transpilador, `DslRuleTranslator`, prompts) de piorar
+silenciosamente a qualidade de geração — só o job semanal na VM detectaria, dias depois. Não existe
+"rodar um subconjunto pequeno do eval-test a cada PR que toca `ai/**`".
+
+## 2. Plano faseado
+
+### Fase A (curto prazo, baixo custo) — feito nesta sessão como POC
+Wrapper de comparação multi-modelo sobre a infra existente (fecha G1 parcialmente, sem tocar
+C#). Ver §4.
+
+### Fase B — Convergência do loop completo por modelo (fecha G3)
+Novo modo `--mode=repair-batch` (ou flag no `metrics-batch` existente) que, por caso do dataset,
+roda `RepairOrchestrator.RunAsync` (não só `OllamaClient.GenerateAsync`) e registra:
+`Converged`, `Iterations`, `FinalDiffs.Count`, `FinalXsd.IsValid` — os campos que `SynthesisReport`
+já expõe, hoje só usados no fluxo `--generate` interativo (1 caso), nunca em lote. É extensão
+natural do `RepairOrchestrator` já existente, não coisa nova — o trabalho é o loop de lote +
+log estruturado (mesmo padrão `Source=AiMetrics`, campo novo `Source=AiConvergence` ou reaproveitar
+o mesmo schema com `Converged`/`Iterations` adicionados). Mais caro que o `metrics-batch` atual
+(várias chamadas de LLM por caso, não 1) — candidato a rodar só nightly/semanal, com `--limit`
+pequeno em CI.
+Dono sugerido: `@lp-parser-llm`.
+
+### Fase C — Captura de CPU/RAM real (fecha G2)
+Na VM Linux, envolver a chamada ao `dotnet XslSynth.dll --mode=metrics-batch` com `/usr/bin/time -v`
+(já disponível em Ubuntu sem instalar nada extra) capturando `Maximum resident set size` e
+`Percent of CPU this job got` — **mas atenção**: a inferência roda no processo do **Ollama server**,
+não no processo do XslSynth (o XslSynth só faz a chamada HTTP). Medir RSS do processo `ollama`
+(via `ps`/`/proc/<pid>/status` no momento da chamada, ou `nvidia-smi` equivalente para CPU: nenhum,
+é CPU-only) é o dado que realmente importa para "cabe no servidor". Proposta: script wrapper que,
+durante a rodada, faz polling de `ps -o rss,%cpu -p $(pgrep ollama)` a cada N segundos e agrega
+min/max/média — soma pouco código, sem mudar C#.
+Dono sugerido: `@lp-devops` (acesso à VM) + `@lp-parser-llm` (integração do dado no relatório).
+
+### Fase D — Suíte sintética por categoria de operação (fecha G4)
+10-20 pares TCL→XSLT sintéticos mínimos, 1-3 por categoria (copy, concat, conditional, lookup,
+date-format, numeric-format), versionados em `ai/XslSynth/training-data/eval-suite-sintetica/`
+(separado do dataset real de treino/held-out — este é só para diagnóstico, nunca para treino).
+Reaproveita o mesmo `--mode=metrics-batch --dataset <esse arquivo>` — não é modo novo, é dataset
+novo. Menor prioridade que B/C porque o dataset real já dá sinal agregado; isto é para quando um
+modelo específico precisar de diagnóstico fino ("por que caiu a nota, o que ele não sabe fazer").
+Dono sugerido: `@lp-parser-llm` (conhece as categorias DSL) com `@lp-qa` revisando os gabaritos.
+
+### Fase E — Lint estrutural + gate de CI (fecha G5, G6)
+1. Função pequena e determinística (sem LLM) que valida: XML bem-formado, raiz
+   `xsl:stylesheet`/`xsl:transform`, presença de `xsl:output`. Pode nascer como método estático em
+   `OutputValidator` (reaproveitando o parse já feito) ou em `ai/XslSynth.Core/Core/` se for usada
+   fora do contexto de métricas.
+2. Step de CI (`.github/workflows/ci-dev.yml` ou workflow novo) que roda
+   `--mode=metrics-batch --limit 5 --dry-run=false` contra um modelo pequeno/rápido em todo PR que
+   toca `ai/**`, com um teto de qualidade mínimo (ex.: `TagOverlapRatio` médio não pode cair mais
+   que X% vs. a última rodada nightly) — **não bloqueante no início** (`continue-on-error: true`),
+   vira gate real só depois de ter baseline suficiente para não gerar falso-positivo.
+Dono sugerido: `@lp-devops` (CI) com `@lp-qa` definindo o teto de qualidade.
+
+## 3. Onde cada coisa roda (trade-offs)
+
+| Peça | Onde | Por quê |
+|---|---|---|
+| Fase A (comparação multi-modelo) | Manual, sob demanda (script) | Decisão pontual e cara (múltiplos modelos grandes) — não é algo para rodar toda semana sem necessidade. |
+| Fase B (convergência do loop) | Nightly/semanal na VM (estende o cron já existente) | Caro (múltiplas chamadas LLM por caso); frequência baixa é aceitável, é dado de tendência, não de PR. |
+| Fase C (CPU/RAM) | Acoplado à Fase A e B (mesma execução, dado extra) | Não é uma execução própria, é instrumentação da que já existe. |
+| Fase D (suíte sintética) | Manual/sob demanda + opcionalmente no gate de CI (Fase E), por ser barata (poucos casos) | Rápida o bastante para caber em CI sem estourar o orçamento de minutos. |
+| Fase E (lint + gate CI) | CI, a cada PR em `ai/**` | É exatamente o caso de uso de CI: feedback rápido, caso pequeno, não pode esperar o nightly. |
+
+## 4. POC implementado nesta sessão (Fase A, mínimo)
+
+`Scripts/vm/run-model-benchmark-comparison.sh` — wrapper que roda `--mode=metrics-batch` para uma
+lista de modelos (env `MODELS="qwen2.5-coder:7b qwen2.5-coder:14b layoutparser-sysmiddle-dsl:1.5b"`),
+mesmo `--dataset`/`--limit`, e agrega os `Resumo do lote` (já logados pelo `MetricsBatchRunner`
+existente, `LogResumo`) numa tabela markdown única em stdout — sem mudar nenhum código C#, só
+orquestração de shell reaproveitando o binário publicado que já existe na VM (§6 do plano de
+produção). Não implementa G2 (CPU/RAM) nem G3 (convergência) — só fecha a lacuna mecânica de "rodar
+N modelos numa sessão e comparar sem grep manual".
+
+**Limitação honesta:** não roda de verdade no ambiente de dev (sem Ollama local configurado com os
+modelos grandes, sem acesso à VM nesta sessão) — não pôde ser validado empiricamente contra a VM
+real. É esqueleto revisável, não uma execução comprovada. `@lp-devops`/dono devem rodar na VM antes
+de confiar no output.
+
+## 5. Recomendação de issue (não criada aqui — papel do `@lp-pm`)
+
+Sugiro ao `@lp-pm` abrir 1 issue por fase (B a E), linkadas a este documento, com a Fase B como
+prioridade mais alta (é o gap que mais distorce a decisão de "aumentar modelo": sem ela, decide-se
+por similaridade textual do primeiro palpite, não pela taxa de convergência real do sistema em
+produção).


### PR DESCRIPTION
## Promoção develop -> master

Conteúdo novo: PR #353 — modo `--mode=repair-batch` no `XslSynth`, medindo taxa de convergência
real (diff==0 + XSD) por modelo. Validado com rodada E2E real contra o Ollama de produção
(`172.25.32.5`, modelo `layoutparser-sysmiddle-dsl:1.5b`) antes do merge.

`dotnet test`: 89/89 verdes, sem regressão. Sem mudança de contrato público da API (é
ferramenta de linha de comando em `ai/XslSynth`, não endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)