### PR TITLE
fix(generation): calcula dígito verificador real (módulo 11) de CPF/CNPJ sintético

### DIFF
--- a/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
+++ b/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
@@ -255,16 +255,60 @@ namespace LayoutParserApi.Services.Generation.Implementations
 
         private string GenerateCnpj()
         {
-            // Gerar CNPJ válido sinteticamente
-            var cnpj = _random.Next(10000000, 99999999).ToString() + "0001" + _random.Next(10, 99).ToString();
-            return cnpj.PadLeft(14, '0');
+            // Gera CNPJ sinteticamente válido: 12 dígitos base (8 aleatórios + "0001" de
+            // filial matriz) seguidos dos 2 dígitos verificadores calculados por módulo 11.
+            var baseDigits = _random.Next(10000000, 99999999).ToString() + "0001";
+            var dv1 = CalculateCnpjCheckDigit(baseDigits);
+            var dv2 = CalculateCnpjCheckDigit(baseDigits + dv1);
+            return baseDigits + dv1 + dv2;
         }
 
         private string GenerateCpf()
         {
-            // Gerar CPF válido sinteticamente
-            var cpf = _random.Next(100000000, 999999999).ToString() + _random.Next(10, 99).ToString();
-            return cpf.PadLeft(11, '0');
+            // Gera CPF sinteticamente válido: 9 dígitos base aleatórios seguidos dos 2
+            // dígitos verificadores calculados por módulo 11.
+            var baseDigits = _random.Next(100000000, 999999999).ToString().PadLeft(9, '0');
+            var dv1 = CalculateCpfCheckDigit(baseDigits);
+            var dv2 = CalculateCpfCheckDigit(baseDigits + dv1);
+            return baseDigits + dv1 + dv2;
+        }
+
+        /// <summary>
+        /// Calcula um dígito verificador de CPF pelo algoritmo padrão de módulo 11.
+        /// Os pesos começam em (tamanho do trecho + 1) e decrescem até 2.
+        /// </summary>
+        private static int CalculateCpfCheckDigit(string digits)
+        {
+            var sum = 0;
+            var weight = digits.Length + 1;
+
+            foreach (var c in digits)
+            {
+                sum += (c - '0') * weight;
+                weight--;
+            }
+
+            var remainder = sum % 11;
+            return remainder < 2 ? 0 : 11 - remainder;
+        }
+
+        /// <summary>
+        /// Calcula um dígito verificador de CNPJ pelo algoritmo padrão de módulo 11.
+        /// Os pesos seguem a sequência fixa 2..9 repetida da direita para a esquerda.
+        /// </summary>
+        private static int CalculateCnpjCheckDigit(string digits)
+        {
+            var sum = 0;
+            var weight = 2;
+
+            for (var i = digits.Length - 1; i >= 0; i--)
+            {
+                sum += (digits[i] - '0') * weight;
+                weight = weight == 9 ? 2 : weight + 1;
+            }
+
+            var remainder = sum % 11;
+            return remainder < 2 ? 0 : 11 - remainder;
         }
 
         private string GenerateDate()

--- a/tests/LayoutParserApi.Tests/Services/Generation/SyntheticDataGeneratorServiceCpfCnpjTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Generation/SyntheticDataGeneratorServiceCpfCnpjTests.cs
@@ -1,0 +1,104 @@
+using LayoutParserApi.Models.Entities;
+using LayoutParserApi.Services.Generation.Implementations;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LayoutParserApi.Tests.Services.Generation
+{
+    /// <summary>
+    /// Cobre a correção do bug encontrado pelo `@lp-architect` (ADR
+    /// docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md):
+    /// <see cref="SyntheticDataGeneratorService"/> comentava gerar CPF/CNPJ "válido", mas só
+    /// preenchia dígitos aleatórios — sem dígito verificador real (módulo 11). Este teste roda
+    /// a geração várias vezes e valida o dígito verificador de verdade, pra não ser coincidência.
+    /// </summary>
+    public class SyntheticDataGeneratorServiceCpfCnpjTests
+    {
+        private const int Iterations = 100;
+
+        private static SyntheticDataGeneratorService CriarServico()
+            => new(NullLogger<SyntheticDataGeneratorService>.Instance);
+
+        [Fact]
+        public async Task GenerateFieldValueAsync_cpf_gera_sempre_digito_verificador_valido()
+        {
+            var service = CriarServico();
+            var field = new FieldElement { Name = "CPF_CLIENTE", LengthField = 11 };
+
+            for (var i = 0; i < Iterations; i++)
+            {
+                var cpf = await service.GenerateFieldValueAsync(field, $"Record {i}", "cpf");
+
+                Assert.Equal(11, cpf.Length);
+                Assert.True(IsCpfValido(cpf), $"CPF gerado inválido: {cpf}");
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFieldValueAsync_cnpj_gera_sempre_digito_verificador_valido()
+        {
+            var service = CriarServico();
+            var field = new FieldElement { Name = "CNPJ_EMPRESA", LengthField = 14 };
+
+            for (var i = 0; i < Iterations; i++)
+            {
+                var cnpj = await service.GenerateFieldValueAsync(field, $"Record {i}", "cnpj");
+
+                Assert.Equal(14, cnpj.Length);
+                Assert.True(IsCnpjValido(cnpj), $"CNPJ gerado inválido: {cnpj}");
+            }
+        }
+
+        /// <summary>Validação independente de CPF por módulo 11 (não reaproveita a lógica testada).</summary>
+        private static bool IsCpfValido(string cpf)
+        {
+            if (cpf.Length != 11 || !cpf.All(char.IsDigit)) return false;
+
+            var dv1 = CalcularDigito(cpf[..9], pesoInicial: 10);
+            var dv2 = CalcularDigito(cpf[..9] + dv1, pesoInicial: 11);
+
+            return cpf == cpf[..9] + dv1 + dv2;
+        }
+
+        /// <summary>Validação independente de CNPJ por módulo 11 (não reaproveita a lógica testada).</summary>
+        private static bool IsCnpjValido(string cnpj)
+        {
+            if (cnpj.Length != 14 || !cnpj.All(char.IsDigit)) return false;
+
+            var dv1 = CalcularDigitoCnpj(cnpj[..12]);
+            var dv2 = CalcularDigitoCnpj(cnpj[..12] + dv1);
+
+            return cnpj == cnpj[..12] + dv1 + dv2;
+        }
+
+        private static int CalcularDigito(string digits, int pesoInicial)
+        {
+            var sum = 0;
+            var weight = pesoInicial;
+
+            foreach (var c in digits)
+            {
+                sum += (c - '0') * weight;
+                weight--;
+            }
+
+            var remainder = sum % 11;
+            return remainder < 2 ? 0 : 11 - remainder;
+        }
+
+        private static int CalcularDigitoCnpj(string digits)
+        {
+            var sum = 0;
+            var weight = 2;
+
+            for (var i = digits.Length - 1; i >= 0; i--)
+            {
+                sum += (digits[i] - '0') * weight;
+                weight = weight == 9 ? 2 : weight + 1;
+            }
+
+            var remainder = sum % 11;
+            return remainder < 2 ? 0 : 11 - remainder;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

`Services/Generation/Implementations/SyntheticDataGeneratorService.cs` — `GenerateCnpj()`/
`GenerateCpf()` afirmavam no comentário gerar CPF/CNPJ "válido", mas só preenchiam dígitos
aleatórios com `PadLeft`, sem calcular dígito verificador nenhum. Achado pelo `@lp-architect`
durante o ADR `docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md`.

## Fix

- 9 (CPF) / 12 (CNPJ) primeiros dígitos continuam aleatórios.
- 2 dígitos verificadores agora calculados de verdade por módulo 11 (`CalculateCpfCheckDigit`/
  `CalculateCnpjCheckDigit`, novos métodos privados estáticos).
- Assinatura pública e retorno (`string`) inalterados.
- Comentários corrigidos pra refletir o comportamento real.

## Testes

100 iterações cada (CPF/CNPJ) via `GenerateFieldValueAsync`, validando o dígito verificador com
uma implementação de validação **independente** (não reaproveita a lógica sob teste). `dotnet
build`: 0 erros.

Não resolve sozinho o gap de coerência semântica entre campos nem a existência fiscal real do
documento (registrado no ADR) — só a validade estrutural do dígito verificador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)