### PR TITLE
feat(ai): retraining automatizado do modelo fine-tuned — F4.1/F4.2/F4.3 (issue #351)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -649,6 +649,24 @@ try
     // de treino incremental (ai/XslSynth/training-data/*.jsonl).
     builder.Services.AddScoped<LayoutParserApi.Services.Transformation.Ai.TrainingDataCaptureService>();
 
+    // ✅ Issue #351 (F4): retraining automatizado do modelo fine-tuned.
+    //  - F4.1: telemetria de duração/iterações do RepairOrchestrator em runtime (Source=AiMetrics).
+    //  - F4.2: contador de exemplos novos (alimentado por F3) + gatilho por volume OU teto de 90d.
+    //  - F4.3: exclusão mútua Ollama-inferência × treino (retraining.lock) + validação pós-treino.
+    // Estado durável em arquivo na árvore de XslSynth:TrainingDataPath (mesmo padrão de F3) — nunca
+    // no SQL compartilhado 172.31.249.51 (read-only, ver .claude/rules/security.md). Singletons:
+    // contador compartilhado entre o hook de F3 (escopo de request) e o background service.
+    builder.Services.Configure<LayoutParserApi.Services.Transformation.Ai.Retraining.RetrainingOptions>(
+        builder.Configuration.GetSection(
+            LayoutParserApi.Services.Transformation.Ai.Retraining.RetrainingOptions.SectionName));
+    builder.Services.AddSingleton<LayoutParserApi.Services.Transformation.Ai.Retraining.IRetrainingStateStore,
+        LayoutParserApi.Services.Transformation.Ai.Retraining.FileRetrainingStateStore>();
+    builder.Services.AddSingleton<LayoutParserApi.Services.Transformation.Ai.Retraining.IRetrainingLock,
+        LayoutParserApi.Services.Transformation.Ai.Retraining.FileRetrainingLock>();
+    builder.Services.AddSingleton<LayoutParserApi.Services.Transformation.Ai.Retraining.IRetrainingCoordinator,
+        LayoutParserApi.Services.Transformation.Ai.Retraining.RetrainingCoordinator>();
+    builder.Services.AddHostedService<LayoutParserApi.Services.Transformation.Ai.Retraining.RetrainingSchedulerBackgroundService>();
+
     // Transformation Services (ML)
     builder.Services.AddScoped<TransformationLearningService>();
     builder.Services.AddScoped<PatternComparisonService>();

--- a/Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs
+++ b/Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs
@@ -1,10 +1,14 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 
 using LayoutParserApi.Models.Entities;
 using LayoutParserApi.Services.Interfaces;
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
 using LayoutParserApi.Services.XmlAnalysis;
 
 using Microsoft.Extensions.Options;
+
+using Serilog.Context;
 
 using XslSynth.Core;
 using XslSynth.Synthesis;
@@ -30,6 +34,9 @@ namespace LayoutParserApi.Services.Transformation.Ai
         private readonly XmlDocumentTypeDetector _documentTypeDetector;
         private readonly OllamaOptions _ollamaOptions;
         private readonly TrainingDataCaptureService _trainingDataCapture;
+        // F4.3 (issue #351): exclusão mútua com o treino LoRA na mesma VM. Opcional (nullable) —
+        // sem o serviço registrado, a checagem é ignorada e o comportamento é o de hoje.
+        private readonly IRetrainingLock? _retrainingLock;
         private readonly string _xsdBasePath;
         private readonly string _xslBasePath;
         private readonly RepairOrchestrator _orchestrator = new();
@@ -42,13 +49,15 @@ namespace LayoutParserApi.Services.Transformation.Ai
             XmlDocumentTypeDetector documentTypeDetector,
             IOptions<OllamaOptions> ollamaOptions,
             IConfiguration configuration,
-            TrainingDataCaptureService trainingDataCapture)
+            TrainingDataCaptureService trainingDataCapture,
+            IRetrainingLock? retrainingLock = null)
         {
             _logger = logger;
             _mapperService = mapperService;
             _documentTypeDetector = documentTypeDetector;
             _ollamaOptions = ollamaOptions.Value;
             _trainingDataCapture = trainingDataCapture;
+            _retrainingLock = retrainingLock;
             _xsdBasePath = configuration["XsdValidation:BasePath"] ?? @"C:\inetpub\wwwroot\layoutparser\xsd";
             // Mesma convenção de TransformationPipelineService/AutoTransformationGeneratorService —
             // {mapperName}_{layoutName}.xsl (issue #55) — pra persistir o XSLT sintetizado no lugar
@@ -71,6 +80,21 @@ namespace LayoutParserApi.Services.Transformation.Ai
             var safeLayoutName = Services.Logging.LogMessageSanitizer.Sanitize(layoutName);
             try
             {
+                // F4.3 (issue #351, ADR §6.2): se o treino LoRA está rodando na VM (retraining.lock
+                // presente), a síntese via Ollama fica suspensa — treino + inferência juntos na
+                // mesma CPU degradam a convergência pelas ~40h inteiras. Degrada graciosamente
+                // (não lança): o ticket de IA volta como não-convergido e pode ser retentado depois.
+                if (_retrainingLock?.IsHeld() == true)
+                {
+                    _logger.LogWarning(
+                        "Síntese de XSLT suspensa: retraining LoRA em andamento na VM ({LockPath}) — " +
+                        "Ollama de inferência não é acionado enquanto o treino roda (mapperGuid={MapperGuid})",
+                        Services.Logging.LogMessageSanitizer.Sanitize(_retrainingLock.LockFilePath), safeMapperGuid);
+                    return Failed(
+                        "Retraining do modelo em andamento na VM — síntese via Ollama suspensa até o treino " +
+                        "terminar (retraining.lock presente). Retente mais tarde.");
+                }
+
                 var mapper = await ResolveMapperAsync(mapperGuid, cancellationToken);
                 if (mapper is null)
                 {
@@ -133,6 +157,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 // TryPersistXslt já usa para gravar (issue #55).
                 var seedXslt = TryLoadSeedXslt(mapper.Name, layoutName);
 
+                var stopwatch = Stopwatch.StartNew();
                 var report = await _orchestrator.RunAsync(
                     mapperVo,
                     input,
@@ -143,6 +168,13 @@ namespace LayoutParserApi.Services.Transformation.Ai
                     maxIterations,
                     cancellationToken,
                     seedXslt);
+                stopwatch.Stop();
+
+                // F4.1 (issue #351, ADR §8/§10): telemetria de duração/iterações do RepairOrchestrator
+                // no caminho de PRODUÇÃO — até agora só o CLI offline (MetricsBatchRunner) media isso.
+                // Mesmo canal de F3 (Source=AiMetrics), pré-requisito pra calibrar o N do gatilho de F4.2.
+                LogRuntimeMetrics(safeMapperGuid, safeLayoutName, stopwatch.Elapsed.TotalSeconds, report.Iterations,
+                    report.Converged, report.FinalXsd.IsValid);
 
                 if (report.Converged && !string.IsNullOrWhiteSpace(layoutName))
                     TryPersistXslt(mapper.Name, layoutName!, report.FinalXslt);
@@ -324,6 +356,32 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 Environment.SetEnvironmentVariable("OLLAMA_MODEL", _ollamaOptions.Model);
 
             return new OllamaXslSynthesizer(message => _logger.LogDebug("[Ollama] {Message}", message));
+        }
+
+        /// <summary>
+        /// F4.1 (issue #351): grava a linha estruturada de duração/iterações do RepairOrchestrator
+        /// em runtime, com <c>Source=AiMetrics</c> (mesmo canal que o job <c>--mode=metrics-batch</c>
+        /// e a ingestão externa já usam). Pares Chave=Valor, cultura invariante no double — o leitor
+        /// de métricas tokeniza por espaço e ignora chave desconhecida, então é aditivo.
+        /// </summary>
+        private void LogRuntimeMetrics(
+            string safeMapperGuid, string? safeLayoutName, double durationSeconds, int iterations,
+            bool converged, bool xsdValid)
+        {
+            using (LogContext.PushProperty("Source", "AiMetrics"))
+            {
+                _logger.LogInformation(
+                    "RepairOrchestrator runtime concluido. MapperGuid={MapperGuid} Layout={Layout} " +
+                    "DuracaoSegundos={DurationSeconds} Iteracoes={Iterations} Convergiu={Converged} " +
+                    "XsdValido={XsdValid} Origem={Origem}",
+                    safeMapperGuid,
+                    safeLayoutName ?? string.Empty,
+                    durationSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture),
+                    iterations,
+                    converged,
+                    xsdValid,
+                    "repair-orchestrator-runtime");
+            }
         }
 
         private static XslSynthesisResult Failed(string error) => new()

--- a/Services/Transformation/Ai/Retraining/FileRetrainingLock.cs
+++ b/Services/Transformation/Ai/Retraining/FileRetrainingLock.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Exclusão mútua Ollama-inferência × treino LoRA (F4.3, issue #351, ADR §6.2). O treino de
+    /// ~40h em CPU na mesma VM que serve o Ollama de produção degrada toda convergência em runtime
+    /// pela duração inteira — então enquanto o treino roda, a síntese via Ollama é suspensa.
+    /// </summary>
+    public interface IRetrainingLock
+    {
+        /// <summary><c>true</c> se o <c>retraining.lock</c> existe na VM (treino em andamento).</summary>
+        bool IsHeld();
+
+        /// <summary>Caminho do arquivo de lock, pra logs/diagnóstico e pro script da VM.</summary>
+        string LockFilePath { get; }
+    }
+
+    /// <summary>
+    /// Implementação por arquivo. A API só LÊ o lock — quem cria/remove é o script de treino da VM
+    /// (handoff <c>@lp-devops</c>). Checa idade do arquivo pra logar suspeita de lock órfão sem
+    /// removê-lo (remoção é decisão operacional, não automática).
+    /// </summary>
+    public class FileRetrainingLock : IRetrainingLock
+    {
+        private readonly ILogger<FileRetrainingLock> _logger;
+        private readonly int _staleAfterHours;
+
+        public FileRetrainingLock(
+            ILogger<FileRetrainingLock> logger,
+            IOptions<RetrainingOptions> options,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+
+            var trainingDataPath = configuration["XslSynth:TrainingDataPath"]
+                ?? Path.Combine(AppContext.BaseDirectory, "ai", "XslSynth", "training-data");
+
+            LockFilePath = !string.IsNullOrWhiteSpace(options.Value.LockFilePath)
+                ? options.Value.LockFilePath!
+                : Path.Combine(trainingDataPath, "retraining.lock");
+
+            _staleAfterHours = options.Value.StaleLockAfterHours;
+        }
+
+        public string LockFilePath { get; }
+
+        public bool IsHeld()
+        {
+            try
+            {
+                if (!File.Exists(LockFilePath))
+                    return false;
+
+                if (_staleAfterHours > 0)
+                {
+                    var age = DateTime.UtcNow - File.GetLastWriteTimeUtc(LockFilePath);
+                    if (age > TimeSpan.FromHours(_staleAfterHours))
+                        _logger.LogWarning(
+                            "retraining.lock em {Path} tem {Horas:F1}h — acima do teto de {Teto}h. " +
+                            "Suspeita de lock órfão (treino morto sem limpar). Não removido automaticamente.",
+                            LockFilePath, age.TotalHours, _staleAfterHours);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Se não dá pra checar o lock, o lado seguro é assumir que NÃO está travado —
+                // travar a síntese por um erro de I/O na checagem seria pior que o risco de
+                // concorrência (que só existe se um treino estiver de fato rodando).
+                _logger.LogWarning(ex, "Falha ao checar o retraining.lock em {Path} — assumindo não travado", LockFilePath);
+                return false;
+            }
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/FileRetrainingStateStore.cs
+++ b/Services/Transformation/Ai/Retraining/FileRetrainingStateStore.cs
@@ -1,0 +1,134 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Leitura/escrita do <see cref="RetrainingState"/> durável.</summary>
+    public interface IRetrainingStateStore
+    {
+        /// <summary>Carrega o estado; se o arquivo não existir ou estiver corrompido, devolve um
+        /// estado novo já com <see cref="RetrainingState.CreatedUtc"/> setado (e persiste).</summary>
+        RetrainingState Load();
+
+        /// <summary>Persiste o estado de forma atômica (escreve em arquivo temporário e move).</summary>
+        void Save(RetrainingState state);
+
+        /// <summary>Executa <paramref name="mutate"/> sobre o estado sob lock de processo e persiste
+        /// o resultado. Devolve o estado já mutado.</summary>
+        RetrainingState Update(Action<RetrainingState> mutate);
+    }
+
+    /// <summary>
+    /// Implementação file-based do estado de retraining (F4.2, issue #351). Segue o mesmo padrão
+    /// de persistência de F3 (arquivo na árvore de <c>XslSynth:TrainingDataPath</c>) — nada de SQL
+    /// compartilhado. Lock só de processo (a API roda como instância única na VM; concorrência real
+    /// aqui é entre o background service e o hook de F3 no mesmo processo).
+    /// </summary>
+    public class FileRetrainingStateStore : IRetrainingStateStore
+    {
+        private static readonly object Gate = new();
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        private readonly ILogger<FileRetrainingStateStore> _logger;
+        private readonly string _stateFilePath;
+
+        public FileRetrainingStateStore(
+            ILogger<FileRetrainingStateStore> logger,
+            IOptions<RetrainingOptions> options,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+
+            var trainingDataPath = configuration["XslSynth:TrainingDataPath"]
+                ?? Path.Combine(AppContext.BaseDirectory, "ai", "XslSynth", "training-data");
+
+            _stateFilePath = !string.IsNullOrWhiteSpace(options.Value.StateFilePath)
+                ? options.Value.StateFilePath!
+                : Path.Combine(trainingDataPath, "retraining-state.json");
+        }
+
+        public RetrainingState Load()
+        {
+            lock (Gate)
+            {
+                return LoadUnlocked();
+            }
+        }
+
+        public void Save(RetrainingState state)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+            lock (Gate)
+            {
+                SaveUnlocked(state);
+            }
+        }
+
+        public RetrainingState Update(Action<RetrainingState> mutate)
+        {
+            ArgumentNullException.ThrowIfNull(mutate);
+            lock (Gate)
+            {
+                var state = LoadUnlocked();
+                mutate(state);
+                SaveUnlocked(state);
+                return state;
+            }
+        }
+
+        private RetrainingState LoadUnlocked()
+        {
+            try
+            {
+                if (File.Exists(_stateFilePath))
+                {
+                    var json = File.ReadAllText(_stateFilePath);
+                    var loaded = JsonSerializer.Deserialize<RetrainingState>(json, JsonOptions);
+                    if (loaded is not null)
+                    {
+                        if (loaded.CreatedUtc == default)
+                            loaded.CreatedUtc = DateTime.UtcNow;
+                        return loaded;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Estado de retraining ilegível em {Path} — recomeçando de um estado novo (contador zerado)",
+                    _stateFilePath);
+            }
+
+            var fresh = new RetrainingState { CreatedUtc = DateTime.UtcNow };
+            SaveUnlocked(fresh);
+            return fresh;
+        }
+
+        private void SaveUnlocked(RetrainingState state)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_stateFilePath);
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
+
+                var tmp = _stateFilePath + ".tmp";
+                File.WriteAllText(tmp, JsonSerializer.Serialize(state, JsonOptions));
+                File.Move(tmp, _stateFilePath, overwrite: true);
+            }
+            catch (Exception ex)
+            {
+                // Best-effort: persistência de estado de retraining não pode derrubar o request de
+                // síntese nem o background service (dotnet-standards.md §Resiliência).
+                _logger.LogWarning(ex, "Falha ao persistir o estado de retraining em {Path}", _stateFilePath);
+            }
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/ModelMetricsComparer.cs
+++ b/Services/Transformation/Ai/Retraining/ModelMetricsComparer.cs
@@ -1,0 +1,65 @@
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Foto das métricas de um modelo contra o held-out set (saída do
+    /// <c>MetricsBatchRunner --mode=metrics-batch</c>). Taxas em 0..1.
+    /// </summary>
+    public readonly record struct ModelMetricsSnapshot(
+        string Model,
+        int SampleCount,
+        double ConvergenceRate,
+        double XsdValidRate,
+        double DiffZeroRate);
+
+    /// <summary>Decisão de promoção do modelo recém-treinado.</summary>
+    public readonly record struct RetrainingPromotionDecision(bool Promote, IReadOnlyList<string> Reasons);
+
+    /// <summary>
+    /// Comparação pós-treino (F4.3, issue #351, ADR §6.3): só promove o modelo novo (troca de
+    /// tag/symlink no Ollama, feita no lado da VM) se as métricas contra o held-out atual NÃO
+    /// regredirem frente ao modelo em produção. Lógica pura, testável — a execução do
+    /// <c>MetricsBatchRunner</c> e o swap do symlink ficam no script da VM (handoff @lp-devops).
+    /// </summary>
+    public static class ModelMetricsComparer
+    {
+        /// <summary>
+        /// <paramref name="tolerance"/>: quanto de queda numa taxa ainda é aceitável (default 0 =
+        /// "não regredir"). Uma folga pequena (ex. 0.01) absorve ruído de amostragem se o held-out
+        /// for pequeno.
+        /// </summary>
+        public static RetrainingPromotionDecision Decide(
+            ModelMetricsSnapshot current,
+            ModelMetricsSnapshot candidate,
+            double tolerance = 0.0)
+        {
+            var reasons = new List<string>();
+
+            if (candidate.SampleCount <= 0)
+            {
+                reasons.Add("Candidato sem amostras avaliadas — impossível comparar; não promove.");
+                return new RetrainingPromotionDecision(false, reasons);
+            }
+
+            if (candidate.SampleCount < current.SampleCount)
+                reasons.Add($"Held-out do candidato menor ({candidate.SampleCount}) que o do atual ({current.SampleCount}) — comparação menos confiável.");
+
+            CheckRate("convergência", current.ConvergenceRate, candidate.ConvergenceRate, tolerance, reasons);
+            CheckRate("XSD válido", current.XsdValidRate, candidate.XsdValidRate, tolerance, reasons);
+            CheckRate("diff==0", current.DiffZeroRate, candidate.DiffZeroRate, tolerance, reasons);
+
+            var regressed = reasons.Exists(r => r.Contains("REGRESSÃO", StringComparison.Ordinal));
+            if (!regressed)
+                reasons.Add("Nenhuma métrica regrediu além da tolerância — promover o modelo novo.");
+
+            return new RetrainingPromotionDecision(!regressed, reasons);
+        }
+
+        private static void CheckRate(string nome, double atual, double novo, double tolerance, List<string> reasons)
+        {
+            if (novo < atual - tolerance)
+                reasons.Add($"REGRESSÃO em {nome}: {atual:P1} → {novo:P1} (queda de {(atual - novo):P1}, tolerância {tolerance:P1}).");
+            else
+                reasons.Add($"{nome}: {atual:P1} → {novo:P1} (ok).");
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingCoordinator.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingCoordinator.cs
@@ -1,0 +1,195 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Orquestra o gatilho de retraining (F4.2/F4.3, issue #351): mantém o contador de exemplos
+    /// novos alimentado por F3, avalia o gatilho (volume OU teto de agenda), escreve o
+    /// arquivo-marcador que o cron da VM observa, e detecta a conclusão do treino (marcador
+    /// removido + lock livre) pra zerar o contador.
+    ///
+    /// <para>Singleton — estado compartilhado (contador) entre o hook de F3 (escopo de request) e
+    /// o <see cref="RetrainingSchedulerBackgroundService"/>. Toda a durabilidade fica no
+    /// <see cref="IRetrainingStateStore"/> (arquivo). Best-effort ponta a ponta: nada aqui pode
+    /// derrubar a síntese nem o host.</para>
+    /// </summary>
+    public interface IRetrainingCoordinator
+    {
+        /// <summary>Chamado por F3 quando uma convergência real é gravada no JSONL incremental.</summary>
+        void RegisterCapturedExample();
+
+        /// <summary>Avalia o gatilho e, se for o caso, escreve o marcador de disparo. Também detecta
+        /// a conclusão de um treino anterior. Idempotente por tick.</summary>
+        Task EvaluateAndMaybeTriggerAsync(CancellationToken cancellationToken);
+
+        /// <summary>Snapshot do estado atual (leitura), pra observabilidade/testes.</summary>
+        RetrainingState PeekState();
+    }
+
+    public class RetrainingCoordinator : IRetrainingCoordinator
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        private readonly ILogger<RetrainingCoordinator> _logger;
+        private readonly IRetrainingStateStore _stateStore;
+        private readonly IRetrainingLock _lock;
+        private readonly RetrainingOptions _options;
+        private readonly string _triggerFilePath;
+
+        public RetrainingCoordinator(
+            ILogger<RetrainingCoordinator> logger,
+            IRetrainingStateStore stateStore,
+            IRetrainingLock retrainingLock,
+            IOptions<RetrainingOptions> options,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+            _stateStore = stateStore;
+            _lock = retrainingLock;
+            _options = options.Value;
+
+            var trainingDataPath = configuration["XslSynth:TrainingDataPath"]
+                ?? Path.Combine(AppContext.BaseDirectory, "ai", "XslSynth", "training-data");
+
+            _triggerFilePath = !string.IsNullOrWhiteSpace(_options.TriggerFilePath)
+                ? _options.TriggerFilePath!
+                : Path.Combine(trainingDataPath, "retraining.trigger.json");
+        }
+
+        public void RegisterCapturedExample()
+        {
+            try
+            {
+                var state = _stateStore.Update(s => s.ExamplesSinceLastTraining++);
+                _logger.LogDebug(
+                    "Contador de retraining incrementado: {Contador} exemplo(s) novo(s) desde o último treino",
+                    state.ExamplesSinceLastTraining);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha ao incrementar o contador de retraining (best-effort)");
+            }
+        }
+
+        public RetrainingState PeekState()
+        {
+            try
+            {
+                return _stateStore.Load();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha ao ler o estado de retraining");
+                return new RetrainingState { CreatedUtc = DateTime.UtcNow };
+            }
+        }
+
+        public Task EvaluateAndMaybeTriggerAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var state = _stateStore.Load();
+                var lockHeld = _lock.IsHeld();
+                var triggerFileExists = File.Exists(_triggerFilePath);
+
+                // 1. Detecção de conclusão: havia um disparo pendente, o marcador já foi removido
+                //    pelo script da VM e o lock está livre → o treino terminou.
+                if (state.TriggerPending && !triggerFileExists && !lockHeld)
+                {
+                    var completed = _stateStore.Update(s =>
+                    {
+                        // Só o tanto contado no disparo é zerado — o que F3 capturou durante o
+                        // treino de ~40h fica pro próximo ciclo.
+                        s.ExamplesSinceLastTraining = Math.Max(0, s.ExamplesSinceLastTraining - s.ExamplesCountedAtTrigger);
+                        s.ExamplesCountedAtTrigger = 0;
+                        s.TriggerPending = false;
+                        s.LastTrainingCompletedUtc = DateTime.UtcNow;
+                    });
+                    _logger.LogInformation(
+                        "Retraining detectado como concluído (marcador removido, lock livre). " +
+                        "Contador reiniciado para {Contador} exemplo(s) acumulado(s) durante o treino.",
+                        completed.ExamplesSinceLastTraining);
+                    return Task.CompletedTask;
+                }
+
+                // 2. Enquanto o treino roda, não faz mais nada.
+                if (lockHeld || state.TriggerPending)
+                {
+                    _logger.LogDebug(
+                        "Avaliação de gatilho de retraining pulada: lockHeld={LockHeld}, triggerPending={Pending}",
+                        lockHeld, state.TriggerPending);
+                    return Task.CompletedTask;
+                }
+
+                // 3. Avalia o gatilho.
+                var decision = RetrainingTriggerEvaluator.Evaluate(state, _options, DateTime.UtcNow);
+                if (!decision.ShouldTrigger)
+                {
+                    _logger.LogDebug("Gatilho de retraining não disparou: {Explicacao}", decision.Explanation);
+                    return Task.CompletedTask;
+                }
+
+                if (!_options.Enabled)
+                {
+                    _logger.LogInformation(
+                        "Gatilho de retraining SATISFEITO ({Motivo}: {Explicacao}), mas XslSynth:Retraining:Enabled=false — " +
+                        "marcador de disparo NÃO escrito. Fiação do lado da VM (cron/lock) é pré-requisito.",
+                        decision.Reason, decision.Explanation);
+                    return Task.CompletedTask;
+                }
+
+                WriteTriggerMarker(state, decision);
+                var updated = _stateStore.Update(s =>
+                {
+                    s.TriggerPending = true;
+                    s.LastTriggeredUtc = DateTime.UtcNow;
+                    s.ExamplesCountedAtTrigger = s.ExamplesSinceLastTraining;
+                    s.LastTriggerReason = decision.Reason.ToString();
+                });
+
+                _logger.LogWarning(
+                    "Retraining DISPARADO ({Motivo}): {Explicacao}. Marcador escrito em {Path}. " +
+                    "{Contador} exemplo(s) contabilizado(s) no disparo.",
+                    decision.Reason, decision.Explanation, _triggerFilePath, updated.ExamplesCountedAtTrigger);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falha na avaliação do gatilho de retraining (best-effort, não afeta a síntese)");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void WriteTriggerMarker(RetrainingState state, RetrainingTriggerDecision decision)
+        {
+            var threshold = _options.NewExampleThreshold > 0
+                ? _options.NewExampleThreshold
+                : RetrainingOptions.DefaultNewExampleThreshold;
+
+            var request = new RetrainingTriggerRequest
+            {
+                RequestedUtc = DateTime.UtcNow.ToString("o"),
+                Reason = decision.Reason.ToString(),
+                Explanation = decision.Explanation,
+                ExamplesSinceLastTraining = state.ExamplesSinceLastTraining,
+                Threshold = threshold,
+                LastTrainingCompletedUtc = state.LastTrainingCompletedUtc?.ToString("o"),
+            };
+
+            var dir = Path.GetDirectoryName(_triggerFilePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var tmp = _triggerFilePath + ".tmp";
+            File.WriteAllText(tmp, JsonSerializer.Serialize(request, JsonOptions));
+            File.Move(tmp, _triggerFilePath, overwrite: true);
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingOptions.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingOptions.cs
@@ -1,0 +1,88 @@
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Configuração do retraining automatizado do modelo fine-tuned (F4 do ADR
+    /// docs/architecture/adr-backfill-catalogo-e-retraining-automatizado-2026-09-08.md, issue #351).
+    /// Seção <c>XslSynth:Retraining</c> do appsettings.
+    ///
+    /// <para><b>Persistência:</b> segue o mesmo padrão de F3 (arquivos na árvore de
+    /// <c>XslSynth:TrainingDataPath</c>, na VM <c>172.25.32.5</c>) — NÃO usa o SQL compartilhado
+    /// <c>172.31.249.51</c> (read-only, ver <c>.claude/rules/security.md</c>). O estado (contador,
+    /// timestamps) é um JSON durável ao lado do JSONL incremental.</para>
+    ///
+    /// <para><b>Desligado por padrão</b> (<see cref="Enabled"/> = false): o disparo real de
+    /// <c>train_lora.py</c> e o <c>retraining.lock</c> físico dependem de fiação no lado da VM
+    /// (cron/script), que é handoff pro <c>@lp-devops</c>. Enquanto isso não existe, a API só
+    /// mantém o contador e checa o lock (se o arquivo aparecer), sem tentar disparar nada.</para>
+    /// </summary>
+    public class RetrainingOptions
+    {
+        /// <summary>Nome da seção no appsettings.</summary>
+        public const string SectionName = "XslSynth:Retraining";
+
+        /// <summary>Default do gatilho por volume — exemplos novos (F3) desde o último treino.</summary>
+        public const int DefaultNewExampleThreshold = 300;
+
+        /// <summary>Default do teto de agenda, em dias, desde o último treino concluído.</summary>
+        public const int DefaultMaxDaysBetweenTrainings = 90;
+
+        /// <summary>Default do intervalo entre avaliações do gatilho pelo background service, em horas.</summary>
+        public const int DefaultEvaluationIntervalHours = 6;
+
+        /// <summary>
+        /// Liga a avaliação periódica do gatilho e a escrita do arquivo-marcador de disparo. Com
+        /// <c>false</c> (default), o <see cref="RetrainingCoordinator"/> ainda incrementa o contador
+        /// a cada convergência capturada por F3 (barato, sem efeito colateral), mas nunca dispara
+        /// treino — seguro até o lado da VM estar pronto.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Dispara o retraining quando o contador de exemplos novos capturados por F3 desde o
+        /// último treino atinge este valor. Valor &lt;= 0 cai no default
+        /// (<see cref="DefaultNewExampleThreshold"/>). ADR §6.1: F3 cresce devagar (convergência
+        /// real, não batch), então a ordem de grandeza é centenas, não o tamanho do dataset atual.
+        /// </summary>
+        public int NewExampleThreshold { get; set; } = DefaultNewExampleThreshold;
+
+        /// <summary>
+        /// Rede de segurança (ADR §6.1): se o volume não bater <see cref="NewExampleThreshold"/>
+        /// dentro deste número de dias desde o último treino concluído, dispara mesmo assim com o
+        /// que houver acumulado (desde que haja pelo menos 1 exemplo novo). Valor &lt;= 0 cai no
+        /// default (<see cref="DefaultMaxDaysBetweenTrainings"/>).
+        /// </summary>
+        public int MaxDaysBetweenTrainings { get; set; } = DefaultMaxDaysBetweenTrainings;
+
+        /// <summary>Intervalo entre avaliações do gatilho. Valor &lt;= 0 cai no default (6h).</summary>
+        public int EvaluationIntervalHours { get; set; } = DefaultEvaluationIntervalHours;
+
+        /// <summary>
+        /// Caminho do JSON de estado durável (contador + timestamps). Default: <c>retraining-state.json</c>
+        /// na árvore de <c>XslSynth:TrainingDataPath</c>.
+        /// </summary>
+        public string? StateFilePath { get; set; }
+
+        /// <summary>
+        /// Caminho do arquivo-marcador que o cron da VM observa pra disparar <c>train_lora.py</c>.
+        /// Default: <c>retraining.trigger.json</c> na árvore de <c>XslSynth:TrainingDataPath</c>.
+        /// O script da VM deve APAGAR este arquivo ao terminar o treino (é assim que a API detecta
+        /// a conclusão — ver <see cref="RetrainingCoordinator"/>).
+        /// </summary>
+        public string? TriggerFilePath { get; set; }
+
+        /// <summary>
+        /// Caminho do lock de exclusão mútua Ollama-inferência × treino (ADR §6.2). Default:
+        /// <c>retraining.lock</c> na árvore de <c>XslSynth:TrainingDataPath</c>. Enquanto este
+        /// arquivo existir, o <see cref="RepairOrchestratorXslSynthesizerService"/> recusa a
+        /// síntese via Ollama (graciosamente, sem exceção) e o coordenador não dispara treino novo.
+        /// </summary>
+        public string? LockFilePath { get; set; }
+
+        /// <summary>
+        /// Idade (em horas) a partir da qual o <c>retraining.lock</c> é considerado órfão e apenas
+        /// logado como warning (não é removido automaticamente — remoção é decisão operacional).
+        /// Default 60h (~40h de treino + margem). Valor &lt;= 0 desliga a checagem de idade.
+        /// </summary>
+        public int StaleLockAfterHours { get; set; } = 60;
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingSchedulerBackgroundService.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingSchedulerBackgroundService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Avaliação periódica do gatilho de retraining (F4.2, issue #351). Timer previsível e
+    /// independente de tráfego — mesmo padrão de <see cref="AiCandidateStoreCleanupBackgroundService"/>.
+    /// O trabalho pesado (disparar/detectar) é todo do <see cref="IRetrainingCoordinator"/>; aqui
+    /// só há o laço e o intervalo.
+    ///
+    /// <para>O incremento do contador NÃO passa por aqui — vem do hook de F3
+    /// (<see cref="TrainingDataCaptureService"/>) a cada convergência real. Este serviço só decide
+    /// "já é hora de treinar?" e detecta a conclusão de um treino anterior.</para>
+    /// </summary>
+    public class RetrainingSchedulerBackgroundService : BackgroundService
+    {
+        private readonly ILogger<RetrainingSchedulerBackgroundService> _logger;
+        private readonly IRetrainingCoordinator _coordinator;
+        private readonly TimeSpan _interval;
+
+        public RetrainingSchedulerBackgroundService(
+            ILogger<RetrainingSchedulerBackgroundService> logger,
+            IRetrainingCoordinator coordinator,
+            IOptions<RetrainingOptions> options)
+        {
+            _logger = logger;
+            _coordinator = coordinator;
+
+            var hours = options.Value.EvaluationIntervalHours;
+            _interval = TimeSpan.FromHours(
+                hours > 0 ? hours : RetrainingOptions.DefaultEvaluationIntervalHours);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            _logger.LogInformation(
+                "Scheduler de retraining ativo (avaliação a cada {IntervaloHoras}h)", _interval.TotalHours);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await _coordinator.EvaluateAndMaybeTriggerAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Falha no ciclo de avaliação do gatilho de retraining");
+                }
+
+                try
+                {
+                    await Task.Delay(_interval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingState.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingState.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Estado durável do gatilho de retraining (F4.2, issue #351). Serializado como JSON no
+    /// caminho de <see cref="RetrainingOptions.StateFilePath"/>. Todos os instantes em UTC.
+    /// </summary>
+    public class RetrainingState
+    {
+        /// <summary>
+        /// Exemplos novos capturados por F3 (<see cref="TrainingDataCaptureService"/>) desde o
+        /// último treino concluído. Incrementado a cada convergência real gravada no JSONL.
+        /// </summary>
+        [JsonPropertyName("examplesSinceLastTraining")]
+        public int ExamplesSinceLastTraining { get; set; }
+
+        /// <summary>Instante em que este estado foi criado pela primeira vez — âncora do teto de
+        /// agenda enquanto nenhum treino tiver concluído.</summary>
+        [JsonPropertyName("createdUtc")]
+        public DateTime CreatedUtc { get; set; }
+
+        /// <summary>Instante do último treino concluído (marcador de disparo removido + lock livre).
+        /// <c>null</c> = nunca treinou por este mecanismo.</summary>
+        [JsonPropertyName("lastTrainingCompletedUtc")]
+        public DateTime? LastTrainingCompletedUtc { get; set; }
+
+        /// <summary>Instante do último disparo escrito (arquivo-marcador criado).</summary>
+        [JsonPropertyName("lastTriggeredUtc")]
+        public DateTime? LastTriggeredUtc { get; set; }
+
+        /// <summary><c>true</c> entre o disparo e a detecção da conclusão — evita disparo duplicado
+        /// enquanto o treino de ~40h roda.</summary>
+        [JsonPropertyName("triggerPending")]
+        public bool TriggerPending { get; set; }
+
+        /// <summary>Valor de <see cref="ExamplesSinceLastTraining"/> no instante do disparo — na
+        /// conclusão, só ESTE tanto é zerado, preservando o que F3 capturou durante o treino.</summary>
+        [JsonPropertyName("examplesCountedAtTrigger")]
+        public int ExamplesCountedAtTrigger { get; set; }
+
+        /// <summary>Motivo do último disparo (volume ou teto de agenda), pra auditoria.</summary>
+        [JsonPropertyName("lastTriggerReason")]
+        public string? LastTriggerReason { get; set; }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingTriggerEvaluator.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingTriggerEvaluator.cs
@@ -1,0 +1,78 @@
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Motivo pelo qual o retraining foi (ou não) disparado.</summary>
+    public enum RetrainingTriggerReason
+    {
+        /// <summary>Nenhuma condição de disparo satisfeita.</summary>
+        None = 0,
+
+        /// <summary>Contador de exemplos novos atingiu <see cref="RetrainingOptions.NewExampleThreshold"/>.</summary>
+        VolumeThreshold = 1,
+
+        /// <summary>Teto de agenda (<see cref="RetrainingOptions.MaxDaysBetweenTrainings"/>) estourado.</summary>
+        ScheduleCeiling = 2,
+
+        /// <summary>Já há um disparo pendente (treino em andamento) — não dispara de novo.</summary>
+        AlreadyPending = 3,
+    }
+
+    /// <summary>Decisão do avaliador de gatilho.</summary>
+    public readonly record struct RetrainingTriggerDecision(bool ShouldTrigger, RetrainingTriggerReason Reason, string Explanation)
+    {
+        public static RetrainingTriggerDecision Skip(RetrainingTriggerReason reason, string explanation)
+            => new(false, reason, explanation);
+
+        public static RetrainingTriggerDecision Fire(RetrainingTriggerReason reason, string explanation)
+            => new(true, reason, explanation);
+    }
+
+    /// <summary>
+    /// Lógica pura do gatilho de retraining (F4.2, issue #351, ADR §6.1). Sem I/O — recebe o
+    /// estado e as opções já resolvidas e devolve a decisão. Testável isoladamente.
+    ///
+    /// <para>Regra: dispara quando <b>(exemplos novos ≥ N)</b> OU <b>(dias desde o último treino ≥
+    /// teto)</b>, o que vier primeiro. O teto de agenda só dispara se houver pelo menos 1 exemplo
+    /// novo — retreinar com dataset idêntico ao anterior não agrega. Nunca dispara se já houver
+    /// um disparo pendente.</para>
+    /// </summary>
+    public static class RetrainingTriggerEvaluator
+    {
+        public static RetrainingTriggerDecision Evaluate(RetrainingState state, RetrainingOptions options, DateTime nowUtc)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+            ArgumentNullException.ThrowIfNull(options);
+
+            if (state.TriggerPending)
+                return RetrainingTriggerDecision.Skip(
+                    RetrainingTriggerReason.AlreadyPending,
+                    "Já há um disparo de retraining pendente (treino em andamento ou marcador não removido).");
+
+            var threshold = options.NewExampleThreshold > 0
+                ? options.NewExampleThreshold
+                : RetrainingOptions.DefaultNewExampleThreshold;
+
+            var maxDays = options.MaxDaysBetweenTrainings > 0
+                ? options.MaxDaysBetweenTrainings
+                : RetrainingOptions.DefaultMaxDaysBetweenTrainings;
+
+            if (state.ExamplesSinceLastTraining >= threshold)
+                return RetrainingTriggerDecision.Fire(
+                    RetrainingTriggerReason.VolumeThreshold,
+                    $"Contador de exemplos novos ({state.ExamplesSinceLastTraining}) atingiu o limite ({threshold}).");
+
+            var anchor = state.LastTrainingCompletedUtc ?? state.CreatedUtc;
+            var elapsed = nowUtc - anchor;
+
+            if (elapsed >= TimeSpan.FromDays(maxDays) && state.ExamplesSinceLastTraining > 0)
+                return RetrainingTriggerDecision.Fire(
+                    RetrainingTriggerReason.ScheduleCeiling,
+                    $"Passaram {elapsed.TotalDays:F1} dias desde o último treino (teto {maxDays}d) " +
+                    $"com {state.ExamplesSinceLastTraining} exemplo(s) novo(s) acumulado(s).");
+
+            return RetrainingTriggerDecision.Skip(
+                RetrainingTriggerReason.None,
+                $"Sem disparo: {state.ExamplesSinceLastTraining}/{threshold} exemplos novos, " +
+                $"{elapsed.TotalDays:F1}/{maxDays} dias desde o último treino.");
+        }
+    }
+}

--- a/Services/Transformation/Ai/Retraining/RetrainingTriggerRequest.cs
+++ b/Services/Transformation/Ai/Retraining/RetrainingTriggerRequest.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace LayoutParserApi.Services.Transformation.Ai.Retraining
+{
+    /// <summary>
+    /// Payload do arquivo-marcador (<see cref="RetrainingOptions.TriggerFilePath"/>) que a API
+    /// escreve quando o gatilho de retraining dispara. O cron/script da VM observa este arquivo,
+    /// roda <c>train_lora.py</c> e o REMOVE ao terminar — é assim que a API detecta a conclusão.
+    /// Só dados de contexto; nenhum segredo.
+    /// </summary>
+    public class RetrainingTriggerRequest
+    {
+        [JsonPropertyName("requestedUtc")]
+        public string RequestedUtc { get; set; } = string.Empty;
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = string.Empty;
+
+        [JsonPropertyName("explanation")]
+        public string Explanation { get; set; } = string.Empty;
+
+        [JsonPropertyName("examplesSinceLastTraining")]
+        public int ExamplesSinceLastTraining { get; set; }
+
+        [JsonPropertyName("threshold")]
+        public int Threshold { get; set; }
+
+        [JsonPropertyName("lastTrainingCompletedUtc")]
+        public string? LastTrainingCompletedUtc { get; set; }
+
+        /// <summary>Nota operacional pro humano/script que ler o marcador.</summary>
+        [JsonPropertyName("note")]
+        public string Note { get; set; } =
+            "Marcador escrito por LayoutParserApi (F4.2). O script da VM deve criar o retraining.lock " +
+            "antes de iniciar train_lora.py, e APAGAR este arquivo (e o lock) ao concluir. " +
+            "Após o treino, rodar MetricsBatchRunner --mode=metrics-batch contra o held-out atual e " +
+            "só promover o modelo novo se as métricas não regredirem (ver ModelMetricsComparer).";
+    }
+}

--- a/Services/Transformation/Ai/TrainingDataCaptureService.cs
+++ b/Services/Transformation/Ai/TrainingDataCaptureService.cs
@@ -2,6 +2,8 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
 namespace LayoutParserApi.Services.Transformation.Ai
 {
     /// <summary>
@@ -43,11 +45,18 @@ namespace LayoutParserApi.Services.Transformation.Ai
         private readonly ILogger<TrainingDataCaptureService> _logger;
         private readonly string _trainingDataPath;
 
+        // F4.2 (issue #351): a cada exemplo efetivamente gravado no JSONL, o contador de retraining
+        // avança. Opcional (nullable) pra não quebrar quem constrói o serviço só com logger+config
+        // (testes de F3) — sem coordenador, a captura funciona igual, só não alimenta o gatilho.
+        private readonly IRetrainingCoordinator? _retrainingCoordinator;
+
         public TrainingDataCaptureService(
             ILogger<TrainingDataCaptureService> logger,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            IRetrainingCoordinator? retrainingCoordinator = null)
         {
             _logger = logger;
+            _retrainingCoordinator = retrainingCoordinator;
             // Sem convenção de prod existente pra esta pasta (diferente de XSD/XSL — ver
             // XsdValidation:BasePath / TransformationPipeline:XslPath); fica configurável e cai,
             // por padrão, na mesma árvore do dataset batch já versionado no repo.
@@ -92,6 +101,10 @@ namespace LayoutParserApi.Services.Transformation.Ai
                 _logger.LogInformation(
                     "Exemplo de convergência capturado pro dataset de treino incremental em {Path} (mapperGuid={MapperGuid})",
                     Services.Logging.LogMessageSanitizer.Sanitize(path), safeMapperGuid);
+
+                // F4.2 (issue #351): só conta depois que a linha foi de fato escrita — se a
+                // gravação acima falhar, o contador não avança (cai no catch abaixo).
+                _retrainingCoordinator?.RegisterCapturedExample();
             }
             catch (Exception ex)
             {

--- a/appsettings.json
+++ b/appsettings.json
@@ -40,6 +40,16 @@
     "TicketTtlHours": 72,
     "CleanupIntervalMinutes": 60
   },
+  "XslSynth": {
+    "Retraining": {
+      "_comment": "F4 (issue #351) — retraining automatizado do modelo fine-tuned. Enabled=false por padrao: o disparo real de train_lora.py e o retraining.lock fisico dependem de fiacao no cron/script da VM 172.25.32.5 (handoff @lp-devops). Com Enabled=false a API so mantem o contador de exemplos novos (F3) e checa o lock se o arquivo aparecer. TriggerFilePath/LockFilePath/StateFilePath caem, por padrao, na arvore de XslSynth:TrainingDataPath.",
+      "Enabled": false,
+      "NewExampleThreshold": 300,
+      "MaxDaysBetweenTrainings": 90,
+      "EvaluationIntervalHours": 6,
+      "StaleLockAfterHours": 60
+    }
+  },
   "RAG": {
     "ExamplesPath": "Exemplos",
     "RulesPath": "Data/Rules"

--- a/docs/architecture/handoff-f4-retraining-automatizado-lado-vm-351.md
+++ b/docs/architecture/handoff-f4-retraining-automatizado-lado-vm-351.md
@@ -1,0 +1,60 @@
+# Handoff — F4 retraining automatizado: o que falta no lado da VM (issue #351)
+
+Destino: `@lp-devops`. Origem: `@lp-parser-llm`. Refere-se ao ADR
+`docs/architecture/adr-backfill-catalogo-e-retraining-automatizado-2026-09-08.md`.
+
+## O que já está pronto em C# (branch `feat/retraining-automatizado-f4-351`)
+
+| Sub-fase | Implementado | Onde |
+|---|---|---|
+| **F4.1** | Telemetria de `DuracaoSegundos`/`Iteracoes`/`Convergiu`/`XsdValido` do `RepairOrchestrator` em runtime, linha `Source=AiMetrics` (`RepairOrchestrator runtime concluido. ...`). Emitida sempre que `RunAsync` retorna, convergindo ou não. | `Services/Transformation/Ai/RepairOrchestratorXslSynthesizerService.cs` (`LogRuntimeMetrics`) |
+| **F4.2** | Contador de exemplos novos alimentado pelo hook de F3; estado durável em JSON; avaliador de gatilho (volume ≥ N **OU** ≥ 90 dias); background service que avalia a cada 6h; escrita do arquivo-marcador `retraining.trigger.json`; detecção de conclusão. | `Services/Transformation/Ai/Retraining/*` |
+| **F4.3** | Checagem de `retraining.lock` **antes de acionar o Ollama** em runtime (recusa graciosa, sem exceção); coordenador não dispara treino com lock ativo; comparador de métricas pós-treino (regressão → não promove). | `FileRetrainingLock.cs`, `RepairOrchestratorXslSynthesizerService.cs`, `ModelMetricsComparer.cs` |
+
+Config: seção `XslSynth:Retraining` no `appsettings.json`, **`Enabled: false`**. Com `false`, a
+API só mantém o contador e lê o lock — nunca escreve o marcador de disparo.
+
+Caminhos default (todos relativos a `XslSynth:TrainingDataPath`, na VM `172.25.32.5`):
+- `retraining-state.json` — contador + timestamps (a API é dona)
+- `retraining.trigger.json` — marcador de disparo (a API escreve, **a VM apaga**)
+- `retraining.lock` — exclusão mútua (**a VM cria e apaga**, a API só lê)
+
+## O que falta no lado da VM (`@lp-devops`)
+
+1. **Cron/serviço na VM `172.25.32.5`** que, em intervalo curto (ex. a cada 15 min):
+   - checa se `retraining.trigger.json` existe **e** `retraining.lock` **não** existe;
+   - se sim: cria `retraining.lock` (com PID + timestamp), roda
+     `python3 ~/ft_venv/.../train_lora.py` (o script de treino já resumível, ver
+     `feat/finetuning-resume-apos-reboot`), com o dataset = JSONL batch atual +
+     `runtime-capture-*.jsonl` acumulados;
+   - ao terminar o treino: roda a **validação pós-treino** (passo 2 abaixo);
+   - **só então** apaga `retraining.trigger.json` e `retraining.lock` (nessa ordem).
+   - A API detecta a conclusão sozinha no próximo tick (marcador sumiu + lock livre) e zera
+     o contador, preservando o que F3 capturou durante as ~40h.
+
+2. **Validação pós-treino antes de promover** (ADR §6.3):
+   - rodar `ai/XslSynth --mode=metrics-batch` com o modelo novo contra o held-out set atual;
+   - montar dois `ModelMetricsSnapshot` (atual em produção × candidato) — taxas de convergência,
+     XSD válido e diff==0;
+   - a regra de decisão já está em `ModelMetricsComparer.Decide(...)` (C#). No lado da VM, ou se
+     replica a regra em shell (candidato regride em qualquer das 3 taxas além da tolerância →
+     não promove), ou expõe-se um pequeno endpoint/CLI que chama o comparador. Recomendo replicar
+     em shell — é uma comparação de 3 números, não vale uma round-trip HTTP.
+   - **promover** = trocar a tag/symlink do Ollama (`layoutparser-sysmiddle-dsl:1.5b`) para o
+     GGUF novo (merge + convert + `Q4_K_M` + `ollama create`). Se regrediu: manter o modelo
+     atual, arquivar o candidato, logar.
+
+3. **Alerta de lock órfão**: a API já loga warning se `retraining.lock` passa de
+   `StaleLockAfterHours` (default 60h) — encaminhar esse warning pro canal de alerta de deploy
+   (e-mail, `deploy.yml`) ou um cron simples que cheque a idade do arquivo. A API **não** remove
+   o lock sozinha de propósito (decisão operacional).
+
+4. **`Enabled: true`** no ambiente de produção (`XslSynth__Retraining__Enabled=true`) só depois
+   que o item 1 estiver no ar — antes disso o marcador nunca é escrito e o resto é inócuo.
+
+## Fora de escopo (ADR §5, §8)
+
+Backfill em lote sobre o catálogo (sem corpus real) e piloto de 1 layout — não entram aqui.
+Enumeração de mappers, se algum dia necessária, usa o método filtrado por
+`ProjectId`/`AllowedPackageGuids` de `MapperDatabaseService` (~linha 284), nunca
+`GetAllMappersAsync`.

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/FileRetrainingLockTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/FileRetrainingLockTests.cs
@@ -1,0 +1,65 @@
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Lock de exclusão mútua Ollama × treino (F4.3, issue #351).</summary>
+    public class FileRetrainingLockTests
+    {
+        private static (FileRetrainingLock lockSvc, string dir) Criar(int staleAfterHours = 60)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "lp-retraining-lock-" + Guid.NewGuid().ToString("N"));
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["XslSynth:TrainingDataPath"] = dir })
+                .Build();
+            var lockSvc = new FileRetrainingLock(
+                NullLogger<FileRetrainingLock>.Instance,
+                Options.Create(new RetrainingOptions { StaleLockAfterHours = staleAfterHours }),
+                config);
+            return (lockSvc, dir);
+        }
+
+        [Fact]
+        public void Nao_travado_quando_o_arquivo_nao_existe()
+        {
+            var (lockSvc, dir) = Criar();
+            try
+            {
+                Assert.False(lockSvc.IsHeld());
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void Travado_quando_o_arquivo_existe()
+        {
+            var (lockSvc, dir) = Criar();
+            try
+            {
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(lockSvc.LockFilePath, "pid 1234");
+
+                Assert.True(lockSvc.IsHeld());
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void Lock_antigo_continua_travado_e_nao_lanca()
+        {
+            var (lockSvc, dir) = Criar(staleAfterHours: 1);
+            try
+            {
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(lockSvc.LockFilePath, "pid 1234");
+                File.SetLastWriteTimeUtc(lockSvc.LockFilePath, DateTime.UtcNow.AddHours(-5));
+
+                Assert.True(lockSvc.IsHeld());
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/FileRetrainingStateStoreTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/FileRetrainingStateStoreTests.cs
@@ -1,0 +1,70 @@
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Persistência durável do estado de retraining em arquivo (F4.2, issue #351).</summary>
+    public class FileRetrainingStateStoreTests
+    {
+        private static (FileRetrainingStateStore store, string dir) Criar()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "lp-retraining-" + Guid.NewGuid().ToString("N"));
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["XslSynth:TrainingDataPath"] = dir })
+                .Build();
+            var store = new FileRetrainingStateStore(
+                NullLogger<FileRetrainingStateStore>.Instance,
+                Options.Create(new RetrainingOptions()),
+                config);
+            return (store, dir);
+        }
+
+        [Fact]
+        public void Load_sem_arquivo_cria_estado_novo_com_createdUtc()
+        {
+            var (store, dir) = Criar();
+            try
+            {
+                var state = store.Load();
+
+                Assert.NotEqual(default, state.CreatedUtc);
+                Assert.Equal(0, state.ExamplesSinceLastTraining);
+                Assert.True(File.Exists(Path.Combine(dir, "retraining-state.json")));
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void Update_persiste_a_mutacao_e_sobrevive_a_um_reload()
+        {
+            var (store, dir) = Criar();
+            try
+            {
+                store.Update(s => s.ExamplesSinceLastTraining += 7);
+                store.Update(s => s.ExamplesSinceLastTraining += 3);
+
+                var reloaded = store.Load();
+                Assert.Equal(10, reloaded.ExamplesSinceLastTraining);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void Arquivo_corrompido_volta_para_estado_novo_sem_lancar()
+        {
+            var (store, dir) = Criar();
+            try
+            {
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(Path.Combine(dir, "retraining-state.json"), "{ nao é json válido");
+
+                var state = store.Load();
+                Assert.Equal(0, state.ExamplesSinceLastTraining);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/ModelMetricsComparerTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/ModelMetricsComparerTests.cs
@@ -1,0 +1,52 @@
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Validação pós-treino antes de promover o modelo (F4.3, issue #351, ADR §6.3).</summary>
+    public class ModelMetricsComparerTests
+    {
+        private static ModelMetricsSnapshot Snap(double conv, double xsd, double diff, int n = 54, string model = "m")
+            => new(model, n, conv, xsd, diff);
+
+        [Fact]
+        public void Promove_quando_nenhuma_metrica_regride()
+        {
+            var atual = Snap(0.40, 0.60, 0.30);
+            var novo = Snap(0.45, 0.60, 0.35);
+
+            var decision = ModelMetricsComparer.Decide(atual, novo);
+
+            Assert.True(decision.Promote);
+        }
+
+        [Fact]
+        public void Bloqueia_quando_convergencia_regride()
+        {
+            var atual = Snap(0.40, 0.60, 0.30);
+            var novo = Snap(0.35, 0.60, 0.30);
+
+            var decision = ModelMetricsComparer.Decide(atual, novo);
+
+            Assert.False(decision.Promote);
+            Assert.Contains(decision.Reasons, r => r.Contains("REGRESSÃO") && r.Contains("convergência"));
+        }
+
+        [Fact]
+        public void Bloqueia_quando_candidato_nao_tem_amostras()
+        {
+            var decision = ModelMetricsComparer.Decide(Snap(0.4, 0.6, 0.3), Snap(0.9, 0.9, 0.9, n: 0));
+
+            Assert.False(decision.Promote);
+        }
+
+        [Fact]
+        public void Tolerancia_absorve_queda_pequena()
+        {
+            var atual = Snap(0.40, 0.60, 0.30);
+            var novo = Snap(0.395, 0.60, 0.30);
+
+            Assert.False(ModelMetricsComparer.Decide(atual, novo, tolerance: 0.0).Promote);
+            Assert.True(ModelMetricsComparer.Decide(atual, novo, tolerance: 0.01).Promote);
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/RetrainingCoordinatorTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/RetrainingCoordinatorTests.cs
@@ -1,0 +1,130 @@
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Orquestração do gatilho de retraining (F4.2/F4.3, issue #351).</summary>
+    public class RetrainingCoordinatorTests
+    {
+        private sealed class InMemoryStateStore : IRetrainingStateStore
+        {
+            public RetrainingState State = new() { CreatedUtc = DateTime.UtcNow.AddDays(-1) };
+            public RetrainingState Load() => State;
+            public void Save(RetrainingState state) => State = state;
+            public RetrainingState Update(Action<RetrainingState> mutate) { mutate(State); return State; }
+        }
+
+        private sealed class FakeLock : IRetrainingLock
+        {
+            public bool Held;
+            public bool IsHeld() => Held;
+            public string LockFilePath => "fake.lock";
+        }
+
+        private static (RetrainingCoordinator coord, InMemoryStateStore store, FakeLock lockSvc, string dir, string triggerPath)
+            Criar(bool enabled, int threshold = 300)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "lp-coord-" + Guid.NewGuid().ToString("N"));
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["XslSynth:TrainingDataPath"] = dir })
+                .Build();
+            var store = new InMemoryStateStore();
+            var lockSvc = new FakeLock();
+            var options = Options.Create(new RetrainingOptions { Enabled = enabled, NewExampleThreshold = threshold });
+            var coord = new RetrainingCoordinator(
+                NullLogger<RetrainingCoordinator>.Instance, store, lockSvc, options, config);
+            return (coord, store, lockSvc, dir, Path.Combine(dir, "retraining.trigger.json"));
+        }
+
+        [Fact]
+        public void RegisterCapturedExample_incrementa_o_contador()
+        {
+            var (coord, store, _, dir, _) = Criar(enabled: true);
+            try
+            {
+                coord.RegisterCapturedExample();
+                coord.RegisterCapturedExample();
+
+                Assert.Equal(2, store.State.ExamplesSinceLastTraining);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public async Task Dispara_e_escreve_o_marcador_quando_habilitado_e_volume_atingido()
+        {
+            var (coord, store, _, dir, triggerPath) = Criar(enabled: true, threshold: 5);
+            try
+            {
+                store.State.ExamplesSinceLastTraining = 5;
+
+                await coord.EvaluateAndMaybeTriggerAsync(CancellationToken.None);
+
+                Assert.True(File.Exists(triggerPath));
+                Assert.True(store.State.TriggerPending);
+                Assert.Equal(5, store.State.ExamplesCountedAtTrigger);
+                Assert.Equal("VolumeThreshold", store.State.LastTriggerReason);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public async Task Nao_escreve_marcador_quando_desabilitado()
+        {
+            var (coord, store, _, dir, triggerPath) = Criar(enabled: false, threshold: 5);
+            try
+            {
+                store.State.ExamplesSinceLastTraining = 50;
+
+                await coord.EvaluateAndMaybeTriggerAsync(CancellationToken.None);
+
+                Assert.False(File.Exists(triggerPath));
+                Assert.False(store.State.TriggerPending);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public async Task Nao_dispara_enquanto_o_lock_esta_ativo()
+        {
+            var (coord, store, lockSvc, dir, triggerPath) = Criar(enabled: true, threshold: 5);
+            try
+            {
+                store.State.ExamplesSinceLastTraining = 999;
+                lockSvc.Held = true;
+
+                await coord.EvaluateAndMaybeTriggerAsync(CancellationToken.None);
+
+                Assert.False(File.Exists(triggerPath));
+                Assert.False(store.State.TriggerPending);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public async Task Detecta_conclusao_e_preserva_exemplos_capturados_durante_o_treino()
+        {
+            var (coord, store, lockSvc, dir, _) = Criar(enabled: true, threshold: 5);
+            try
+            {
+                // Estado pós-disparo: 5 contados no disparo + 4 capturados durante o treino de ~40h.
+                store.State.TriggerPending = true;
+                store.State.ExamplesCountedAtTrigger = 5;
+                store.State.ExamplesSinceLastTraining = 9;
+                lockSvc.Held = false; // treino terminou, lock liberado
+                // marcador não existe (script da VM removeu)
+
+                await coord.EvaluateAndMaybeTriggerAsync(CancellationToken.None);
+
+                Assert.False(store.State.TriggerPending);
+                Assert.Equal(4, store.State.ExamplesSinceLastTraining);
+                Assert.Equal(0, store.State.ExamplesCountedAtTrigger);
+                Assert.NotNull(store.State.LastTrainingCompletedUtc);
+            }
+            finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+        }
+    }
+}

--- a/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/RetrainingTriggerEvaluatorTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Transformation/Ai/Retraining/RetrainingTriggerEvaluatorTests.cs
@@ -1,0 +1,107 @@
+using LayoutParserApi.Services.Transformation.Ai.Retraining;
+
+namespace LayoutParserApi.Tests.Services.Transformation.Ai.Retraining
+{
+    /// <summary>Lógica pura do gatilho de retraining (F4.2, issue #351).</summary>
+    public class RetrainingTriggerEvaluatorTests
+    {
+        private static readonly DateTime Now = new(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
+
+        private static RetrainingOptions Options(int threshold = 300, int maxDays = 90) => new()
+        {
+            NewExampleThreshold = threshold,
+            MaxDaysBetweenTrainings = maxDays,
+        };
+
+        [Fact]
+        public void Dispara_por_volume_quando_contador_atinge_o_limite()
+        {
+            var state = new RetrainingState { CreatedUtc = Now.AddDays(-1), ExamplesSinceLastTraining = 300 };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.True(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.VolumeThreshold, decision.Reason);
+        }
+
+        [Fact]
+        public void Nao_dispara_quando_abaixo_do_limite_e_dentro_do_prazo()
+        {
+            var state = new RetrainingState { CreatedUtc = Now.AddDays(-10), ExamplesSinceLastTraining = 299 };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.False(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.None, decision.Reason);
+        }
+
+        [Fact]
+        public void Dispara_pelo_teto_de_agenda_quando_ha_exemplos_novos()
+        {
+            var state = new RetrainingState
+            {
+                CreatedUtc = Now.AddDays(-200),
+                LastTrainingCompletedUtc = Now.AddDays(-91),
+                ExamplesSinceLastTraining = 5,
+            };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.True(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.ScheduleCeiling, decision.Reason);
+        }
+
+        [Fact]
+        public void Teto_de_agenda_nao_dispara_sem_exemplos_novos()
+        {
+            var state = new RetrainingState
+            {
+                CreatedUtc = Now.AddDays(-200),
+                LastTrainingCompletedUtc = Now.AddDays(-120),
+                ExamplesSinceLastTraining = 0,
+            };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.False(decision.ShouldTrigger);
+        }
+
+        [Fact]
+        public void Usa_createdUtc_como_ancora_do_teto_quando_nunca_treinou()
+        {
+            var state = new RetrainingState { CreatedUtc = Now.AddDays(-95), ExamplesSinceLastTraining = 1 };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.True(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.ScheduleCeiling, decision.Reason);
+        }
+
+        [Fact]
+        public void Nao_dispara_quando_ja_ha_disparo_pendente()
+        {
+            var state = new RetrainingState
+            {
+                CreatedUtc = Now.AddDays(-200),
+                ExamplesSinceLastTraining = 100_000,
+                TriggerPending = true,
+            };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(), Now);
+
+            Assert.False(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.AlreadyPending, decision.Reason);
+        }
+
+        [Fact]
+        public void Opcoes_nao_positivas_caem_nos_defaults()
+        {
+            var state = new RetrainingState { CreatedUtc = Now.AddDays(-1), ExamplesSinceLastTraining = RetrainingOptions.DefaultNewExampleThreshold };
+
+            var decision = RetrainingTriggerEvaluator.Evaluate(state, Options(threshold: 0, maxDays: -5), Now);
+
+            Assert.True(decision.ShouldTrigger);
+            Assert.Equal(RetrainingTriggerReason.VolumeThreshold, decision.Reason);
+        }
+    }
+}


### PR DESCRIPTION
## Resumo

Fecha o loop de captura incremental do F3 (#338): quando exemplos suficientes forem capturados (ou o teto de agenda estourar), dispara retreino do modelo fine-tuned automaticamente, com exclusão mútua contra a inferência Ollama e validação pós-treino antes de promover.

Base: `develop` (f56d3fb). **Desabilitado por padrão** (`XslSynth:Retraining:Enabled=false`).

## F4.1 — Telemetria de duração em produção

`RepairOrchestratorXslSynthesizerService` agora mede (`Stopwatch`) e loga estruturado `DuracaoSegundos`/`Iteracoes`/`Convergiu`/`XsdValido` no canal `Source=AiMetrics` (mesmo do CLI/ingest), sempre — convergindo ou não. Antes só o CLI offline media isso.

## F4.2 — Gatilho por volume + teto de agenda

Novo `Services/Transformation/Ai/Retraining/`:
- `RetrainingOptions` (seção `XslSynth:Retraining`): `Enabled=false`, `NewExampleThreshold=300`, `MaxDaysBetweenTrainings=90`, `EvaluationIntervalHours=6`.
- `FileRetrainingStateStore` (`IRetrainingStateStore`) — JSON durável, escrita atômica, na árvore de `XslSynth:TrainingDataPath` (padrão do F3, **não** toca `172.31.249.51`).
- `RetrainingTriggerEvaluator` (lógica pura) — dispara se `exemplos ≥ N` **OU** `dias desde último treino ≥ teto` (com ≥1 exemplo); nunca com disparo já pendente.
- `RetrainingCoordinator` (Singleton) — `RegisterCapturedExample()` incrementa contador; `EvaluateAndMaybeTriggerAsync()` detecta conclusão do treino anterior (preserva exemplos capturados durante as ~40h) e escreve `retraining.trigger.json` quando o gatilho satisfaz e `Enabled=true`.
- `RetrainingSchedulerBackgroundService` (`AddHostedService`) — laço a cada 6h.
- Hook F3: `TrainingDataCaptureService` chama `RegisterCapturedExample()` após o append no JSONL dar certo.

## F4.3 — Exclusão mútua + validação pós-treino

- `FileRetrainingLock` (`IRetrainingLock`) — lê `retraining.lock` na VM `172.25.32.5`; warning se `StaleLockAfterHours` estourar (não remove — decisão operacional).
- `RepairOrchestratorXslSynthesizerService` checa `_retrainingLock?.IsHeld()` **antes de instanciar o Ollama synthesizer**; travado → `Failed(...)` gracioso, sem chamar Ollama.
- `ModelMetricsComparer.Decide(current, candidate, tolerance)` (puro) — regressão em qualquer das 3 taxas (convergência / XSD válido / diff==0) além da tolerância → não promove.

DI em `Program.cs`, grupo AI (Singletons + hosted service).

## Testes

`dotnet build` verde. `dotnet test`: **756 verdes**, 22 novos em `tests/.../Ai/Retraining/` (evaluator, state store, lock, coordinator, metrics comparer).

## Handoff `@lp-devops` (lado VM)

`docs/architecture/handoff-f4-retraining-automatizado-lado-vm-351.md` — falta: cron que observa `retraining.trigger.json` / gerencia `retraining.lock` / roda `train_lora.py`; validação pós-treino via `--mode=metrics-batch` + regra do comparer; alerta de lock órfão; e só então `XslSynth__Retraining__Enabled=true` em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)