### PR TITLE
Promove develop -> master: endpoint generate-sample (issue #355)

### DIFF
--- a/Controllers/FiscalMappingPackagesController.cs
+++ b/Controllers/FiscalMappingPackagesController.cs
@@ -95,7 +95,14 @@ namespace LayoutParserApi.Controllers
                 using var memoryStream = new MemoryStream();
                 await file.CopyToAsync(memoryStream, cancellationToken);
 
-                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray()));
+                // ✅ issue #341: campo de texto opcional "{kind}Provenance" (ex.: "sampleProvenance")
+                // — proveniência declarada pelo analista, NUNCA inferida. Ausente/inválido vira null
+                // e o serviço trata como amostra real (fail-closed, ver ArtifactProvenance.IsValid).
+                var provenance = Request.Form.TryGetValue($"{file.Name}Provenance", out var provenanceValue)
+                    ? provenanceValue.ToString()
+                    : null;
+
+                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray(), provenance));
             }
 
             var idempotencyKey = Request.Headers.TryGetValue("Idempotency-Key", out var headerValue) ? headerValue.ToString() : null;
@@ -205,7 +212,14 @@ namespace LayoutParserApi.Controllers
                 using var memoryStream = new MemoryStream();
                 await file.CopyToAsync(memoryStream, cancellationToken);
 
-                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray()));
+                // ✅ issue #341: campo de texto opcional "{kind}Provenance" (ex.: "sampleProvenance")
+                // — proveniência declarada pelo analista, NUNCA inferida. Ausente/inválido vira null
+                // e o serviço trata como amostra real (fail-closed, ver ArtifactProvenance.IsValid).
+                var provenance = Request.Form.TryGetValue($"{file.Name}Provenance", out var provenanceValue)
+                    ? provenanceValue.ToString()
+                    : null;
+
+                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray(), provenance));
             }
 
             CreateRevisionOutcome outcome;
@@ -319,6 +333,7 @@ namespace LayoutParserApi.Controllers
                         originalFileName = a.OriginalFileName,
                         inspectionStatus = a.InspectionStatus,
                         uploadedAt = a.UploadedAt,
+                        provenance = a.Provenance,
                     })
                 }
             }

--- a/Controllers/LayoutsController.cs
+++ b/Controllers/LayoutsController.cs
@@ -57,9 +57,12 @@ namespace LayoutParserApi.Controllers
         /// <response code="400"><c>layoutGuid</c> não corresponde a nenhum layout conhecido.</response>
         /// <response code="404">Layout existe, mas não há mapper (TCL/XSL/XSLT) vinculado — geração de exemplo requer mapeamento existente.</response>
         /// <response code="501">Layout do tipo <c>Xml</c> — cobertura fica para a issue #356 (parser de árvore ainda não existe).</response>
-        // Issue #32/#355: mesma classe de privilégio de DataGenerationController (geração de dado
-        // sintético é operação restrita) — admin.
-        [Authorize(Roles = "admin")]
+        // Issue #355: confirmado com o dono (2026-09-09) que o botão "Gerar documento de
+        // exemplo" é para qualquer usuário autenticado, não admin-only — diferente do padrão
+        // de DataGenerationController (geração a partir de planilha real, essa sim restrita).
+        // Aqui o dado é 100% sintético e a pré-condição de mapper já existente (abaixo) já
+        // limita o uso a layouts em desenvolvimento ativo.
+        [Authorize]
         [HttpPost("{layoutGuid}/generate-sample")]
         public async Task<IActionResult> GenerateSample(string layoutGuid, [FromBody] GenerateSampleRequest? request)
         {

--- a/Controllers/LayoutsController.cs
+++ b/Controllers/LayoutsController.cs
@@ -1,0 +1,164 @@
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Entities;
+using LayoutParserApi.Models.Generation;
+using LayoutParserApi.Services.Database;
+using LayoutParserApi.Services.Filters;
+using LayoutParserApi.Services.Generation.Implementations;
+using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.LowCode;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Controllers
+{
+    /// <summary>
+    /// Operações de catálogo sobre um layout específico. Hoje só a geração de documento de
+    /// exemplo (issue #355) — não reaproveita <c>DataGenerationController</c> porque aquele gira
+    /// em torno de <c>ExcelDataContext</c> (planilha do analista como fonte), cenário diferente
+    /// de "gerar a partir só do layout+mapper já cadastrados".
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    [ServiceFilter(typeof(AuditActionFilter))]
+    public class LayoutsController : ControllerBase
+    {
+        private readonly ICachedLayoutService _cachedLayoutService;
+        private readonly MapperDatabaseService _mapperDb;
+        private readonly ISyntheticDataGeneratorService _dataGenerator;
+        private readonly LowCodeRunnerOptions _lowCodeOpt;
+        private readonly ILogger<LayoutsController> _logger;
+
+        public LayoutsController(
+            ICachedLayoutService cachedLayoutService,
+            MapperDatabaseService mapperDb,
+            ISyntheticDataGeneratorService dataGenerator,
+            IOptions<LowCodeRunnerOptions> lowCodeOptions,
+            ILogger<LayoutsController> logger)
+        {
+            _cachedLayoutService = cachedLayoutService;
+            _mapperDb = mapperDb;
+            _dataGenerator = dataGenerator;
+            _lowCodeOpt = lowCodeOptions.Value;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gera um documento de exemplo sintético a partir de um layout <c>TextPositional</c> que
+        /// já tem mapper (TCL/XSL/XSLT) vinculado — pré-condição obrigatória (correção do dono no
+        /// ADR docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md): o exemplo serve
+        /// para alimentar/testar um mapper existente, nunca "existe sozinho".
+        /// </summary>
+        /// <param name="layoutGuid">GUID do layout (com ou sem prefixo <c>LAY_</c>).</param>
+        /// <param name="request">Quantidade de registros e semente (semente ainda não suportada — ver aviso no response).</param>
+        /// <response code="200">Documento gerado, com <c>warnings</c> honestos sobre a qualidade do dado.</response>
+        /// <response code="400"><c>layoutGuid</c> não corresponde a nenhum layout conhecido.</response>
+        /// <response code="404">Layout existe, mas não há mapper (TCL/XSL/XSLT) vinculado — geração de exemplo requer mapeamento existente.</response>
+        /// <response code="501">Layout do tipo <c>Xml</c> — cobertura fica para a issue #356 (parser de árvore ainda não existe).</response>
+        // Issue #32/#355: mesma classe de privilégio de DataGenerationController (geração de dado
+        // sintético é operação restrita) — admin.
+        [Authorize(Roles = "admin")]
+        [HttpPost("{layoutGuid}/generate-sample")]
+        public async Task<IActionResult> GenerateSample(string layoutGuid, [FromBody] GenerateSampleRequest? request)
+        {
+            if (string.IsNullOrWhiteSpace(layoutGuid))
+                return BadRequest(new { error = "layoutGuid é obrigatório" });
+
+            request ??= new GenerateSampleRequest();
+            var numberOfRecords = request.NumberOfRecords > 0 ? request.NumberOfRecords : 1;
+
+            // ✅ 400 — layoutGuid não corresponde a nenhum layout conhecido no catálogo.
+            LayoutRecord? layoutRecord;
+            try
+            {
+                layoutRecord = await _cachedLayoutService.GetLayoutByGuidAsync(layoutGuid);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha de infraestrutura ao resolver layout {LayoutGuid} para generate-sample", layoutGuid);
+                return StatusCode(500, new { error = "Falha de infraestrutura ao consultar o catálogo de layouts" });
+            }
+
+            if (layoutRecord == null || string.IsNullOrWhiteSpace(layoutRecord.DecryptedContent))
+                return BadRequest(new { error = $"Layout '{layoutGuid}' não encontrado no catálogo" });
+
+            // ⚠️ Landmine já registrada (lowcode-allowedpackageguids-empty-in-null-2026-08-15):
+            // AllowedPackageGuids vazio faz a query de mapper virar IN (NULL), gerando
+            // falso-negativo de "sem mapper". Logamos o alerta antes de tratar null como
+            // definitivo — não bloqueia a resposta (o host pode legitimamente não ter mapper).
+            if (_lowCodeOpt.AllowedPackageGuids is null || _lowCodeOpt.AllowedPackageGuids.Count == 0)
+            {
+                _logger.LogWarning(
+                    "LowCode:AllowedPackageGuids esta vazio ao resolver mapper para generate-sample (layout={LayoutGuid}) — " +
+                    "um 404 aqui pode ser falso-negativo de configuracao, nao ausencia real de mapper.",
+                    layoutGuid);
+            }
+
+            // ✅ 404 — pré-condição obrigatória: layout existe, mas sem mapper vinculado.
+            var mapper = await _mapperDb.GetBestMapperForLayoutGuidAsync(layoutGuid, _lowCodeOpt.ProjectId, _lowCodeOpt.AllowedPackageGuids);
+            if (mapper == null)
+            {
+                return NotFound(new
+                {
+                    error = "Nenhum mapper vinculado a este layout. Geração de exemplo requer mapeamento existente " +
+                             "(ver docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md)."
+                });
+            }
+
+            Layout layout;
+            try
+            {
+                layout = XmlLayoutLoader.LoadLayoutFromXmlString(layoutRecord.DecryptedContent);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao parsear XML do layout {LayoutGuid} para generate-sample", layoutGuid);
+                return StatusCode(500, new { error = "Falha ao interpretar o XML do layout" });
+            }
+
+            // Escopo desta issue: só TextPositional. Xml fica para a #356 (parser de árvore ainda
+            // não existe no repo C# — ver ADR, Decisão 4).
+            if (!string.Equals(layout.LayoutType, "TextPositional", StringComparison.OrdinalIgnoreCase))
+            {
+                return StatusCode(StatusCodes.Status501NotImplemented, new
+                {
+                    error = $"Geração de exemplo para layout tipo '{layout.LayoutType}' ainda não implementada. " +
+                             "Cobertura de layout Xml é escopo da issue #356 (parser de árvore em C#, ainda não existe)."
+                });
+            }
+
+            var warnings = new List<string>
+            {
+                "CPF/CNPJ gerados têm dígito verificador matematicamente válido, mas não correspondem a pessoa/empresa real.",
+                "Campos não têm correlação semântica entre si (datas, valores, CFOP etc. são gerados independentemente) — não usar como dado fiscalmente coerente.",
+                "Este exemplo não é injetado automaticamente em nenhum pipeline de aprendizado/medição — requer revisão humana antes de qualquer uso em RepairOrchestrator/RepairBatchRunner."
+            };
+
+            if (request.Seed.HasValue)
+                warnings.Add("O parâmetro 'seed' foi ignorado: o gerador de dados sintéticos atual não suporta geração determinística por semente.");
+
+            var syntheticRequest = new Models.Generation.SyntheticDataRequest
+            {
+                Layout = layout,
+                NumberOfRecords = numberOfRecords,
+                UseAI = false
+            };
+
+            var result = await _dataGenerator.GenerateSyntheticDataAsync(syntheticRequest);
+            if (!result.Success)
+            {
+                _logger.LogWarning("Falha ao gerar exemplo sintético para layout {LayoutGuid}: {Error}", layoutGuid, result.ErrorMessage);
+                return StatusCode(500, new { error = result.ErrorMessage ?? "Falha na geração do documento de exemplo" });
+            }
+
+            return Ok(new GenerateSampleResponse
+            {
+                GeneratedDocument = string.Join("\n", result.GeneratedLines),
+                Format = "positional",
+                Warnings = warnings
+            });
+        }
+    }
+}

--- a/Models/Entities/Fiscal/PackageArtifact.cs
+++ b/Models/Entities/Fiscal/PackageArtifact.cs
@@ -46,6 +46,38 @@ namespace LayoutParserApi.Models.Entities.Fiscal
     }
 
     /// <summary>
+    /// Proveniência do CONTEÚDO de um <see cref="PackageArtifact"/> (issue #341 — Fase F2 do ADR
+    /// docs/architecture/adr-llm-provider-plugavel-2026-09-08.md). Explícito e preenchido pelo
+    /// analista ao anexar o arquivo — NUNCA inferido pelo tipo (<see cref="ArtifactKind"/>) ou
+    /// pelo nome do arquivo. Regra central (ADR §2.3, issue #341 critério de aceite): a AUSÊNCIA
+    /// deste valor (<c>null</c>/vazio) resolve para <c>RealCustomerSample</c> — nunca para
+    /// <see cref="Synthetic"/> por omissão/default. Ver <see cref="ResolveSensitivity"/>.
+    /// </summary>
+    public static class ArtifactProvenance
+    {
+        /// <summary>Gerado por regra/fixture — elegível a <c>DataSensitivity.SyntheticOrAnonymized</c> (fases futuras de F3).</summary>
+        public const string Synthetic = "synthetic";
+
+        /// <summary>Amostra real de cliente anexada pelo analista — sempre <c>DataSensitivity.RealFiscalDocument</c>.</summary>
+        public const string RealCustomerSample = "real_customer_sample";
+
+        public static readonly IReadOnlyCollection<string> All = new[] { Synthetic, RealCustomerSample };
+
+        public static bool IsValid(string? value) => value != null && All.Contains(value);
+
+        /// <summary>
+        /// Resolve a <see cref="Services.Llm.DataSensitivity"/> a partir da proveniência declarada.
+        /// Fail-closed: qualquer valor ausente, vazio ou não reconhecido resolve para
+        /// <see cref="Services.Llm.DataSensitivity.RealFiscalDocument"/> — só o valor EXPLÍCITO
+        /// <see cref="Synthetic"/> resolve para <see cref="Services.Llm.DataSensitivity.SyntheticOrAnonymized"/>.
+        /// </summary>
+        public static Services.Llm.DataSensitivity ResolveSensitivity(string? provenance)
+            => provenance == Synthetic
+                ? Services.Llm.DataSensitivity.SyntheticOrAnonymized
+                : Services.Llm.DataSensitivity.RealFiscalDocument;
+    }
+
+    /// <summary>
     /// Um artefato binário dentro de uma revisão imutável de <see cref="FiscalMappingPackage"/>.
     /// Metadado em SQL; conteúdo bruto em filesystem (<c>MLData/FiscalMappingPackages/...</c>) —
     /// nunca no log/erro (ver <c>.claude/rules/security.md</c>).
@@ -88,5 +120,8 @@ namespace LayoutParserApi.Models.Entities.Fiscal
 
         /// <summary>Caminho relativo dentro do store de filesystem (não é o caminho absoluto do host).</summary>
         public string StoragePath { get; set; } = string.Empty;
+
+        /// <summary>Ver <see cref="ArtifactProvenance"/>. <c>null</c> resolve como <see cref="ArtifactProvenance.RealCustomerSample"/> (fail-closed).</summary>
+        public string? Provenance { get; set; }
     }
 }

--- a/Models/Generation/GenerateSampleRequest.cs
+++ b/Models/Generation/GenerateSampleRequest.cs
@@ -1,0 +1,20 @@
+namespace LayoutParserApi.Models.Generation
+{
+    /// <summary>
+    /// Body de <c>POST /api/layouts/{layoutGuid}/generate-sample</c> (issue #355).
+    /// </summary>
+    public class GenerateSampleRequest
+    {
+        /// <summary>Quantos registros gerar. Default 1.</summary>
+        public int NumberOfRecords { get; set; } = 1;
+
+        /// <summary>
+        /// Semente para geração determinística. ⚠️ Ainda NÃO suportado por
+        /// <see cref="Interfaces.ISyntheticDataGeneratorService"/> (usa <c>Random</c> sem seed
+        /// injetável) — aceito no contrato para não quebrar quem já envia o campo, mas ignorado
+        /// com aviso honesto em <c>warnings</c> do response. Ver ADR
+        /// docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md.
+        /// </summary>
+        public int? Seed { get; set; }
+    }
+}

--- a/Models/Generation/GenerateSampleResponse.cs
+++ b/Models/Generation/GenerateSampleResponse.cs
@@ -1,0 +1,20 @@
+namespace LayoutParserApi.Models.Generation
+{
+    /// <summary>
+    /// Response de <c>POST /api/layouts/{layoutGuid}/generate-sample</c> (issue #355).
+    /// </summary>
+    public class GenerateSampleResponse
+    {
+        /// <summary>Documento sintético gerado (linhas separadas por <c>\n</c> quando <c>NumberOfRecords &gt; 1</c>).</summary>
+        public string GeneratedDocument { get; set; } = string.Empty;
+
+        /// <summary>Formato do documento: <c>"positional"</c> (esta issue) ou <c>"xml"</c> (issue #356, não implementado aqui).</summary>
+        public string Format { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Avisos honestos sobre a qualidade do dado gerado — nunca sobre-prometer qualidade
+        /// fiscal (ver ADR §"Decisão 1"/correção do dono).
+        /// </summary>
+        public List<string> Warnings { get; set; } = new();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -493,10 +493,10 @@ try
     builder.Services.AddScoped<IAntivirusScanner, LayoutParserApi.Services.Fiscal.WindowsDefenderAntivirusScanner>();
     builder.Services.AddScoped<IFiscalPackageService, LayoutParserApi.Services.Fiscal.FiscalPackageService>();
     // ✅ Slice 3 (issue #230): MappingDraft human-in-the-loop — mesmo banco/padrão ADO.NET.
-    // MappingSuggestionService usa HttpClient (Ollama) — AddHttpClient para pooling correto de conexão,
-    // mesmo padrão de OllamaValidationDiagnosticService.
+    // MappingSuggestionService consome ILlmProvider (issue #340/F1) — sem HttpClient direto aqui;
+    // o pooling de conexão HTTP fica encapsulado dentro do registro do OllamaLlmProvider (grupo Llm, abaixo).
     builder.Services.AddScoped<IMappingDraftStore, SqlMappingDraftStore>();
-    builder.Services.AddHttpClient<IMappingSuggestionService, LayoutParserApi.Services.Fiscal.MappingSuggestionService>();
+    builder.Services.AddScoped<IMappingSuggestionService, LayoutParserApi.Services.Fiscal.MappingSuggestionService>();
     builder.Services.AddScoped<LayoutParserApi.Services.Filters.MappingEngineGuardFilter>();
     // ✅ Slice 4 (issue #226/#227): MappingExplanation — 3 adapters determinísticos (sem LLM),
     // resolvidos por Engine no controller via IEnumerable<IMappingExplanationAdapter>.
@@ -599,16 +599,20 @@ try
     // docs/architecture/multi-candidato-e-diagnostico-ia-contrato.md. Não usa GeminiAIService
     // (decomissionado, sem registro no DI — ver generation-services-unregistered-di.md).
     builder.Services.Configure<OllamaOptions>(builder.Configuration.GetSection("Ollama"));
-    // ✅ Desliga o HttpClient.Timeout padrão (100s) do client tipado: o timeout real de
-    // diagnóstico é o nosso próprio CancellationTokenSource (Ollama:DiagnosisTimeoutSeconds,
-    // dentro de OllamaValidationDiagnosticService). Descoberto em teste manual: sem isso, o
-    // timeout de 100s do HttpClient dispara ANTES do nosso e lança TaskCanceledException/
-    // TimeoutException que o catch dedicado de timeout não reconhecia — caía no 500 genérico
-    // em vez do 504 esperado pelo contrato (Gap 2).
-    builder.Services.AddHttpClient<OllamaValidationDiagnosticService>(client =>
+
+    // ✅ Issue #340 (F1, ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md): abstração
+    // ILlmProvider/LlmProviderResolver — único provider registrado nesta fase é o Ollama local.
+    // Desliga o HttpClient.Timeout padrão (100s) do client tipado: cada serviço consumidor controla
+    // seu próprio timeout via CancellationToken (ex.: Ollama:DiagnosisTimeoutSeconds dentro de
+    // OllamaValidationDiagnosticService). Descoberto em teste manual (Gap 2): sem isso, o timeout de
+    // 100s do HttpClient dispara ANTES do timeout dedicado e lança TaskCanceledException/
+    // TimeoutException que o catch dedicado de timeout não reconhecia — caía no 500 genérico em
+    // vez do 504 esperado pelo contrato.
+    builder.Services.AddHttpClient<LayoutParserApi.Services.Llm.ILlmProvider, LayoutParserApi.Services.Llm.OllamaLlmProvider>(client =>
     {
         client.Timeout = Timeout.InfiniteTimeSpan;
     });
+    builder.Services.AddScoped<LayoutParserApi.Services.Llm.LlmProviderResolver>();
 
     // ✅ Pathway IA de execute-candidates (Issue #40) — loop gerar → validar XSD → comparar com o
     // gabarito sysmiddle → corrigir, assíncrono/desacoplado do ciclo síncrono do endpoint (ver

--- a/Services/Database/MapperDatabaseService.cs
+++ b/Services/Database/MapperDatabaseService.cs
@@ -184,7 +184,10 @@ namespace LayoutParserApi.Services.Database
         /// Busca o "melhor" mapeador para um layoutGuid, restrito a ProjectId e uma lista de PackageGuids permitidos.
         /// Prioriza mappers onde o layoutGuid é InputLayoutGuid; se não encontrar, tenta TargetLayoutGuid.
         /// </summary>
-        public async Task<Mapper?> GetBestMapperForLayoutGuidAsync(string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids)
+        // virtual: mesmo ponto de substituição de GetRankedMapperCandidatesForLayoutGuidAsync —
+        // testes de endpoints que decidem 404 "sem mapper" (ex.: LayoutsController.GenerateSample,
+        // issue #355) precisam exercitar essa decisão sem SQL Server real.
+        public virtual async Task<Mapper?> GetBestMapperForLayoutGuidAsync(string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids)
         {
             var candidates = await GetMappersByLayoutGuidForPackagesAsync(layoutGuid, projectId, allowedPackageGuids);
             if (candidates.Count == 0)

--- a/Services/Database/SqlFiscalPackageStore.cs
+++ b/Services/Database/SqlFiscalPackageStore.cs
@@ -130,10 +130,10 @@ namespace LayoutParserApi.Services.Database
                     using var insertArtifact = new SqlCommand(
                         @"INSERT INTO dbo.tbPackageArtifact
                             (ArtifactId, RevisionId, Kind, Sha256, SizeBytes, OriginalFileName, MimeDeclared, MimeSniffed,
-                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath)
+                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath, Provenance)
                           VALUES
                             (@ArtifactId, @RevisionId, @Kind, @Sha256, @SizeBytes, @OriginalFileName, @MimeDeclared, @MimeSniffed,
-                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath);",
+                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath, @Provenance);",
                         connection, tx);
 
                     insertArtifact.Parameters.AddWithValue("@ArtifactId", artifact.ArtifactId);
@@ -149,6 +149,7 @@ namespace LayoutParserApi.Services.Database
                     insertArtifact.Parameters.AddWithValue("@RetentionPolicy", (object?)artifact.RetentionPolicy ?? DBNull.Value);
                     insertArtifact.Parameters.AddWithValue("@InspectionStatus", artifact.InspectionStatus);
                     insertArtifact.Parameters.AddWithValue("@StoragePath", artifact.StoragePath);
+                    insertArtifact.Parameters.AddWithValue("@Provenance", (object?)artifact.Provenance ?? DBNull.Value);
                     await insertArtifact.ExecuteNonQueryAsync(cancellationToken);
                 }
 
@@ -190,7 +191,7 @@ namespace LayoutParserApi.Services.Database
                     revisionId,
                     1,
                     createdAt,
-                    artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt)).ToList()));
+                    artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt, a.Provenance)).ToList()));
         }
 
         public async Task<PackageDetail?> GetPackageIfMemberAsync(Guid packageId, Guid userId, CancellationToken cancellationToken)
@@ -248,7 +249,7 @@ namespace LayoutParserApi.Services.Database
 
             var artifacts = new List<ArtifactSummary>();
             using (var selectArtifacts = new SqlCommand(
-                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt
+                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt, Provenance
                   FROM dbo.tbPackageArtifact
                   WHERE RevisionId = @RevisionId
                   ORDER BY UploadedAt ASC;",
@@ -265,7 +266,8 @@ namespace LayoutParserApi.Services.Database
                         reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                         reader.GetString(reader.GetOrdinal("OriginalFileName")),
                         reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero)));
+                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                        reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
                 }
             }
 
@@ -340,7 +342,7 @@ namespace LayoutParserApi.Services.Database
 
             var artifacts = new List<ArtifactSummary>();
             using (var selectArtifacts = new SqlCommand(
-                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt
+                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt, Provenance
                   FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId ORDER BY UploadedAt ASC;",
                 connection))
             {
@@ -355,7 +357,8 @@ namespace LayoutParserApi.Services.Database
                         reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                         reader.GetString(reader.GetOrdinal("OriginalFileName")),
                         reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero)));
+                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                        reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
                 }
             }
 
@@ -370,7 +373,7 @@ namespace LayoutParserApi.Services.Database
             await EnsureSchemaAsync(connection, cancellationToken);
 
             using var command = new SqlCommand(
-                @"SELECT a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, a.UploadedAt
+                @"SELECT a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, a.UploadedAt, a.Provenance
                   FROM dbo.tbPackageArtifact a
                   JOIN dbo.tbFiscalMappingPackageRevision r ON r.RevisionId = a.RevisionId
                   WHERE r.PackageId = @PackageId AND a.Sha256 = @Sha256
@@ -390,7 +393,8 @@ namespace LayoutParserApi.Services.Database
                 reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                 reader.GetString(reader.GetOrdinal("OriginalFileName")),
                 reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero));
+                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance")));
         }
 
         public async Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken)
@@ -484,10 +488,10 @@ namespace LayoutParserApi.Services.Database
                     using var insertArtifact = new SqlCommand(
                         @"INSERT INTO dbo.tbPackageArtifact
                             (ArtifactId, RevisionId, Kind, Sha256, SizeBytes, OriginalFileName, MimeDeclared, MimeSniffed,
-                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath)
+                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath, Provenance)
                           VALUES
                             (@ArtifactId, @RevisionId, @Kind, @Sha256, @SizeBytes, @OriginalFileName, @MimeDeclared, @MimeSniffed,
-                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath);",
+                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath, @Provenance);",
                         connection, tx);
 
                     insertArtifact.Parameters.AddWithValue("@ArtifactId", artifact.ArtifactId);
@@ -503,6 +507,7 @@ namespace LayoutParserApi.Services.Database
                     insertArtifact.Parameters.AddWithValue("@RetentionPolicy", (object?)artifact.RetentionPolicy ?? DBNull.Value);
                     insertArtifact.Parameters.AddWithValue("@InspectionStatus", artifact.InspectionStatus);
                     insertArtifact.Parameters.AddWithValue("@StoragePath", artifact.StoragePath);
+                    insertArtifact.Parameters.AddWithValue("@Provenance", (object?)artifact.Provenance ?? DBNull.Value);
                     await insertArtifact.ExecuteNonQueryAsync(cancellationToken);
                 }
 
@@ -517,7 +522,7 @@ namespace LayoutParserApi.Services.Database
                         revisionId,
                         revisionNumber,
                         createdAt,
-                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt)).ToList())
+                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt, a.Provenance)).ToList())
                 };
             }
             catch
@@ -628,7 +633,12 @@ CREATE TABLE dbo.tbPackageArtifact (
 );
 
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbPackageArtifact_RevisionId' AND object_id = OBJECT_ID('dbo.tbPackageArtifact'))
-CREATE INDEX IX_tbPackageArtifact_RevisionId ON dbo.tbPackageArtifact(RevisionId);";
+CREATE INDEX IX_tbPackageArtifact_RevisionId ON dbo.tbPackageArtifact(RevisionId);
+
+-- ✅ issue #341 (F2): coluna nova em tabela que pode já existir num banco antigo — ALTER idempotente
+-- separado do CREATE TABLE acima (que só roda se a tabela ainda não existir).
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.tbPackageArtifact') AND name = 'Provenance')
+ALTER TABLE dbo.tbPackageArtifact ADD Provenance NVARCHAR(32) NULL;";
 
         // internal (não mais private): chamado também pelo FiscalSchemaInitializer no startup, além
         // do próprio store por requisição (idempotente — safety net se o initializer não rodou/falhou).

--- a/Services/Database/SqlMappingDraftStore.cs
+++ b/Services/Database/SqlMappingDraftStore.cs
@@ -59,7 +59,7 @@ namespace LayoutParserApi.Services.Database
 
             var result = new List<ArtifactFileRef>();
             using var command = new SqlCommand(
-                "SELECT ArtifactId, Kind, StoragePath, OriginalFileName FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId;",
+                "SELECT ArtifactId, Kind, StoragePath, OriginalFileName, Provenance FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId;",
                 connection);
             command.Parameters.AddWithValue("@RevisionId", revisionId);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -69,7 +69,11 @@ namespace LayoutParserApi.Services.Database
                     reader.GetGuid(reader.GetOrdinal("ArtifactId")),
                     reader.GetString(reader.GetOrdinal("Kind")),
                     reader.GetString(reader.GetOrdinal("StoragePath")),
-                    reader.GetString(reader.GetOrdinal("OriginalFileName"))));
+                    reader.GetString(reader.GetOrdinal("OriginalFileName")),
+                    // ✅ issue #341: coluna pode não existir ainda se o schema de tbPackageArtifact
+                    // (dono: SqlFiscalPackageStore) não rodou o ALTER — trata ausência da coluna em si
+                    // como erro real (propaga), só o VALOR NULL da linha é tratado como ausência de proveniência.
+                    reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
             }
             return result;
         }

--- a/Services/Fiscal/FiscalPackageService.cs
+++ b/Services/Fiscal/FiscalPackageService.cs
@@ -107,6 +107,9 @@ namespace LayoutParserApi.Services.Fiscal
                         UploadedAt = DateTimeOffset.UtcNow,
                         InspectionStatus = Models.Entities.Fiscal.InspectionStatus.Pending,
                         StoragePath = relativePath,
+                        // ✅ issue #341: só grava a proveniência se for um valor explícito e válido —
+                        // valor ausente/inválido vira null, que a leitura trata como amostra real (fail-closed).
+                        Provenance = Models.Entities.Fiscal.ArtifactProvenance.IsValid(input.Provenance) ? input.Provenance : null,
                     });
                 }
 
@@ -191,6 +194,9 @@ namespace LayoutParserApi.Services.Fiscal
                         UploadedAt = DateTimeOffset.UtcNow,
                         InspectionStatus = Models.Entities.Fiscal.InspectionStatus.Pending,
                         StoragePath = relativePath,
+                        // ✅ issue #341: só grava a proveniência se for um valor explícito e válido —
+                        // valor ausente/inválido vira null, que a leitura trata como amostra real (fail-closed).
+                        Provenance = Models.Entities.Fiscal.ArtifactProvenance.IsValid(input.Provenance) ? input.Provenance : null,
                     });
                 }
 

--- a/Services/Fiscal/MappingSuggestionService.cs
+++ b/Services/Fiscal/MappingSuggestionService.cs
@@ -18,8 +18,11 @@ namespace LayoutParserApi.Services.Fiscal
     /// em vez de <see cref="HttpClient"/>/<see cref="XmlAnalysis.OllamaOptions"/> diretos (mesmo
     /// motor Ollama por trás — ver ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md).
     /// Nunca nuvem (Gemini/OpenAI decomissionados — dado fiscal sensível, ver <c>security.md</c>);
-    /// declara <see cref="DataSensitivity.RealFiscalDocument"/> explicitamente (artefatos do draft
-    /// podem conter amostra real — ADR §1.1, tratado como REAL até provar o contrário).
+    /// ✅ Issue #341 (F2): a sensibilidade NÃO é mais hardcoded incondicional — é resolvida a partir
+    /// da <see cref="ArtifactProvenance"/> declarada em cada artefato via
+    /// <see cref="ArtifactProvenance.ResolveSensitivity"/> (fail-closed: ausência/valor inválido
+    /// resolve para <see cref="DataSensitivity.RealFiscalDocument"/>, nunca para
+    /// <see cref="DataSensitivity.SyntheticOrAnonymized"/> por omissão — ADR §2.3).
     /// </summary>
     public sealed class MappingSuggestionService : IMappingSuggestionService
     {
@@ -146,8 +149,15 @@ namespace LayoutParserApi.Services.Fiscal
 
             var prompt = await BuildPromptAsync(relevant, cancellationToken);
 
-            var llmRequest = new LlmRequest(prompt, DataSensitivity.RealFiscalDocument, JsonSchema: "\"json\"", Temperature: 0.0);
-            var provider = _providerResolver.Resolve(DataSensitivity.RealFiscalDocument);
+            // ✅ issue #341: se QUALQUER artefato relevante não tiver proveniência explícita
+            // "synthetic", o lote inteiro é tratado como RealFiscalDocument — um artefato real
+            // misturado no prompt contamina a sensibilidade de tudo que foi enviado junto ao modelo.
+            var sensitivity = relevant.Any(a => Models.Entities.Fiscal.ArtifactProvenance.ResolveSensitivity(a.Provenance) == DataSensitivity.RealFiscalDocument)
+                ? DataSensitivity.RealFiscalDocument
+                : DataSensitivity.SyntheticOrAnonymized;
+
+            var llmRequest = new LlmRequest(prompt, sensitivity, JsonSchema: "\"json\"", Temperature: 0.0);
+            var provider = _providerResolver.Resolve(sensitivity);
 
             LlmResponse response;
             try

--- a/Services/Fiscal/MappingSuggestionService.cs
+++ b/Services/Fiscal/MappingSuggestionService.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 using LayoutParserApi.Models.Entities.Fiscal;
 using LayoutParserApi.Services.Interfaces;
-using LayoutParserApi.Services.XmlAnalysis;
+using LayoutParserApi.Services.Llm;
 
 using Microsoft.Extensions.Options;
 
@@ -14,14 +14,17 @@ namespace LayoutParserApi.Services.Fiscal
     /// <summary>
     /// Implementação de <see cref="IMappingSuggestionService"/> — Slice 3 (issue #230). Prompt novo,
     /// upstream do <c>RepairOrchestrator</c> (que sintetiza XSLT executável — não se aplica aqui).
-    /// Reaproveita só a infra Ollama de baixo nível (<see cref="HttpClient"/>/<see cref="OllamaOptions"/>),
-    /// nunca nuvem (Gemini/OpenAI decomissionados — dado fiscal sensível, ver <c>security.md</c>).
+    /// ✅ Issue #340 (F1): consome <see cref="ILlmProvider"/> via <see cref="LlmProviderResolver"/>
+    /// em vez de <see cref="HttpClient"/>/<see cref="XmlAnalysis.OllamaOptions"/> diretos (mesmo
+    /// motor Ollama por trás — ver ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md).
+    /// Nunca nuvem (Gemini/OpenAI decomissionados — dado fiscal sensível, ver <c>security.md</c>);
+    /// declara <see cref="DataSensitivity.RealFiscalDocument"/> explicitamente (artefatos do draft
+    /// podem conter amostra real — ADR §1.1, tratado como REAL até provar o contrário).
     /// </summary>
     public sealed class MappingSuggestionService : IMappingSuggestionService
     {
         private readonly ILogger<MappingSuggestionService> _logger;
-        private readonly HttpClient _httpClient;
-        private readonly OllamaOptions _ollamaOptions;
+        private readonly LlmProviderResolver _providerResolver;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly string _artifactStorePath;
 
@@ -39,14 +42,12 @@ namespace LayoutParserApi.Services.Fiscal
 
         public MappingSuggestionService(
             ILogger<MappingSuggestionService> logger,
-            HttpClient httpClient,
-            IOptions<OllamaOptions> ollamaOptions,
+            LlmProviderResolver providerResolver,
             IServiceScopeFactory scopeFactory,
             IConfiguration configuration)
         {
             _logger = logger;
-            _httpClient = httpClient;
-            _ollamaOptions = ollamaOptions.Value;
+            _providerResolver = providerResolver;
             _scopeFactory = scopeFactory;
             _artifactStorePath = configuration["ML:FiscalMappingPackagesPath"]
                 ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MLData", "FiscalMappingPackages");
@@ -145,26 +146,13 @@ namespace LayoutParserApi.Services.Fiscal
 
             var prompt = await BuildPromptAsync(relevant, cancellationToken);
 
-            var payload = new
-            {
-                model = _ollamaOptions.Model,
-                prompt,
-                stream = false,
-                format = "json",
-                options = new { temperature = 0.0 }
-            };
+            var llmRequest = new LlmRequest(prompt, DataSensitivity.RealFiscalDocument, JsonSchema: "\"json\"", Temperature: 0.0);
+            var provider = _providerResolver.Resolve(DataSensitivity.RealFiscalDocument);
 
-            string raw;
+            LlmResponse response;
             try
             {
-                using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-                var response = await _httpClient.PostAsync($"{_ollamaOptions.Url.TrimEnd('/')}/api/generate", content, cancellationToken);
-                if (!response.IsSuccessStatusCode)
-                {
-                    _logger.LogWarning("Ollama respondeu {StatusCode} ao gerar sugestões de mapeamento.", response.StatusCode);
-                    return Array.Empty<MappingDraftRuleProposal>();
-                }
-                raw = await response.Content.ReadAsStringAsync(cancellationToken);
+                response = await provider.GenerateAsync(llmRequest, cancellationToken);
             }
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
             {
@@ -174,10 +162,13 @@ namespace LayoutParserApi.Services.Fiscal
                 return Array.Empty<MappingDraftRuleProposal>();
             }
 
-            using var doc = JsonDocument.Parse(raw);
-            var modelText = doc.RootElement.TryGetProperty("response", out var r) ? r.GetString() ?? "" : "";
+            if (!response.Success)
+            {
+                _logger.LogWarning("Falha ao gerar sugestões de mapeamento via {Provider}: {Error}", provider.Name, response.ErrorMessage);
+                return Array.Empty<MappingDraftRuleProposal>();
+            }
 
-            return ParseProposals(modelText);
+            return ParseProposals(response.Text);
         }
 
         private async Task<string> BuildPromptAsync(IReadOnlyList<ArtifactFileRef> artifacts, CancellationToken cancellationToken)

--- a/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
+++ b/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
@@ -39,6 +39,17 @@ namespace LayoutParserApi.Services.Generation.Implementations
                 // o campo quebraria o payload de quem já chama o endpoint, e responder 400 a um
                 // request que antes funcionava seria pior que atendê-lo por regras. Quando a
                 // geração semântica voltar sobre Ollama local, é este flag que a religa.
+                //
+                // ✅ issue #341 (F2 — ponto de religamento preparado, NÃO ativado aqui): quando esse
+                // caminho voltar a chamar um ILlmProvider, se o prompt embutir uma amostra/planilha
+                // REAL do analista como referência de formato (ex.: um artefato anexado ao draft com
+                // ArtifactProvenance ausente/RealCustomerSample), a chamada deve declarar
+                // DataSensitivity.RealFiscalDocument e usar LlmProviderResolver — que recusa em
+                // runtime qualquer provider ProviderLocality.Cloud para essa sensibilidade (ver
+                // LlmProviderResolver.Resolve). Isso vale MESMO que a SAÍDA final seja sintética: é o
+                // conteúdo do PROMPT que importa, não o do resultado. Nunca decida a sensibilidade
+                // aqui a partir de "a saída é sintética" — resolva a partir da proveniência real de
+                // cada artefato usado como referência (ArtifactProvenance.ResolveSensitivity).
                 if (request.UseAI)
                     _logger.LogInformation("UseAI ignorado: geração por IA em nuvem foi decomissionada; usando regras.");
 

--- a/Services/Interfaces/IFiscalPackageService.cs
+++ b/Services/Interfaces/IFiscalPackageService.cs
@@ -1,7 +1,8 @@
 namespace LayoutParserApi.Services.Interfaces
 {
     /// <summary>Um arquivo recebido no upload, já lido em memória pelo controller (até o limite de tamanho).</summary>
-    public sealed record UploadedArtifactInput(string Kind, string OriginalFileName, string ContentType, byte[] Content);
+    /// <summary><paramref name="Provenance"/> ver <see cref="Models.Entities.Fiscal.ArtifactProvenance"/> (issue #341) — opcional, ausência resolve fail-closed como amostra real.</summary>
+    public sealed record UploadedArtifactInput(string Kind, string OriginalFileName, string ContentType, byte[] Content, string? Provenance = null);
 
     /// <summary>Resultado de uma tentativa de criação de pacote — pode falhar por validação (422) sem lançar.</summary>
     public sealed record CreatePackageOutcome(bool Success, string? Error, PackageDetail? Package);

--- a/Services/Interfaces/IFiscalPackageStore.cs
+++ b/Services/Interfaces/IFiscalPackageStore.cs
@@ -10,7 +10,8 @@ namespace LayoutParserApi.Services.Interfaces
         long SizeBytes,
         string OriginalFileName,
         string InspectionStatus,
-        DateTimeOffset UploadedAt);
+        DateTimeOffset UploadedAt,
+        string? Provenance = null);
 
     /// <summary>Resumo de uma revisão com seu inventário de artefatos.</summary>
     public sealed record RevisionSummary(

--- a/Services/Interfaces/IMappingDraftStore.cs
+++ b/Services/Interfaces/IMappingDraftStore.cs
@@ -52,8 +52,12 @@ namespace LayoutParserApi.Services.Interfaces
         string Status,
         IReadOnlyList<string> OpenQuestions);
 
-    /// <summary>Referência a um artefato em filesystem — usado pelo job de sugestão para ler o conteúdo-fonte.</summary>
-    public sealed record ArtifactFileRef(Guid ArtifactId, string Kind, string StoragePath, string OriginalFileName);
+    /// <summary>
+    /// Referência a um artefato em filesystem — usado pelo job de sugestão para ler o conteúdo-fonte.
+    /// <paramref name="Provenance"/> ver <see cref="Models.Entities.Fiscal.ArtifactProvenance"/>
+    /// (issue #341) — <c>null</c> é tratado como amostra real (fail-closed) por quem consome este DTO.
+    /// </summary>
+    public sealed record ArtifactFileRef(Guid ArtifactId, string Kind, string StoragePath, string OriginalFileName, string? Provenance = null);
 
     /// <summary>
     /// Acesso a dado de <see cref="MappingDraft"/>/<see cref="MappingDraftRule"/>/

--- a/Services/Llm/DataSensitivity.cs
+++ b/Services/Llm/DataSensitivity.cs
@@ -1,0 +1,16 @@
+namespace LayoutParserApi.Services.Llm
+{
+    /// <summary>
+    /// Classifica a sensibilidade do dado que trafega num <see cref="LlmRequest"/> — obrigatório
+    /// no construtor do request (sem valor default), forçando quem escreve uma chamada nova a
+    /// decidir conscientemente. Ver ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md §2.1.
+    /// </summary>
+    public enum DataSensitivity
+    {
+        /// <summary>Documento/campo de cliente real (fiscal) — jamais pode ir para provider de nuvem.</summary>
+        RealFiscalDocument,
+
+        /// <summary>Dado gerado, anonimizado, ou fixture de teste — provider de nuvem é elegível (fases futuras).</summary>
+        SyntheticOrAnonymized
+    }
+}

--- a/Services/Llm/ILlmProvider.cs
+++ b/Services/Llm/ILlmProvider.cs
@@ -1,0 +1,46 @@
+namespace LayoutParserApi.Services.Llm
+{
+    /// <summary>Onde o provider roda — usado pelo <see cref="LlmProviderResolver"/> como gate de segurança.</summary>
+    public enum ProviderLocality
+    {
+        Local,
+        Cloud
+    }
+
+    /// <summary>
+    /// Requisição genérica de geração de texto a um provider de LLM. <see cref="Sensitivity"/> é
+    /// obrigatório (sem default) — spec ADR §2.1: nenhuma chamada nasce sem declarar conscientemente
+    /// se o dado é fiscal real ou sintético/anonimizado.
+    /// </summary>
+    public sealed record LlmRequest(
+        string Prompt,
+        DataSensitivity Sensitivity,
+        string? JsonSchema = null,
+        double Temperature = 0.0);
+
+    /// <summary>Resposta genérica de um provider de LLM — cobre sucesso, timeout e erro de infraestrutura sem lançar exceção para o chamador.</summary>
+    public sealed record LlmResponse(
+        string Text,
+        bool Success,
+        bool TimedOut = false,
+        string? ErrorMessage = null);
+
+    /// <summary>
+    /// Abstração de provedor de LLM (ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md).
+    /// Segue o mesmo espírito de <c>ai/XslSynth.Core/Synthesis/IXslSynthesizer.cs</c> — interface
+    /// enxuta, sem vazar detalhe de payload HTTP de nenhum provider concreto no contrato. Só Ollama
+    /// implementa nesta fase (F1); providers de nuvem são fases futuras (F3/F4), gated por
+    /// <see cref="LlmProviderResolver"/>.
+    /// </summary>
+    public interface ILlmProvider
+    {
+        /// <summary>Identificador do provider (ex.: "ollama-local", "anthropic") — usado em logs e, futuramente, em resolução por nome.</summary>
+        string Name { get; }
+
+        ProviderLocality Locality { get; }
+
+        Task<LlmResponse> GenerateAsync(LlmRequest request, CancellationToken cancellationToken = default);
+
+        Task<bool> IsReachableAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Services/Llm/LlmProviderResolver.cs
+++ b/Services/Llm/LlmProviderResolver.cs
@@ -1,0 +1,50 @@
+namespace LayoutParserApi.Services.Llm
+{
+    /// <summary>
+    /// Ponto único de decisão de qual <see cref="ILlmProvider"/> usar para uma chamada, com o guard
+    /// de segurança central (ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md §2.2):
+    /// dado classificado <see cref="DataSensitivity.RealFiscalDocument"/> NUNCA pode ser roteado a um
+    /// provider <see cref="ProviderLocality.Cloud"/> — recusa em runtime, sem downgrade silencioso
+    /// para não mascarar erro de configuração. Nenhum provider de nuvem existe nesta fase (F1), mas o
+    /// guard já precisa estar ativo desde o primeiro commit — é o mecanismo que F3 vai depender.
+    /// </summary>
+    public sealed class LlmProviderResolver
+    {
+        private readonly IReadOnlyList<ILlmProvider> _providers;
+        private readonly ILlmProvider _defaultProvider;
+
+        public LlmProviderResolver(IEnumerable<ILlmProvider> providers)
+        {
+            _providers = providers.ToList();
+            if (_providers.Count == 0)
+                throw new InvalidOperationException("Nenhum ILlmProvider registrado no DI — pelo menos o provider local (Ollama) é obrigatório.");
+
+            // ✅ Default é o primeiro provider Local registrado — nesta fase (F1) só existe Ollama,
+            // mas a busca explícita por Locality.Local evita que um provider de nuvem registrado no
+            // futuro (F3+) vire default sem decisão explícita de quem chama.
+            _defaultProvider = _providers.FirstOrDefault(p => p.Locality == ProviderLocality.Local)
+                ?? _providers[0];
+        }
+
+        /// <summary>
+        /// Resolve o provider a usar para a sensibilidade declarada. Lança <see cref="InvalidOperationException"/>
+        /// (nunca degrada silenciosamente) se o provider resolvido for de nuvem e o dado for fiscal real.
+        /// </summary>
+        public ILlmProvider Resolve(DataSensitivity sensitivity, string? requestedProviderName = null)
+        {
+            var provider = string.IsNullOrWhiteSpace(requestedProviderName)
+                ? _defaultProvider
+                : _providers.FirstOrDefault(p => string.Equals(p.Name, requestedProviderName, StringComparison.OrdinalIgnoreCase))
+                    ?? _defaultProvider;
+
+            if (sensitivity == DataSensitivity.RealFiscalDocument && provider.Locality == ProviderLocality.Cloud)
+            {
+                throw new InvalidOperationException(
+                    $"Recusado: provider de nuvem '{provider.Name}' não pode processar dado classificado como " +
+                    $"{sensitivity}. Configure um provider local para este fluxo.");
+            }
+
+            return provider;
+        }
+    }
+}

--- a/Services/Llm/OllamaLlmProvider.cs
+++ b/Services/Llm/OllamaLlmProvider.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using System.Text.Json;
+
+using LayoutParserApi.Services.XmlAnalysis;
+
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Llm
+{
+    /// <summary>
+    /// Implementação de <see cref="ILlmProvider"/> por trás do Ollama (LLM local) — encapsula o que
+    /// <see cref="XmlAnalysis.OllamaValidationDiagnosticService"/>/<see cref="Fiscal.MappingSuggestionService"/>
+    /// já faziam via <see cref="HttpClient"/>/<see cref="OllamaOptions"/> crus, sem mudar comportamento
+    /// observável (ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md §3.4). Único provider
+    /// registrado nesta fase (F1) — providers de nuvem ficam para F3/F4.
+    /// </summary>
+    public sealed class OllamaLlmProvider : ILlmProvider
+    {
+        private readonly HttpClient _httpClient;
+        private readonly OllamaOptions _options;
+        private readonly ILogger<OllamaLlmProvider> _logger;
+
+        public string Name => "ollama-local";
+        public ProviderLocality Locality => ProviderLocality.Local;
+
+        public OllamaLlmProvider(HttpClient httpClient, IOptions<OllamaOptions> options, ILogger<OllamaLlmProvider> logger)
+        {
+            _httpClient = httpClient;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        public async Task<LlmResponse> GenerateAsync(LlmRequest request, CancellationToken cancellationToken = default)
+        {
+            object? format = null;
+            if (!string.IsNullOrWhiteSpace(request.JsonSchema))
+            {
+                try
+                {
+                    // ✅ JsonSchema é texto bruto (pode ser um schema estruturado — objeto — ou o
+                    // literal "json" usado pelo modo genérico do Ollama) — reparseamos aqui pra
+                    // embutir como valor real do campo "format" do payload, não como string escapada.
+                    using var parsed = JsonDocument.Parse(request.JsonSchema);
+                    format = parsed.RootElement.Clone();
+                }
+                catch (JsonException)
+                {
+                    _logger.LogDebug("JsonSchema informado em LlmRequest não é JSON válido; ignorando restrição de formato.");
+                }
+            }
+
+            var payload = format is null
+                ? new
+                {
+                    model = _options.Model,
+                    prompt = request.Prompt,
+                    stream = false,
+                    options = new { temperature = request.Temperature }
+                }
+                : (object)new
+                {
+                    model = _options.Model,
+                    prompt = request.Prompt,
+                    stream = false,
+                    format,
+                    options = new { temperature = request.Temperature }
+                };
+
+            HttpResponseMessage response;
+            try
+            {
+                using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                response = await _httpClient.PostAsync($"{_options.Url.TrimEnd('/')}/api/generate", content, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("Chamada ao Ollama cancelada/excedeu o timeout (modelo {Model})", _options.Model);
+                return new LlmResponse(string.Empty, Success: false, TimedOut: true, ErrorMessage: "Tempo limite excedido");
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "Ollama indisponível em {Url}", _options.Url);
+                return new LlmResponse(string.Empty, Success: false, ErrorMessage: "Provedor de IA indisponível no momento");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await SafeReadBodyAsync(response);
+                _logger.LogWarning("Ollama respondeu {StatusCode}: {Body}", response.StatusCode, body);
+                return new LlmResponse(string.Empty, Success: false, ErrorMessage: $"Erro de infraestrutura ({(int)response.StatusCode})");
+            }
+
+            try
+            {
+                var raw = await response.Content.ReadAsStringAsync(cancellationToken);
+                using var doc = JsonDocument.Parse(raw);
+                var text = doc.RootElement.TryGetProperty("response", out var r) ? r.GetString() ?? "" : "";
+                return new LlmResponse(text, Success: true);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("Timeout ao ler resposta do Ollama (modelo {Model})", _options.Model);
+                return new LlmResponse(string.Empty, Success: false, TimedOut: true, ErrorMessage: "Tempo limite excedido");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao processar resposta do Ollama");
+                return new LlmResponse(string.Empty, Success: false, ErrorMessage: "Erro interno ao processar resposta do provedor de IA");
+            }
+        }
+
+        public async Task<bool> IsReachableAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(5));
+                var response = await _httpClient.GetAsync($"{_options.Url.TrimEnd('/')}/api/tags", cts.Token);
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static async Task<string> SafeReadBodyAsync(HttpResponseMessage response)
+        {
+            try
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/Services/XmlAnalysis/OllamaValidationDiagnosticService.cs
+++ b/Services/XmlAnalysis/OllamaValidationDiagnosticService.cs
@@ -1,6 +1,7 @@
-using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+
+using LayoutParserApi.Services.Llm;
 
 using Microsoft.Extensions.Options;
 
@@ -11,19 +12,24 @@ namespace LayoutParserApi.Services.XmlAnalysis
     /// arquitetura: Gemini/OpenAI foram decomissionados (ver [[gemini-openai-decommission-decision]]
     /// na memória do @lp-architect), Ollama assume 100% do papel de LLM neste projeto. Mantém dado
     /// fiscal potencialmente sensível (XML transformado, mensagens de erro) no servidor.
+    /// ✅ Issue #340 (F1): consome <see cref="ILlmProvider"/> via <see cref="LlmProviderResolver"/>
+    /// em vez de <see cref="HttpClient"/>/<see cref="OllamaOptions"/> diretos — mesma chamada
+    /// HTTP por trás, agora atrás da abstração plugável (ver ADR
+    /// docs/architecture/adr-llm-provider-plugavel-2026-09-08.md). Dado aqui é sempre
+    /// <see cref="DataSensitivity.RealFiscalDocument"/>, hardcoded (não configurável via appsettings).
     /// </summary>
     public class OllamaValidationDiagnosticService
     {
-        private readonly HttpClient _httpClient;
+        private readonly LlmProviderResolver _providerResolver;
         private readonly ILogger<OllamaValidationDiagnosticService> _logger;
         private readonly OllamaOptions _options;
 
         public OllamaValidationDiagnosticService(
-            HttpClient httpClient,
+            LlmProviderResolver providerResolver,
             IOptions<OllamaOptions> options,
             ILogger<OllamaValidationDiagnosticService> logger)
         {
-            _httpClient = httpClient;
+            _providerResolver = providerResolver;
             _logger = logger;
             _options = options.Value;
         }
@@ -38,82 +44,60 @@ namespace LayoutParserApi.Services.XmlAnalysis
             using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
-            var payload = new
+            // ✅ Saída estruturada nativa do Ollama (suportado a partir da v0.5, confirmado em
+            // uso nesta instância v0.31.2 via teste manual): força o modelo a devolver
+            // {summary, suggestedFix, confidence} como JSON válido em vez de depender de
+            // parsing de texto livre por regex/heurística. Fallback de parsing de texto livre
+            // ainda existe abaixo (ParseModelResponse) para o caso de o modelo não respeitar
+            // o schema (acontece ocasionalmente com modelos menores sob temperature > 0).
+            // Nota: usamos apenas "string"/"number" simples (sem union type) no schema — o
+            // suporte de tipo nullable ("string"|"null") do JSON Schema completo não foi
+            // validado contra esta versão do Ollama; pedimos "" via prompt quando não houver
+            // sugestão e tratamos string vazia como null no parse (ParseModelResponse).
+            var jsonSchema = JsonSerializer.Serialize(new
             {
-                model = _options.Model,
-                prompt,
-                stream = false,
-                // ✅ Saída estruturada nativa do Ollama (suportado a partir da v0.5, confirmado em
-                // uso nesta instância v0.31.2 via teste manual): força o modelo a devolver
-                // {summary, suggestedFix, confidence} como JSON válido em vez de depender de
-                // parsing de texto livre por regex/heurística. Fallback de parsing de texto livre
-                // ainda existe abaixo (ParseModelResponse) para o caso de o modelo não respeitar
-                // o schema (acontece ocasionalmente com modelos menores sob temperature > 0).
-                // Nota: usamos apenas "string"/"number" simples (sem union type) no schema — o
-                // suporte de tipo nullable ("string"|"null") do JSON Schema completo não foi
-                // validado contra esta versão do Ollama; pedimos "" via prompt quando não houver
-                // sugestão e tratamos string vazia como null no parse (ParseModelResponse).
-                format = new
+                type = "object",
+                properties = new
                 {
-                    type = "object",
-                    properties = new
-                    {
-                        summary = new { type = "string" },
-                        suggestedFix = new { type = "string" },
-                        confidence = new { type = "number" }
-                    },
-                    required = new[] { "summary", "confidence" }
+                    summary = new { type = "string" },
+                    suggestedFix = new { type = "string" },
+                    confidence = new { type = "number" }
                 },
-                options = new { temperature = 0.0 }
-            };
+                required = new[] { "summary", "confidence" }
+            });
 
-            HttpResponseMessage response;
+            var llmRequest = new LlmRequest(prompt, DataSensitivity.RealFiscalDocument, jsonSchema, Temperature: 0.0);
+            var provider = _providerResolver.Resolve(DataSensitivity.RealFiscalDocument);
+
+            LlmResponse response;
             try
             {
-                using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-                response = await _httpClient.PostAsync($"{_options.Url.TrimEnd('/')}/api/generate", content, linkedCts.Token);
+                response = await provider.GenerateAsync(llmRequest, linkedCts.Token);
             }
             catch (OperationCanceledException)
             {
                 // Cobre tanto o nosso timeoutCts quanto qualquer outro cancelamento da chamada
                 // (ex.: cliente HTTP desconectou, cancellationToken do próprio request ASP.NET).
-                // Tratar como Timeout é o fallback mais seguro aqui — nenhum dos dois casos é
-                // "resposta obtida com sucesso", e nenhum é a mesma coisa que "Ollama indisponível"
-                // (que exige HttpRequestException por connection refused).
                 _logger.LogWarning("Diagnóstico via Ollama cancelado/excedeu o timeout de {Timeout}s (modelo {Model})", timeoutSeconds, _options.Model);
                 return ValidationDiagnosticResult.Fail(DiagnosticFailureKind.Timeout, "Diagnóstico excedeu o tempo limite");
             }
-            catch (HttpRequestException ex)
+
+            if (response.TimedOut)
             {
-                // Connection refused / DNS / socket — Ollama fora do ar ou inacessível.
-                _logger.LogWarning(ex, "Ollama indisponível em {Url}", _options.Url);
-                return ValidationDiagnosticResult.Fail(DiagnosticFailureKind.Unavailable, "Provedor de IA indisponível no momento");
+                _logger.LogWarning("Diagnóstico via Ollama cancelado/excedeu o timeout de {Timeout}s (modelo {Model})", timeoutSeconds, _options.Model);
+                return ValidationDiagnosticResult.Fail(DiagnosticFailureKind.Timeout, "Diagnóstico excedeu o tempo limite");
             }
 
-            if (!response.IsSuccessStatusCode)
+            if (!response.Success)
             {
-                var body = await SafeReadBodyAsync(response);
-                _logger.LogWarning("Ollama respondeu {StatusCode} ao diagnosticar erro: {Body}", response.StatusCode, body);
-
-                // Se o próprio Ollama devolveu erro de conexão indireto (ex.: 502 de um proxy na frente
-                // dele), tratamos como indisponibilidade; qualquer outro código HTTP inesperado do
-                // servidor Ollama em si é infraestrutura genérica.
+                _logger.LogWarning("Falha ao diagnosticar erro via {Provider}: {Error}", provider.Name, response.ErrorMessage);
                 return ValidationDiagnosticResult.Fail(DiagnosticFailureKind.Infrastructure, "Erro de infraestrutura ao chamar o provedor de IA");
             }
 
             try
             {
-                var raw = await response.Content.ReadAsStringAsync(linkedCts.Token);
-                using var doc = JsonDocument.Parse(raw);
-                var modelResponseText = doc.RootElement.TryGetProperty("response", out var r) ? r.GetString() ?? "" : "";
-
-                var diagnostic = ParseModelResponse(modelResponseText);
+                var diagnostic = ParseModelResponse(response.Text);
                 return ValidationDiagnosticResult.Ok(diagnostic);
-            }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
-            {
-                _logger.LogWarning("Timeout ao ler resposta do Ollama (modelo {Model})", _options.Model);
-                return ValidationDiagnosticResult.Fail(DiagnosticFailureKind.Timeout, "Diagnóstico excedeu o tempo limite");
             }
             catch (Exception ex)
             {
@@ -244,16 +228,5 @@ namespace LayoutParserApi.Services.XmlAnalysis
             return sb.ToString();
         }
 
-        private static async Task<string> SafeReadBodyAsync(HttpResponseMessage response)
-        {
-            try
-            {
-                return await response.Content.ReadAsStringAsync();
-            }
-            catch
-            {
-                return "";
-            }
-        }
     }
 }

--- a/tests/LayoutParserApi.Tests/Controllers/LayoutsControllerGenerateSampleTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/LayoutsControllerGenerateSampleTests.cs
@@ -1,0 +1,220 @@
+using LayoutParserApi.Controllers;
+using LayoutParserApi.Models.Database;
+using LayoutParserApi.Models.Entities;
+using LayoutParserApi.Models.Generation;
+using LayoutParserApi.Services.Database;
+using LayoutParserApi.Services.Generation.Implementations;
+using LayoutParserApi.Services.Generation.Interfaces;
+using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.LowCode;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Controllers
+{
+    /// <summary>
+    /// Issue #355: <c>POST /api/layouts/{layoutGuid}/generate-sample</c>. Cobre a pré-condição
+    /// obrigatória de mapper existente (correção do dono no ADR
+    /// docs/architecture/adr-geracao-documento-exemplo-2026-09-09.md), o caminho feliz
+    /// TextPositional (reaproveitando <see cref="SyntheticDataGeneratorService"/>) e o
+    /// not-implemented explícito para layout Xml (fica para a issue #356).
+    /// </summary>
+    public class LayoutsControllerGenerateSampleTests
+    {
+        private const string TextPositionalLayoutXml = @"<LayoutVO xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <LayoutGuid>LAY_teste-355</LayoutGuid>
+  <LayoutType>TextPositional</LayoutType>
+  <Name>LAYOUT_TESTE_355</Name>
+  <Description>Layout de teste</Description>
+  <LimitOfCaracters>20</LimitOfCaracters>
+  <Elements>
+    <Element xsi:type=""LineElementVO"">
+      <ElementGuid>line-1</ElementGuid>
+      <Name>Linha1</Name>
+      <Sequence>1</Sequence>
+      <IsRequired>true</IsRequired>
+      <Elements>
+        <Element xsi:type=""FieldElementVO"">
+          <ElementGuid>field-1</ElementGuid>
+          <Name>Nome</Name>
+          <Sequence>1</Sequence>
+          <IsRequired>true</IsRequired>
+          <LengthField>20</LengthField>
+          <AlignmentType>Left</AlignmentType>
+        </Element>
+      </Elements>
+    </Element>
+  </Elements>
+</LayoutVO>";
+
+        private const string XmlLayoutXml = @"<LayoutVO xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <LayoutGuid>LAY_teste-xml-355</LayoutGuid>
+  <LayoutType>Xml</LayoutType>
+  <Name>LAYOUT_XML_TESTE_355</Name>
+  <Description>Layout XML de teste</Description>
+  <Elements></Elements>
+</LayoutVO>";
+
+        private static LayoutsController BuildController(
+            LayoutRecord? layoutRecord,
+            Mapper? mapper,
+            List<string>? allowedPackageGuids = null)
+        {
+            var fakeLayoutService = new FakeCachedLayoutService(layoutRecord);
+            var fakeMapperDb = new FakeMapperDatabaseService(mapper);
+            var dataGenerator = new SyntheticDataGeneratorService(NullLogger<SyntheticDataGeneratorService>.Instance);
+            var options = Options.Create(new LowCodeRunnerOptions
+            {
+                ProjectId = 2,
+                AllowedPackageGuids = allowedPackageGuids ?? new List<string> { "PAC_teste" }
+            });
+
+            return new LayoutsController(
+                fakeLayoutService,
+                fakeMapperDb,
+                dataGenerator,
+                options,
+                NullLogger<LayoutsController>.Instance);
+        }
+
+        [Fact]
+        public async Task GenerateSample_retorna_400_quando_layout_nao_existe()
+        {
+            var controller = BuildController(layoutRecord: null, mapper: null);
+
+            var result = await controller.GenerateSample("guid-inexistente", new GenerateSampleRequest());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GenerateSample_retorna_404_quando_layout_existe_mas_sem_mapper()
+        {
+            var layoutRecord = new LayoutRecord
+            {
+                LayoutGuid = Guid.NewGuid(),
+                Name = "LAYOUT_TESTE_355",
+                LayoutType = "TextPositional",
+                DecryptedContent = TextPositionalLayoutXml
+            };
+            var controller = BuildController(layoutRecord, mapper: null);
+
+            var result = await controller.GenerateSample("teste-355", new GenerateSampleRequest());
+
+            var notFound = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.NotNull(notFound.Value);
+        }
+
+        [Fact]
+        public async Task GenerateSample_gera_documento_positional_quando_layout_TextPositional_tem_mapper()
+        {
+            var layoutRecord = new LayoutRecord
+            {
+                LayoutGuid = Guid.NewGuid(),
+                Name = "LAYOUT_TESTE_355",
+                LayoutType = "TextPositional",
+                DecryptedContent = TextPositionalLayoutXml
+            };
+            var mapper = new Mapper { MapperGuid = "mapper-355", TargetLayoutGuid = "teste-355" };
+            var controller = BuildController(layoutRecord, mapper);
+
+            var result = await controller.GenerateSample("teste-355", new GenerateSampleRequest { NumberOfRecords = 2 });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<GenerateSampleResponse>(ok.Value);
+            Assert.Equal("positional", response.Format);
+            Assert.False(string.IsNullOrWhiteSpace(response.GeneratedDocument));
+            Assert.NotEmpty(response.Warnings);
+            // 2 registros de 1 linha cada, separados por \n.
+            Assert.Equal(2, response.GeneratedDocument.Split('\n').Length);
+        }
+
+        [Fact]
+        public async Task GenerateSample_avisa_quando_seed_e_ignorado()
+        {
+            var layoutRecord = new LayoutRecord
+            {
+                LayoutGuid = Guid.NewGuid(),
+                Name = "LAYOUT_TESTE_355",
+                LayoutType = "TextPositional",
+                DecryptedContent = TextPositionalLayoutXml
+            };
+            var mapper = new Mapper { MapperGuid = "mapper-355", TargetLayoutGuid = "teste-355" };
+            var controller = BuildController(layoutRecord, mapper);
+
+            var result = await controller.GenerateSample("teste-355", new GenerateSampleRequest { Seed = 42 });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<GenerateSampleResponse>(ok.Value);
+            Assert.Contains(response.Warnings, w => w.Contains("seed", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task GenerateSample_retorna_501_quando_layout_e_Xml()
+        {
+            var layoutRecord = new LayoutRecord
+            {
+                LayoutGuid = Guid.NewGuid(),
+                Name = "LAYOUT_XML_TESTE_355",
+                LayoutType = "Xml",
+                DecryptedContent = XmlLayoutXml
+            };
+            var mapper = new Mapper { MapperGuid = "mapper-xml-355", TargetLayoutGuid = "teste-xml-355" };
+            var controller = BuildController(layoutRecord, mapper);
+
+            var result = await controller.GenerateSample("teste-xml-355", new GenerateSampleRequest());
+
+            var objResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status501NotImplemented, objResult.StatusCode);
+        }
+
+        private sealed class FakeCachedLayoutService : ICachedLayoutService
+        {
+            private readonly LayoutRecord? _record;
+
+            public FakeCachedLayoutService(LayoutRecord? record) => _record = record;
+
+            public Task<LayoutSearchResponse> SearchLayoutsAsync(LayoutSearchRequest request) =>
+                throw new NotSupportedException();
+
+            public Task<LayoutRecord?> GetLayoutByIdAsync(int id) => throw new NotSupportedException();
+
+            public Task<LayoutRecord?> GetLayoutByGuidAsync(string layoutGuid) => Task.FromResult(_record);
+
+            public Task RefreshCacheFromDatabaseAsync() => Task.CompletedTask;
+
+            public Task ClearCacheAsync() => Task.CompletedTask;
+
+            public ILayoutDatabaseService GetLayoutDatabaseService() => throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// <c>MapperDatabaseService</c> não tem interface própria — double por herança, no mesmo
+        /// ponto de substituição de <c>GetRankedMapperCandidatesForLayoutGuidAsync</c>
+        /// (ver TransformationExecutionControllerEndToEndAiCandidateTests).
+        /// </summary>
+        private sealed class FakeMapperDatabaseService : MapperDatabaseService
+        {
+            private readonly Mapper? _mapper;
+
+            public FakeMapperDatabaseService(Mapper? mapper)
+                : base(NullLogger<MapperDatabaseService>.Instance, new FakeDecryptionService(), new ConfigurationBuilder().Build())
+            {
+                _mapper = mapper;
+            }
+
+            public override Task<Mapper?> GetBestMapperForLayoutGuidAsync(string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids) =>
+                Task.FromResult(_mapper);
+        }
+
+        private sealed class FakeDecryptionService : IDecryptionService
+        {
+            public Task<string> DecryptContentAsync(string encryptedContent) => Task.FromResult(encryptedContent);
+            public bool IsDecryptorAvailable => true;
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
@@ -280,7 +280,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 LastEnqueueUserId = userId;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
@@ -107,7 +107,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
 
             public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
                 Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
@@ -192,7 +192,7 @@ namespace LayoutParserApi.Tests.Controllers
         {
             public Task EnqueueAsync(string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
 
             public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
                 Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -61,9 +61,9 @@ namespace LayoutParserApi.Tests.Controllers
         {
             public MapperDbVazio(IConfiguration config) : base(NullLogger<MapperDatabaseService>.Instance, null!, config) { }
 
-            public override Task<List<Models.Entities.Mapper>> GetRankedMapperCandidatesForLayoutGuidAsync(
+            public override Task<List<LayoutParserApi.Models.Entities.Mapper>> GetRankedMapperCandidatesForLayoutGuidAsync(
                 string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids)
-                => Task.FromResult(new List<Models.Entities.Mapper>());
+                => Task.FromResult(new List<LayoutParserApi.Models.Entities.Mapper>());
         }
 
         private sealed class SpyAiCandidateService : IAiTransformationCandidateService
@@ -71,7 +71,7 @@ namespace LayoutParserApi.Tests.Controllers
             public int EnqueueCount { get; private set; }
             public Task EnqueueAsync(string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 EnqueueCount++;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -53,7 +53,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 LastEnqueueUserId = userId;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Models/Fiscal/ArtifactProvenanceTests.cs
+++ b/tests/LayoutParserApi.Tests/Models/Fiscal/ArtifactProvenanceTests.cs
@@ -1,0 +1,57 @@
+using LayoutParserApi.Models.Entities.Fiscal;
+using LayoutParserApi.Services.Llm;
+
+using Xunit;
+
+namespace LayoutParserApi.Tests.Models.Fiscal
+{
+    /// <summary>
+    /// Issue #341 (F2 do ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md): garante que
+    /// a AUSÊNCIA de proveniência declarada nunca resolve para <see cref="DataSensitivity.SyntheticOrAnonymized"/>
+    /// por omissão — só o valor explícito <see cref="ArtifactProvenance.Synthetic"/> resolve assim.
+    /// </summary>
+    public class ArtifactProvenanceTests
+    {
+        [Fact]
+        public void ResolveSensitivity_SemValorPreenchido_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(null));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_StringVazia_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(string.Empty));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_ValorDesconhecido_ResolveComoRealFiscalDocument()
+        {
+            // Valor fora do vocabulário conhecido (typo, versão futura etc.) — fail-closed, nunca sintético por engano.
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity("qualquer-coisa"));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_RealCustomerSampleExplicito_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(ArtifactProvenance.RealCustomerSample));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_SyntheticExplicito_ResolveComoSyntheticOrAnonymized()
+        {
+            Assert.Equal(DataSensitivity.SyntheticOrAnonymized, ArtifactProvenance.ResolveSensitivity(ArtifactProvenance.Synthetic));
+        }
+
+        [Theory]
+        [InlineData(ArtifactProvenance.Synthetic, true)]
+        [InlineData(ArtifactProvenance.RealCustomerSample, true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("invalido", false)]
+        public void IsValid_RespeitaVocabularioExplicito(string? value, bool expected)
+        {
+            Assert.Equal(expected, ArtifactProvenance.IsValid(value));
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Llm/LlmProviderResolverTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Llm/LlmProviderResolverTests.cs
@@ -1,0 +1,72 @@
+using LayoutParserApi.Services.Llm;
+
+using Xunit;
+
+namespace LayoutParserApi.Tests.Services.Llm
+{
+    /// <summary>
+    /// Cobre o guard de runtime do ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md §2.2
+    /// (issue #340, F1): dado classificado <see cref="DataSensitivity.RealFiscalDocument"/> NUNCA pode
+    /// ser resolvido para um provider <see cref="ProviderLocality.Cloud"/> — mesmo sem nenhum provider
+    /// de nuvem real existir ainda (fake aqui simula o cenário de F3+).
+    /// </summary>
+    public class LlmProviderResolverTests
+    {
+        private sealed class FakeLocalProvider : ILlmProvider
+        {
+            public string Name => "ollama-local";
+            public ProviderLocality Locality => ProviderLocality.Local;
+            public Task<LlmResponse> GenerateAsync(LlmRequest request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new LlmResponse("ok", Success: true));
+            public Task<bool> IsReachableAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(true);
+        }
+
+        private sealed class FakeCloudProvider : ILlmProvider
+        {
+            public string Name => "fake-cloud";
+            public ProviderLocality Locality => ProviderLocality.Cloud;
+            public Task<LlmResponse> GenerateAsync(LlmRequest request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new LlmResponse("ok", Success: true));
+            public Task<bool> IsReachableAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(true);
+        }
+
+        [Fact]
+        public void Resolve_ComDadoFiscalRealEProviderDeNuvem_LancaInvalidOperationException()
+        {
+            var resolver = new LlmProviderResolver(new ILlmProvider[] { new FakeCloudProvider() });
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => resolver.Resolve(DataSensitivity.RealFiscalDocument, "fake-cloud"));
+
+            Assert.Contains("fake-cloud", ex.Message);
+        }
+
+        [Fact]
+        public void Resolve_ComDadoSinteticoEProviderDeNuvem_NaoLanca()
+        {
+            var resolver = new LlmProviderResolver(new ILlmProvider[] { new FakeLocalProvider(), new FakeCloudProvider() });
+
+            var provider = resolver.Resolve(DataSensitivity.SyntheticOrAnonymized, "fake-cloud");
+
+            Assert.Equal("fake-cloud", provider.Name);
+        }
+
+        [Fact]
+        public void Resolve_ComDadoFiscalRealSemProviderExplicito_UsaDefaultLocal()
+        {
+            var resolver = new LlmProviderResolver(new ILlmProvider[] { new FakeCloudProvider(), new FakeLocalProvider() });
+
+            var provider = resolver.Resolve(DataSensitivity.RealFiscalDocument);
+
+            Assert.Equal(ProviderLocality.Local, provider.Locality);
+        }
+
+        [Fact]
+        public void Construtor_SemProviders_Lanca()
+        {
+            Assert.Throws<InvalidOperationException>(() => new LlmProviderResolver(Array.Empty<ILlmProvider>()));
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceXslSynthesizerTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceXslSynthesizerTests.cs
@@ -185,7 +185,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
 
         /// <summary>Mesma infraestrutura mínima de <c>LineInfoAdditiveSignalsTests.ParseAsync</c> —
         /// invoca o <c>LayoutParserService</c> REAL, não um mock/stub de parsing.</summary>
-        private static async Task<Models.Parsing.ParsingResult> ParseTxtRealAsync(string layoutXml, string documento)
+        private static async Task<LayoutParserApi.Models.Parsing.ParsingResult> ParseTxtRealAsync(string layoutXml, string documento)
         {
             var techLogger = new NoOpTechLoggerLocal();
             var config = new Microsoft.Extensions.Configuration.ConfigurationBuilder()


### PR DESCRIPTION
## Promoção develop -> master

Conteúdo novo: PR #359 — endpoint `POST /api/layouts/{layoutGuid}/generate-sample`, cobertura
`TextPositional`, pré-condição de mapper já existente, `[Authorize]` (não admin-only, conforme
decisão do dono). Build/testes verdes na PR original (710/710, sem regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)