### PR TITLE
feat(fiscal): campo de proveniência explícito em artefatos de draft (issue #341, F2)

### DIFF
--- a/Controllers/FiscalMappingPackagesController.cs
+++ b/Controllers/FiscalMappingPackagesController.cs
@@ -95,7 +95,14 @@ namespace LayoutParserApi.Controllers
                 using var memoryStream = new MemoryStream();
                 await file.CopyToAsync(memoryStream, cancellationToken);
 
-                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray()));
+                // ✅ issue #341: campo de texto opcional "{kind}Provenance" (ex.: "sampleProvenance")
+                // — proveniência declarada pelo analista, NUNCA inferida. Ausente/inválido vira null
+                // e o serviço trata como amostra real (fail-closed, ver ArtifactProvenance.IsValid).
+                var provenance = Request.Form.TryGetValue($"{file.Name}Provenance", out var provenanceValue)
+                    ? provenanceValue.ToString()
+                    : null;
+
+                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray(), provenance));
             }
 
             var idempotencyKey = Request.Headers.TryGetValue("Idempotency-Key", out var headerValue) ? headerValue.ToString() : null;
@@ -205,7 +212,14 @@ namespace LayoutParserApi.Controllers
                 using var memoryStream = new MemoryStream();
                 await file.CopyToAsync(memoryStream, cancellationToken);
 
-                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray()));
+                // ✅ issue #341: campo de texto opcional "{kind}Provenance" (ex.: "sampleProvenance")
+                // — proveniência declarada pelo analista, NUNCA inferida. Ausente/inválido vira null
+                // e o serviço trata como amostra real (fail-closed, ver ArtifactProvenance.IsValid).
+                var provenance = Request.Form.TryGetValue($"{file.Name}Provenance", out var provenanceValue)
+                    ? provenanceValue.ToString()
+                    : null;
+
+                artifacts.Add(new UploadedArtifactInput(file.Name, file.FileName, file.ContentType, memoryStream.ToArray(), provenance));
             }
 
             CreateRevisionOutcome outcome;
@@ -319,6 +333,7 @@ namespace LayoutParserApi.Controllers
                         originalFileName = a.OriginalFileName,
                         inspectionStatus = a.InspectionStatus,
                         uploadedAt = a.UploadedAt,
+                        provenance = a.Provenance,
                     })
                 }
             }

--- a/Models/Entities/Fiscal/PackageArtifact.cs
+++ b/Models/Entities/Fiscal/PackageArtifact.cs
@@ -46,6 +46,38 @@ namespace LayoutParserApi.Models.Entities.Fiscal
     }
 
     /// <summary>
+    /// Proveniência do CONTEÚDO de um <see cref="PackageArtifact"/> (issue #341 — Fase F2 do ADR
+    /// docs/architecture/adr-llm-provider-plugavel-2026-09-08.md). Explícito e preenchido pelo
+    /// analista ao anexar o arquivo — NUNCA inferido pelo tipo (<see cref="ArtifactKind"/>) ou
+    /// pelo nome do arquivo. Regra central (ADR §2.3, issue #341 critério de aceite): a AUSÊNCIA
+    /// deste valor (<c>null</c>/vazio) resolve para <c>RealCustomerSample</c> — nunca para
+    /// <see cref="Synthetic"/> por omissão/default. Ver <see cref="ResolveSensitivity"/>.
+    /// </summary>
+    public static class ArtifactProvenance
+    {
+        /// <summary>Gerado por regra/fixture — elegível a <c>DataSensitivity.SyntheticOrAnonymized</c> (fases futuras de F3).</summary>
+        public const string Synthetic = "synthetic";
+
+        /// <summary>Amostra real de cliente anexada pelo analista — sempre <c>DataSensitivity.RealFiscalDocument</c>.</summary>
+        public const string RealCustomerSample = "real_customer_sample";
+
+        public static readonly IReadOnlyCollection<string> All = new[] { Synthetic, RealCustomerSample };
+
+        public static bool IsValid(string? value) => value != null && All.Contains(value);
+
+        /// <summary>
+        /// Resolve a <see cref="Services.Llm.DataSensitivity"/> a partir da proveniência declarada.
+        /// Fail-closed: qualquer valor ausente, vazio ou não reconhecido resolve para
+        /// <see cref="Services.Llm.DataSensitivity.RealFiscalDocument"/> — só o valor EXPLÍCITO
+        /// <see cref="Synthetic"/> resolve para <see cref="Services.Llm.DataSensitivity.SyntheticOrAnonymized"/>.
+        /// </summary>
+        public static Services.Llm.DataSensitivity ResolveSensitivity(string? provenance)
+            => provenance == Synthetic
+                ? Services.Llm.DataSensitivity.SyntheticOrAnonymized
+                : Services.Llm.DataSensitivity.RealFiscalDocument;
+    }
+
+    /// <summary>
     /// Um artefato binário dentro de uma revisão imutável de <see cref="FiscalMappingPackage"/>.
     /// Metadado em SQL; conteúdo bruto em filesystem (<c>MLData/FiscalMappingPackages/...</c>) —
     /// nunca no log/erro (ver <c>.claude/rules/security.md</c>).
@@ -88,5 +120,8 @@ namespace LayoutParserApi.Models.Entities.Fiscal
 
         /// <summary>Caminho relativo dentro do store de filesystem (não é o caminho absoluto do host).</summary>
         public string StoragePath { get; set; } = string.Empty;
+
+        /// <summary>Ver <see cref="ArtifactProvenance"/>. <c>null</c> resolve como <see cref="ArtifactProvenance.RealCustomerSample"/> (fail-closed).</summary>
+        public string? Provenance { get; set; }
     }
 }

--- a/Services/Database/SqlFiscalPackageStore.cs
+++ b/Services/Database/SqlFiscalPackageStore.cs
@@ -130,10 +130,10 @@ namespace LayoutParserApi.Services.Database
                     using var insertArtifact = new SqlCommand(
                         @"INSERT INTO dbo.tbPackageArtifact
                             (ArtifactId, RevisionId, Kind, Sha256, SizeBytes, OriginalFileName, MimeDeclared, MimeSniffed,
-                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath)
+                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath, Provenance)
                           VALUES
                             (@ArtifactId, @RevisionId, @Kind, @Sha256, @SizeBytes, @OriginalFileName, @MimeDeclared, @MimeSniffed,
-                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath);",
+                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath, @Provenance);",
                         connection, tx);
 
                     insertArtifact.Parameters.AddWithValue("@ArtifactId", artifact.ArtifactId);
@@ -149,6 +149,7 @@ namespace LayoutParserApi.Services.Database
                     insertArtifact.Parameters.AddWithValue("@RetentionPolicy", (object?)artifact.RetentionPolicy ?? DBNull.Value);
                     insertArtifact.Parameters.AddWithValue("@InspectionStatus", artifact.InspectionStatus);
                     insertArtifact.Parameters.AddWithValue("@StoragePath", artifact.StoragePath);
+                    insertArtifact.Parameters.AddWithValue("@Provenance", (object?)artifact.Provenance ?? DBNull.Value);
                     await insertArtifact.ExecuteNonQueryAsync(cancellationToken);
                 }
 
@@ -190,7 +191,7 @@ namespace LayoutParserApi.Services.Database
                     revisionId,
                     1,
                     createdAt,
-                    artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt)).ToList()));
+                    artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt, a.Provenance)).ToList()));
         }
 
         public async Task<PackageDetail?> GetPackageIfMemberAsync(Guid packageId, Guid userId, CancellationToken cancellationToken)
@@ -248,7 +249,7 @@ namespace LayoutParserApi.Services.Database
 
             var artifacts = new List<ArtifactSummary>();
             using (var selectArtifacts = new SqlCommand(
-                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt
+                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt, Provenance
                   FROM dbo.tbPackageArtifact
                   WHERE RevisionId = @RevisionId
                   ORDER BY UploadedAt ASC;",
@@ -265,7 +266,8 @@ namespace LayoutParserApi.Services.Database
                         reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                         reader.GetString(reader.GetOrdinal("OriginalFileName")),
                         reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero)));
+                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                        reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
                 }
             }
 
@@ -340,7 +342,7 @@ namespace LayoutParserApi.Services.Database
 
             var artifacts = new List<ArtifactSummary>();
             using (var selectArtifacts = new SqlCommand(
-                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt
+                @"SELECT ArtifactId, Kind, Sha256, SizeBytes, OriginalFileName, InspectionStatus, UploadedAt, Provenance
                   FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId ORDER BY UploadedAt ASC;",
                 connection))
             {
@@ -355,7 +357,8 @@ namespace LayoutParserApi.Services.Database
                         reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                         reader.GetString(reader.GetOrdinal("OriginalFileName")),
                         reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero)));
+                        new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                        reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
                 }
             }
 
@@ -370,7 +373,7 @@ namespace LayoutParserApi.Services.Database
             await EnsureSchemaAsync(connection, cancellationToken);
 
             using var command = new SqlCommand(
-                @"SELECT a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, a.UploadedAt
+                @"SELECT a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, a.UploadedAt, a.Provenance
                   FROM dbo.tbPackageArtifact a
                   JOIN dbo.tbFiscalMappingPackageRevision r ON r.RevisionId = a.RevisionId
                   WHERE r.PackageId = @PackageId AND a.Sha256 = @Sha256
@@ -390,7 +393,8 @@ namespace LayoutParserApi.Services.Database
                 reader.GetInt64(reader.GetOrdinal("SizeBytes")),
                 reader.GetString(reader.GetOrdinal("OriginalFileName")),
                 reader.GetString(reader.GetOrdinal("InspectionStatus")),
-                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero));
+                new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("UploadedAt")), TimeSpan.Zero),
+                reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance")));
         }
 
         public async Task UpdateInspectionStatusAsync(Guid artifactId, string inspectionStatus, CancellationToken cancellationToken)
@@ -484,10 +488,10 @@ namespace LayoutParserApi.Services.Database
                     using var insertArtifact = new SqlCommand(
                         @"INSERT INTO dbo.tbPackageArtifact
                             (ArtifactId, RevisionId, Kind, Sha256, SizeBytes, OriginalFileName, MimeDeclared, MimeSniffed,
-                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath)
+                             UploadedByUserId, UploadedAt, Classification, RetentionPolicy, InspectionStatus, StoragePath, Provenance)
                           VALUES
                             (@ArtifactId, @RevisionId, @Kind, @Sha256, @SizeBytes, @OriginalFileName, @MimeDeclared, @MimeSniffed,
-                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath);",
+                             @UploadedByUserId, SYSUTCDATETIME(), @Classification, @RetentionPolicy, @InspectionStatus, @StoragePath, @Provenance);",
                         connection, tx);
 
                     insertArtifact.Parameters.AddWithValue("@ArtifactId", artifact.ArtifactId);
@@ -503,6 +507,7 @@ namespace LayoutParserApi.Services.Database
                     insertArtifact.Parameters.AddWithValue("@RetentionPolicy", (object?)artifact.RetentionPolicy ?? DBNull.Value);
                     insertArtifact.Parameters.AddWithValue("@InspectionStatus", artifact.InspectionStatus);
                     insertArtifact.Parameters.AddWithValue("@StoragePath", artifact.StoragePath);
+                    insertArtifact.Parameters.AddWithValue("@Provenance", (object?)artifact.Provenance ?? DBNull.Value);
                     await insertArtifact.ExecuteNonQueryAsync(cancellationToken);
                 }
 
@@ -517,7 +522,7 @@ namespace LayoutParserApi.Services.Database
                         revisionId,
                         revisionNumber,
                         createdAt,
-                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt)).ToList())
+                        artifacts.Select(a => new ArtifactSummary(a.ArtifactId, a.Kind, a.Sha256, a.SizeBytes, a.OriginalFileName, a.InspectionStatus, createdAt, a.Provenance)).ToList())
                 };
             }
             catch
@@ -628,7 +633,12 @@ CREATE TABLE dbo.tbPackageArtifact (
 );
 
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_tbPackageArtifact_RevisionId' AND object_id = OBJECT_ID('dbo.tbPackageArtifact'))
-CREATE INDEX IX_tbPackageArtifact_RevisionId ON dbo.tbPackageArtifact(RevisionId);";
+CREATE INDEX IX_tbPackageArtifact_RevisionId ON dbo.tbPackageArtifact(RevisionId);
+
+-- ✅ issue #341 (F2): coluna nova em tabela que pode já existir num banco antigo — ALTER idempotente
+-- separado do CREATE TABLE acima (que só roda se a tabela ainda não existir).
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.tbPackageArtifact') AND name = 'Provenance')
+ALTER TABLE dbo.tbPackageArtifact ADD Provenance NVARCHAR(32) NULL;";
 
         // internal (não mais private): chamado também pelo FiscalSchemaInitializer no startup, além
         // do próprio store por requisição (idempotente — safety net se o initializer não rodou/falhou).

--- a/Services/Database/SqlMappingDraftStore.cs
+++ b/Services/Database/SqlMappingDraftStore.cs
@@ -59,7 +59,7 @@ namespace LayoutParserApi.Services.Database
 
             var result = new List<ArtifactFileRef>();
             using var command = new SqlCommand(
-                "SELECT ArtifactId, Kind, StoragePath, OriginalFileName FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId;",
+                "SELECT ArtifactId, Kind, StoragePath, OriginalFileName, Provenance FROM dbo.tbPackageArtifact WHERE RevisionId = @RevisionId;",
                 connection);
             command.Parameters.AddWithValue("@RevisionId", revisionId);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -69,7 +69,11 @@ namespace LayoutParserApi.Services.Database
                     reader.GetGuid(reader.GetOrdinal("ArtifactId")),
                     reader.GetString(reader.GetOrdinal("Kind")),
                     reader.GetString(reader.GetOrdinal("StoragePath")),
-                    reader.GetString(reader.GetOrdinal("OriginalFileName"))));
+                    reader.GetString(reader.GetOrdinal("OriginalFileName")),
+                    // ✅ issue #341: coluna pode não existir ainda se o schema de tbPackageArtifact
+                    // (dono: SqlFiscalPackageStore) não rodou o ALTER — trata ausência da coluna em si
+                    // como erro real (propaga), só o VALOR NULL da linha é tratado como ausência de proveniência.
+                    reader.IsDBNull(reader.GetOrdinal("Provenance")) ? null : reader.GetString(reader.GetOrdinal("Provenance"))));
             }
             return result;
         }

--- a/Services/Fiscal/FiscalPackageService.cs
+++ b/Services/Fiscal/FiscalPackageService.cs
@@ -107,6 +107,9 @@ namespace LayoutParserApi.Services.Fiscal
                         UploadedAt = DateTimeOffset.UtcNow,
                         InspectionStatus = Models.Entities.Fiscal.InspectionStatus.Pending,
                         StoragePath = relativePath,
+                        // ✅ issue #341: só grava a proveniência se for um valor explícito e válido —
+                        // valor ausente/inválido vira null, que a leitura trata como amostra real (fail-closed).
+                        Provenance = Models.Entities.Fiscal.ArtifactProvenance.IsValid(input.Provenance) ? input.Provenance : null,
                     });
                 }
 
@@ -191,6 +194,9 @@ namespace LayoutParserApi.Services.Fiscal
                         UploadedAt = DateTimeOffset.UtcNow,
                         InspectionStatus = Models.Entities.Fiscal.InspectionStatus.Pending,
                         StoragePath = relativePath,
+                        // ✅ issue #341: só grava a proveniência se for um valor explícito e válido —
+                        // valor ausente/inválido vira null, que a leitura trata como amostra real (fail-closed).
+                        Provenance = Models.Entities.Fiscal.ArtifactProvenance.IsValid(input.Provenance) ? input.Provenance : null,
                     });
                 }
 

--- a/Services/Fiscal/MappingSuggestionService.cs
+++ b/Services/Fiscal/MappingSuggestionService.cs
@@ -18,8 +18,11 @@ namespace LayoutParserApi.Services.Fiscal
     /// em vez de <see cref="HttpClient"/>/<see cref="XmlAnalysis.OllamaOptions"/> diretos (mesmo
     /// motor Ollama por trás — ver ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md).
     /// Nunca nuvem (Gemini/OpenAI decomissionados — dado fiscal sensível, ver <c>security.md</c>);
-    /// declara <see cref="DataSensitivity.RealFiscalDocument"/> explicitamente (artefatos do draft
-    /// podem conter amostra real — ADR §1.1, tratado como REAL até provar o contrário).
+    /// ✅ Issue #341 (F2): a sensibilidade NÃO é mais hardcoded incondicional — é resolvida a partir
+    /// da <see cref="ArtifactProvenance"/> declarada em cada artefato via
+    /// <see cref="ArtifactProvenance.ResolveSensitivity"/> (fail-closed: ausência/valor inválido
+    /// resolve para <see cref="DataSensitivity.RealFiscalDocument"/>, nunca para
+    /// <see cref="DataSensitivity.SyntheticOrAnonymized"/> por omissão — ADR §2.3).
     /// </summary>
     public sealed class MappingSuggestionService : IMappingSuggestionService
     {
@@ -146,8 +149,15 @@ namespace LayoutParserApi.Services.Fiscal
 
             var prompt = await BuildPromptAsync(relevant, cancellationToken);
 
-            var llmRequest = new LlmRequest(prompt, DataSensitivity.RealFiscalDocument, JsonSchema: "\"json\"", Temperature: 0.0);
-            var provider = _providerResolver.Resolve(DataSensitivity.RealFiscalDocument);
+            // ✅ issue #341: se QUALQUER artefato relevante não tiver proveniência explícita
+            // "synthetic", o lote inteiro é tratado como RealFiscalDocument — um artefato real
+            // misturado no prompt contamina a sensibilidade de tudo que foi enviado junto ao modelo.
+            var sensitivity = relevant.Any(a => Models.Entities.Fiscal.ArtifactProvenance.ResolveSensitivity(a.Provenance) == DataSensitivity.RealFiscalDocument)
+                ? DataSensitivity.RealFiscalDocument
+                : DataSensitivity.SyntheticOrAnonymized;
+
+            var llmRequest = new LlmRequest(prompt, sensitivity, JsonSchema: "\"json\"", Temperature: 0.0);
+            var provider = _providerResolver.Resolve(sensitivity);
 
             LlmResponse response;
             try

--- a/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
+++ b/Services/Generation/Implementations/SyntheticDataGeneratorService.cs
@@ -39,6 +39,17 @@ namespace LayoutParserApi.Services.Generation.Implementations
                 // o campo quebraria o payload de quem já chama o endpoint, e responder 400 a um
                 // request que antes funcionava seria pior que atendê-lo por regras. Quando a
                 // geração semântica voltar sobre Ollama local, é este flag que a religa.
+                //
+                // ✅ issue #341 (F2 — ponto de religamento preparado, NÃO ativado aqui): quando esse
+                // caminho voltar a chamar um ILlmProvider, se o prompt embutir uma amostra/planilha
+                // REAL do analista como referência de formato (ex.: um artefato anexado ao draft com
+                // ArtifactProvenance ausente/RealCustomerSample), a chamada deve declarar
+                // DataSensitivity.RealFiscalDocument e usar LlmProviderResolver — que recusa em
+                // runtime qualquer provider ProviderLocality.Cloud para essa sensibilidade (ver
+                // LlmProviderResolver.Resolve). Isso vale MESMO que a SAÍDA final seja sintética: é o
+                // conteúdo do PROMPT que importa, não o do resultado. Nunca decida a sensibilidade
+                // aqui a partir de "a saída é sintética" — resolva a partir da proveniência real de
+                // cada artefato usado como referência (ArtifactProvenance.ResolveSensitivity).
                 if (request.UseAI)
                     _logger.LogInformation("UseAI ignorado: geração por IA em nuvem foi decomissionada; usando regras.");
 

--- a/Services/Interfaces/IFiscalPackageService.cs
+++ b/Services/Interfaces/IFiscalPackageService.cs
@@ -1,7 +1,8 @@
 namespace LayoutParserApi.Services.Interfaces
 {
     /// <summary>Um arquivo recebido no upload, já lido em memória pelo controller (até o limite de tamanho).</summary>
-    public sealed record UploadedArtifactInput(string Kind, string OriginalFileName, string ContentType, byte[] Content);
+    /// <summary><paramref name="Provenance"/> ver <see cref="Models.Entities.Fiscal.ArtifactProvenance"/> (issue #341) — opcional, ausência resolve fail-closed como amostra real.</summary>
+    public sealed record UploadedArtifactInput(string Kind, string OriginalFileName, string ContentType, byte[] Content, string? Provenance = null);
 
     /// <summary>Resultado de uma tentativa de criação de pacote — pode falhar por validação (422) sem lançar.</summary>
     public sealed record CreatePackageOutcome(bool Success, string? Error, PackageDetail? Package);

--- a/Services/Interfaces/IFiscalPackageStore.cs
+++ b/Services/Interfaces/IFiscalPackageStore.cs
@@ -10,7 +10,8 @@ namespace LayoutParserApi.Services.Interfaces
         long SizeBytes,
         string OriginalFileName,
         string InspectionStatus,
-        DateTimeOffset UploadedAt);
+        DateTimeOffset UploadedAt,
+        string? Provenance = null);
 
     /// <summary>Resumo de uma revisão com seu inventário de artefatos.</summary>
     public sealed record RevisionSummary(

--- a/Services/Interfaces/IMappingDraftStore.cs
+++ b/Services/Interfaces/IMappingDraftStore.cs
@@ -52,8 +52,12 @@ namespace LayoutParserApi.Services.Interfaces
         string Status,
         IReadOnlyList<string> OpenQuestions);
 
-    /// <summary>Referência a um artefato em filesystem — usado pelo job de sugestão para ler o conteúdo-fonte.</summary>
-    public sealed record ArtifactFileRef(Guid ArtifactId, string Kind, string StoragePath, string OriginalFileName);
+    /// <summary>
+    /// Referência a um artefato em filesystem — usado pelo job de sugestão para ler o conteúdo-fonte.
+    /// <paramref name="Provenance"/> ver <see cref="Models.Entities.Fiscal.ArtifactProvenance"/>
+    /// (issue #341) — <c>null</c> é tratado como amostra real (fail-closed) por quem consome este DTO.
+    /// </summary>
+    public sealed record ArtifactFileRef(Guid ArtifactId, string Kind, string StoragePath, string OriginalFileName, string? Provenance = null);
 
     /// <summary>
     /// Acesso a dado de <see cref="MappingDraft"/>/<see cref="MappingDraftRule"/>/

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
@@ -280,7 +280,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 LastEnqueueUserId = userId;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
@@ -107,7 +107,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
 
             public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
                 Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
@@ -192,7 +192,7 @@ namespace LayoutParserApi.Tests.Controllers
         {
             public Task EnqueueAsync(string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null) => Task.CompletedTask;
 
             public Task<AiCandidateStatus> GetStatusAsync(string userId, string ticket, CancellationToken cancellationToken) =>
                 Task.FromResult(new AiCandidateStatus { Status = AiCandidateStatus.StatusNotFound });

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -61,9 +61,9 @@ namespace LayoutParserApi.Tests.Controllers
         {
             public MapperDbVazio(IConfiguration config) : base(NullLogger<MapperDatabaseService>.Instance, null!, config) { }
 
-            public override Task<List<Models.Entities.Mapper>> GetRankedMapperCandidatesForLayoutGuidAsync(
+            public override Task<List<LayoutParserApi.Models.Entities.Mapper>> GetRankedMapperCandidatesForLayoutGuidAsync(
                 string layoutGuid, int projectId, IReadOnlyCollection<string> allowedPackageGuids)
-                => Task.FromResult(new List<Models.Entities.Mapper>());
+                => Task.FromResult(new List<LayoutParserApi.Models.Entities.Mapper>());
         }
 
         private sealed class SpyAiCandidateService : IAiTransformationCandidateService
@@ -71,7 +71,7 @@ namespace LayoutParserApi.Tests.Controllers
             public int EnqueueCount { get; private set; }
             public Task EnqueueAsync(string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 EnqueueCount++;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -53,7 +53,7 @@ namespace LayoutParserApi.Tests.Controllers
             public Task EnqueueAsync(
                 string userId, string ticket, string layoutName, Guid layoutGuid, string mapperGuid,
                 string inputContent, string? groundTruthXml, CancellationToken cancellationToken,
-                IReadOnlyList<Models.Entities.ParsedField>? parsedFields = null)
+                IReadOnlyList<LayoutParserApi.Models.Entities.ParsedField>? parsedFields = null)
             {
                 LastEnqueueUserId = userId;
                 return Task.CompletedTask;

--- a/tests/LayoutParserApi.Tests/Models/Fiscal/ArtifactProvenanceTests.cs
+++ b/tests/LayoutParserApi.Tests/Models/Fiscal/ArtifactProvenanceTests.cs
@@ -1,0 +1,57 @@
+using LayoutParserApi.Models.Entities.Fiscal;
+using LayoutParserApi.Services.Llm;
+
+using Xunit;
+
+namespace LayoutParserApi.Tests.Models.Fiscal
+{
+    /// <summary>
+    /// Issue #341 (F2 do ADR docs/architecture/adr-llm-provider-plugavel-2026-09-08.md): garante que
+    /// a AUSÊNCIA de proveniência declarada nunca resolve para <see cref="DataSensitivity.SyntheticOrAnonymized"/>
+    /// por omissão — só o valor explícito <see cref="ArtifactProvenance.Synthetic"/> resolve assim.
+    /// </summary>
+    public class ArtifactProvenanceTests
+    {
+        [Fact]
+        public void ResolveSensitivity_SemValorPreenchido_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(null));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_StringVazia_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(string.Empty));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_ValorDesconhecido_ResolveComoRealFiscalDocument()
+        {
+            // Valor fora do vocabulário conhecido (typo, versão futura etc.) — fail-closed, nunca sintético por engano.
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity("qualquer-coisa"));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_RealCustomerSampleExplicito_ResolveComoRealFiscalDocument()
+        {
+            Assert.Equal(DataSensitivity.RealFiscalDocument, ArtifactProvenance.ResolveSensitivity(ArtifactProvenance.RealCustomerSample));
+        }
+
+        [Fact]
+        public void ResolveSensitivity_SyntheticExplicito_ResolveComoSyntheticOrAnonymized()
+        {
+            Assert.Equal(DataSensitivity.SyntheticOrAnonymized, ArtifactProvenance.ResolveSensitivity(ArtifactProvenance.Synthetic));
+        }
+
+        [Theory]
+        [InlineData(ArtifactProvenance.Synthetic, true)]
+        [InlineData(ArtifactProvenance.RealCustomerSample, true)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("invalido", false)]
+        public void IsValid_RespeitaVocabularioExplicito(string? value, bool expected)
+        {
+            Assert.Equal(expected, ArtifactProvenance.IsValid(value));
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceXslSynthesizerTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/AiTransformationCandidateServiceXslSynthesizerTests.cs
@@ -185,7 +185,7 @@ namespace LayoutParserApi.Tests.Services.Transformation.Ai
 
         /// <summary>Mesma infraestrutura mínima de <c>LineInfoAdditiveSignalsTests.ParseAsync</c> —
         /// invoca o <c>LayoutParserService</c> REAL, não um mock/stub de parsing.</summary>
-        private static async Task<Models.Parsing.ParsingResult> ParseTxtRealAsync(string layoutXml, string documento)
+        private static async Task<LayoutParserApi.Models.Parsing.ParsingResult> ParseTxtRealAsync(string layoutXml, string documento)
         {
             var techLogger = new NoOpTechLoggerLocal();
             var config = new Microsoft.Extensions.Configuration.ConfigurationBuilder()


### PR DESCRIPTION
## Resumo

Implementa F2 da issue #341: campo `ArtifactProvenance` (`Synthetic`/`RealCustomerSample`) explícito nos artefatos de pacote fiscal, fechando o gap de proveniência real/sintética que o `ILlmProvider`/`LlmProviderResolver` do #340 depende para decidir com segurança se um artefato pode ir para um provider cloud.

Depende do contrato introduzido em #340 (`ILlmProvider`, `DataSensitivity`, `LlmProviderResolver`) — por isso esta PR aponta para a branch `feat/llm-provider-abstraction-340`, não para `develop` diretamente. Depois que #360 (#340) mergear em `develop`, esta branch deve ser rebasada/re-alvo para `develop`.

## Mudanças

- `Models/Entities/Fiscal/PackageArtifact.cs` — novo enum `ArtifactProvenance` (`Synthetic`/`RealCustomerSample`) com `ResolveSensitivity` fail-closed (ausência de proveniência sempre resolve para `RealFiscalDocument`, nunca degrada silenciosamente para dado sintético).
- `Services/Interfaces/IFiscalPackageStore.cs`, `IFiscalPackageService.cs`, `IMappingDraftStore.cs` — `Provenance` adicionado a `ArtifactSummary`/`UploadedArtifactInput`/`ArtifactFileRef`.
- `Services/Fiscal/FiscalPackageService.cs`, `Controllers/FiscalMappingPackagesController.cs` (lê campo opcional de form `"{kind}Provenance"`), `Services/Database/SqlFiscalPackageStore.cs` (`ALTER TABLE` idempotente pra `tbPackageArtifact.Provenance`), `Services/Database/SqlMappingDraftStore.cs`.
- `tests/LayoutParserApi.Tests/Models/Fiscal/ArtifactProvenanceTests.cs` (novo).

## Correção incluída (fix/tests)

Um commit adicional (`84c8e7c`) corrige uma quebra real de build nos testes introduzida pelo próprio commit de feature (`d3783a3`): 6 arquivos de teste referenciavam `Models.Entities.*`/`Models.Parsing.*` sem o prefixo `LayoutParserApi.`, resolvendo incorretamente para o namespace `LayoutParserApi.Tests.Models.*` (inexistente). Essa hipótese foi verificada de forma isolada (build limpo em worktrees de `origin/develop` e de `feat/llm-provider-abstraction-340`) antes de confirmar que a quebra era própria desta branch, não pré-existente.

## Testes

`dotnet build` e `dotnet test` verificados localmente: **719/719 passando, 0 erros.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)