### PR TITLE
Promove develop -> master: curadoria de correção humana (issue #346)

### DIFF
--- a/Controllers/TransformationExecutionController.cs
+++ b/Controllers/TransformationExecutionController.cs
@@ -59,6 +59,7 @@ namespace LayoutParserApi.Controllers
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly Services.Security.ICanaryAlertService _canaryAlert;
         private readonly IFieldCorrectionStore _fieldCorrectionStore;
+        private readonly TrainingDataCaptureService _trainingDataCapture;
 
         public TransformationExecutionController(
             ILogger<TransformationExecutionController> logger,
@@ -80,7 +81,8 @@ namespace LayoutParserApi.Controllers
             FieldMappingCompositionService fieldMappingComposition,
             IServiceScopeFactory scopeFactory,
             Services.Security.ICanaryAlertService canaryAlert,
-            IFieldCorrectionStore fieldCorrectionStore)
+            IFieldCorrectionStore fieldCorrectionStore,
+            TrainingDataCaptureService trainingDataCapture)
         {
             _logger = logger;
             _pipelineService = pipelineService;
@@ -102,6 +104,7 @@ namespace LayoutParserApi.Controllers
             _scopeFactory = scopeFactory;
             _canaryAlert = canaryAlert;
             _fieldCorrectionStore = fieldCorrectionStore;
+            _trainingDataCapture = trainingDataCapture;
         }
 
         // Issue #92: chave de particionamento da AiCandidateStore. ICurrentUser.Name é null quando
@@ -546,6 +549,140 @@ namespace LayoutParserApi.Controllers
                 status = "queued",
                 message = "Correção registrada. Será usada para refinar o modelo em treinos futuros."
             });
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // Curadoria de correção humana (issue #346, ADR §6/§8)
+        //
+        // NOTA DE AUTORIZAÇÃO: não existe hoje um papel dedicado de revisor fiscal no projeto —
+        // os papéis em uso são "admin" (DataGenerationController, LogsController) e "operador"
+        // (MapperDatabaseController). Curar o que vira dado de treino do modelo é uma operação
+        // privilegiada, então cai em "admin". TODO(#346): trocar por um papel "fiscal"/"revisor"
+        // quando o produto definir a matriz de papéis (ver docs/architecture/rollout-p2-autenticacao.md).
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Fila de curadoria: reportes de correção humana ainda <c>pending</c> (issue #346), mais
+        /// antigos primeiro. Somente <c>admin</c>.
+        /// </summary>
+        /// <param name="limit">Teto de itens retornados (default 100, máx. 500).</param>
+        /// <response code="200"><c>{ success, count, reports[] }</c>.</response>
+        /// <response code="404">Sem identidade resolvida (fail-closed).</response>
+        /// <response code="500">Falha de infraestrutura ao consultar o <c>IdentityDatabase</c>.</response>
+        [Authorize(Roles = "admin")]
+        [HttpGet("field-correction/pending")]
+        public async Task<IActionResult> ListPendingFieldCorrections([FromQuery] int limit = 100, CancellationToken cancellationToken = default)
+        {
+            if (_currentUser.UserId is not Guid)
+                return NotFound(); // fail-closed, mesmo padrão de ReportFieldCorrection.
+
+            if (limit <= 0) limit = 100;
+            if (limit > 500) limit = 500;
+
+            try
+            {
+                var pending = await _fieldCorrectionStore.ListPendingReportsAsync(limit, cancellationToken);
+                return Ok(new { success = true, count = pending.Count, reports = pending });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao listar reportes de correção pendentes");
+                return StatusCode(500, new { success = false, error = "Falha de infraestrutura ao listar pendências de curadoria" });
+            }
+        }
+
+        /// <summary>
+        /// Transição de curadoria de um reporte: <c>pending → reviewed_accepted | reviewed_rejected</c>
+        /// (issue #346). Grava <c>ReviewedByUserId</c> (via <see cref="ICurrentUser"/>) e
+        /// <c>ReviewedAtUtc</c>. Idempotente: um segundo review do mesmo reporte devolve <c>409</c>.
+        /// Só <c>reviewed_accepted</c> gera uma linha no dataset de treino incremental
+        /// (<c>source = "human-correction-reviewed"</c>); <c>reviewed_rejected</c> apenas encerra o
+        /// ciclo de vida. O <c>GroundTruthXml</c> do contexto NUNCA é tocado — a revisão só decide
+        /// o que vira treino. Somente <c>admin</c>.
+        /// </summary>
+        /// <response code="200"><c>{ reportId, status }</c> — transição efetuada.</response>
+        /// <response code="400"><c>decision</c> ausente ou diferente de <c>accepted</c>/<c>rejected</c>.</response>
+        /// <response code="404">Sem identidade resolvida (fail-closed).</response>
+        /// <response code="409">Reporte inexistente ou já revisado (só <c>pending</c> transiciona).</response>
+        /// <response code="500">Falha de infraestrutura ao gravar a transição.</response>
+        [Authorize(Roles = "admin")]
+        [HttpPost("field-correction/{reportId:guid}/review")]
+        public async Task<IActionResult> ReviewFieldCorrection(Guid reportId, [FromBody] FieldCorrectionReviewRequest request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid reviewerId)
+                return NotFound(); // fail-closed.
+
+            var decision = request?.Decision?.Trim().ToLowerInvariant();
+            var newStatus = decision switch
+            {
+                "accepted" => FieldCorrectionReportStatus.ReviewedAccepted,
+                "rejected" => FieldCorrectionReportStatus.ReviewedRejected,
+                _ => null
+            };
+            if (newStatus is null)
+                return BadRequest(new { success = false, error = "decision é obrigatório e deve ser 'accepted' ou 'rejected'" });
+
+            bool transitioned;
+            try
+            {
+                transitioned = await _fieldCorrectionStore.TransitionStatusAsync(reportId, newStatus, reviewerId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Falha ao transicionar reporte de correção reportId={ReportId}", reportId);
+                return StatusCode(500, new { success = false, error = "Falha de infraestrutura ao registrar a revisão" });
+            }
+
+            if (!transitioned)
+                return Conflict(new { success = false, error = "reporte inexistente ou já revisado — apenas reportes 'pending' podem ser curados" });
+
+            _logger.LogInformation(
+                "Curadoria de correção humana: reportId={ReportId} status={Status} revisor={ReviewerId}",
+                reportId, newStatus, reviewerId);
+
+            // Só o aceite alimenta o dataset incremental. Best-effort: a transição já está gravada,
+            // uma falha aqui (contexto expirado, disco cheio) vira warning, nunca reverte a revisão
+            // nem derruba a resposta.
+            if (newStatus == FieldCorrectionReportStatus.ReviewedAccepted)
+                await TryCaptureAcceptedCorrectionAsync(reportId, cancellationToken);
+
+            return Ok(new { reportId, status = newStatus });
+        }
+
+        /// <summary>
+        /// Monta o exemplo de treino incremental de um reporte recém-aceito: contexto original
+        /// (<c>InputXml</c>/<c>GroundTruthXml</c>) + <c>ExpectedValue</c> do reporte como saída
+        /// esperada. Delega a escrita ao <see cref="TrainingDataCaptureService"/> (mesmo arquivo
+        /// diário e formato do runtime capture). Best-effort — nunca lança.
+        /// </summary>
+        private async Task TryCaptureAcceptedCorrectionAsync(Guid reportId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var report = await _fieldCorrectionStore.GetReportAsync(reportId, cancellationToken);
+                if (report is null)
+                {
+                    _logger.LogWarning("Reporte aceito não encontrado ao montar o exemplo de treino (reportId={ReportId})", reportId);
+                    return;
+                }
+
+                var context = await _fieldCorrectionStore.GetContextAsync(report.DocumentId, cancellationToken);
+                if (context is null)
+                {
+                    _logger.LogWarning(
+                        "Contexto do documento ausente/expirado ao montar o exemplo de treino do reporte aceito (reportId={ReportId} documentId={DocumentId})",
+                        reportId, report.DocumentId);
+                    return;
+                }
+
+                _trainingDataCapture.TryCaptureHumanCorrection(context, report);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Falha ao capturar o exemplo de treino do reporte aceito — best-effort, a revisão permanece gravada (reportId={ReportId})",
+                    reportId);
+            }
         }
 
         /// <summary>
@@ -1616,5 +1753,14 @@ namespace LayoutParserApi.Controllers
         public string ExpectedValue { get; set; } = "";
         public string? Justification { get; set; }
         public string? DocumentType { get; set; }
+    }
+
+    /// <summary>
+    /// Body de <c>POST field-correction/{reportId}/review</c> (issue #346). <c>decision</c>
+    /// obrigatório: <c>"accepted"</c> ou <c>"rejected"</c> (case-insensitive).
+    /// </summary>
+    public class FieldCorrectionReviewRequest
+    {
+        public string? Decision { get; set; }
     }
 }

--- a/Models/Fiscal/FieldCorrection.cs
+++ b/Models/Fiscal/FieldCorrection.cs
@@ -32,8 +32,28 @@ namespace LayoutParserApi.Models.Fiscal
         string? Justification);
 
     /// <summary>
+    /// Projeção de leitura de uma linha de <c>tbFieldCorrectionReport</c> — usada pela fila de
+    /// curadoria (<c>GET field-correction/pending</c>) e ao montar o exemplo de treino incremental
+    /// quando o reporte é aceito (issue #346).
+    /// </summary>
+    public sealed record FieldCorrectionReportSummary(
+        Guid ReportId,
+        string DocumentId,
+        string CandidateId,
+        string FieldPath,
+        string? ObservedValue,
+        string? ExpectedValue,
+        string? Justification,
+        Guid ReportedByUserId,
+        string Status,
+        DateTimeOffset CreatedAtUtc,
+        Guid? ReviewedByUserId,
+        DateTimeOffset? ReviewedAtUtc);
+
+    /// <summary>
     /// Status do ciclo de vida de um reporte (ADR §6): nunca vira dado de treino direto —
-    /// exige curadoria humana (issue 2, fora do escopo desta issue #345).
+    /// exige curadoria humana (issue #346). <c>Pending → ReviewedAccepted | ReviewedRejected</c>,
+    /// transição única e irreversível; só <c>ReviewedAccepted</c> gera linha no dataset incremental.
     /// </summary>
     public static class FieldCorrectionReportStatus
     {

--- a/Services/Database/SqlFieldCorrectionStore.cs
+++ b/Services/Database/SqlFieldCorrectionStore.cs
@@ -107,6 +107,93 @@ namespace LayoutParserApi.Services.Database
             return reportId;
         }
 
+        public async Task<IReadOnlyList<FieldCorrectionReportSummary>> ListPendingReportsAsync(int limit, CancellationToken cancellationToken)
+        {
+            if (limit <= 0)
+                limit = 100;
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var command = new SqlCommand(
+                @"SELECT TOP (@Limit)
+                      ReportId, DocumentId, CandidateId, FieldPath, ObservedValue, ExpectedValue,
+                      Justification, ReportedByUserId, Status, CreatedAtUtc, ReviewedByUserId, ReviewedAtUtc
+                  FROM dbo.tbFieldCorrectionReport
+                  WHERE Status = @Pending
+                  ORDER BY CreatedAtUtc ASC;",
+                connection);
+            command.Parameters.AddWithValue("@Limit", limit);
+            command.Parameters.AddWithValue("@Pending", FieldCorrectionReportStatus.Pending);
+
+            var result = new List<FieldCorrectionReportSummary>();
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                result.Add(MapReport(reader));
+
+            return result;
+        }
+
+        public async Task<FieldCorrectionReportSummary?> GetReportAsync(Guid reportId, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var command = new SqlCommand(
+                @"SELECT ReportId, DocumentId, CandidateId, FieldPath, ObservedValue, ExpectedValue,
+                         Justification, ReportedByUserId, Status, CreatedAtUtc, ReviewedByUserId, ReviewedAtUtc
+                  FROM dbo.tbFieldCorrectionReport WHERE ReportId = @ReportId;",
+                connection);
+            command.Parameters.AddWithValue("@ReportId", reportId);
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            return await reader.ReadAsync(cancellationToken) ? MapReport(reader) : null;
+        }
+
+        public async Task<bool> TransitionStatusAsync(Guid reportId, string newStatus, Guid reviewedByUserId, CancellationToken cancellationToken)
+        {
+            if (newStatus != FieldCorrectionReportStatus.ReviewedAccepted &&
+                newStatus != FieldCorrectionReportStatus.ReviewedRejected)
+                throw new ArgumentOutOfRangeException(nameof(newStatus), newStatus, "Só reviewed_accepted/reviewed_rejected são transições válidas.");
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            // A cláusula Status = @Pending no WHERE é o que torna a transição idempotente e sem corrida:
+            // um segundo review (ou dois revisores simultâneos) afeta 0 linhas.
+            using var command = new SqlCommand(
+                @"UPDATE dbo.tbFieldCorrectionReport
+                     SET Status = @NewStatus,
+                         ReviewedByUserId = @ReviewedBy,
+                         ReviewedAtUtc = SYSUTCDATETIME()
+                   WHERE ReportId = @ReportId AND Status = @Pending;",
+                connection);
+            command.Parameters.AddWithValue("@NewStatus", newStatus);
+            command.Parameters.AddWithValue("@ReviewedBy", reviewedByUserId);
+            command.Parameters.AddWithValue("@ReportId", reportId);
+            command.Parameters.AddWithValue("@Pending", FieldCorrectionReportStatus.Pending);
+
+            var affected = await command.ExecuteNonQueryAsync(cancellationToken);
+            return affected == 1;
+        }
+
+        private static FieldCorrectionReportSummary MapReport(SqlDataReader reader) => new(
+            reader.GetGuid(reader.GetOrdinal("ReportId")),
+            reader.GetString(reader.GetOrdinal("DocumentId")),
+            reader.GetString(reader.GetOrdinal("CandidateId")),
+            reader.GetString(reader.GetOrdinal("FieldPath")),
+            reader.IsDBNull(reader.GetOrdinal("ObservedValue")) ? null : reader.GetString(reader.GetOrdinal("ObservedValue")),
+            reader.IsDBNull(reader.GetOrdinal("ExpectedValue")) ? null : reader.GetString(reader.GetOrdinal("ExpectedValue")),
+            reader.IsDBNull(reader.GetOrdinal("Justification")) ? null : reader.GetString(reader.GetOrdinal("Justification")),
+            reader.GetGuid(reader.GetOrdinal("ReportedByUserId")),
+            reader.GetString(reader.GetOrdinal("Status")),
+            new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("CreatedAtUtc")), TimeSpan.Zero),
+            reader.IsDBNull(reader.GetOrdinal("ReviewedByUserId")) ? null : reader.GetGuid(reader.GetOrdinal("ReviewedByUserId")),
+            reader.IsDBNull(reader.GetOrdinal("ReviewedAtUtc")) ? null : new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("ReviewedAtUtc")), TimeSpan.Zero));
+
         // ✅ Sem FK entre tbFieldCorrectionReport.DocumentId e tbFieldCorrectionContext.DocumentId
         // (deliberado): o ADR já prevê um cron futuro de retenção/TTL sobre o contexto (§4, "fora de
         // escopo deste ADR") — uma FK travaria essa limpeza. O controller já garante a existência do

--- a/Services/Interfaces/IFieldCorrectionStore.cs
+++ b/Services/Interfaces/IFieldCorrectionStore.cs
@@ -22,5 +22,22 @@ namespace LayoutParserApi.Services.Interfaces
 
         /// <summary>Cria o reporte com <c>Status = pending</c> (ADR §6) e retorna o <c>ReportId</c> gerado.</summary>
         Task<Guid> CreateReportAsync(FieldCorrectionReportInput input, Guid reportedByUserId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Fila de curadoria (issue #346): reportes ainda <c>pending</c>, mais antigos primeiro,
+        /// limitados a <paramref name="limit"/>.
+        /// </summary>
+        Task<IReadOnlyList<FieldCorrectionReportSummary>> ListPendingReportsAsync(int limit, CancellationToken cancellationToken);
+
+        /// <summary>Retorna uma linha de reporte por id, ou <c>null</c> se não existir.</summary>
+        Task<FieldCorrectionReportSummary?> GetReportAsync(Guid reportId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Transição de curadoria (issue #346): grava <paramref name="newStatus"/> +
+        /// <paramref name="reviewedByUserId"/> + <c>ReviewedAtUtc</c> <b>somente</b> se o reporte
+        /// estava <c>pending</c>. Retorna <c>false</c> se o reporte não existe ou já foi revisado
+        /// (idempotente — uma segunda chamada não reverte nem re-transiciona).
+        /// </summary>
+        Task<bool> TransitionStatusAsync(Guid reportId, string newStatus, Guid reviewedByUserId, CancellationToken cancellationToken);
     }
 }

--- a/Services/Transformation/Ai/TrainingDataCaptureService.cs
+++ b/Services/Transformation/Ai/TrainingDataCaptureService.cs
@@ -2,6 +2,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using LayoutParserApi.Models.Fiscal;
 using LayoutParserApi.Services.Transformation.Ai.Retraining;
 
 namespace LayoutParserApi.Services.Transformation.Ai
@@ -84,27 +85,7 @@ namespace LayoutParserApi.Services.Transformation.Ai
                     mapperGuid, mapperName, layoutName, inputXml, groundTruthXml, finalXslt,
                     iterationsUsed, DateTime.UtcNow);
 
-                Directory.CreateDirectory(_trainingDataPath);
-                // Rotação diária — mesmo racional do dataset batch (nome com data), evita um
-                // único arquivo monolítico crescendo pra sempre e facilita auditar por dia.
-                var fileName = $"runtime-capture-{DateTime.UtcNow:yyyy-MM-dd}.jsonl";
-                var path = Path.Combine(_trainingDataPath, fileName);
-
-                // Lock só de processo — várias sínteses convergindo ~simultaneamente no mesmo
-                // worker não podem intercalar linhas parciais no arquivo (fire-and-forget, sem
-                // fila/serialização a montante garantindo exclusão mútua).
-                lock (WriteLock)
-                {
-                    File.AppendAllText(path, line + Environment.NewLine);
-                }
-
-                _logger.LogInformation(
-                    "Exemplo de convergência capturado pro dataset de treino incremental em {Path} (mapperGuid={MapperGuid})",
-                    Services.Logging.LogMessageSanitizer.Sanitize(path), safeMapperGuid);
-
-                // F4.2 (issue #351): só conta depois que a linha foi de fato escrita — se a
-                // gravação acima falhar, o contador não avança (cai no catch abaixo).
-                _retrainingCoordinator?.RegisterCapturedExample();
+                AppendJsonlLine(line, $"mapperGuid={safeMapperGuid}");
             }
             catch (Exception ex)
             {
@@ -113,6 +94,85 @@ namespace LayoutParserApi.Services.Transformation.Ai
                     "Falha ao capturar exemplo de convergência pro dataset de treino incremental — best-effort, não afeta a síntese (mapperGuid={MapperGuid})",
                     safeMapperGuid);
             }
+        }
+
+        /// <summary>
+        /// Curadoria humana aceita (issue #346): grava (best-effort) um exemplo incremental a partir
+        /// do contexto original do documento + o valor esperado revisado por um humano. Mesma forma
+        /// (<c>instruction</c>/<c>input</c>/<c>output</c>) e mesmo arquivo diário do
+        /// <see cref="TryCapture"/>, só com <c>source = "human-correction-reviewed"</c>. Nunca lança.
+        /// Chame SÓ depois que a transição para <c>reviewed_accepted</c> foi confirmada.
+        /// </summary>
+        public void TryCaptureHumanCorrection(FieldCorrectionContext context, FieldCorrectionReportSummary report)
+        {
+            try
+            {
+                var line = BuildHumanCorrectionJsonlLine(context, report, DateTime.UtcNow);
+                AppendJsonlLine(line, $"human-correction reportId={report.ReportId}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Falha ao capturar correção humana revisada pro dataset de treino incremental — best-effort (reportId={ReportId})",
+                    report.ReportId);
+            }
+        }
+
+        /// <summary>
+        /// Append + rotação diária + log + contador de retraining — compartilhado por
+        /// <see cref="TryCapture"/> e <see cref="TryCaptureHumanCorrection"/> (um único
+        /// <c>File.AppendAllText</c> e uma única resolução de path/nome de arquivo).
+        /// </summary>
+        private void AppendJsonlLine(string line, string logContext)
+        {
+            Directory.CreateDirectory(_trainingDataPath);
+            // Rotação diária — mesmo racional do dataset batch (nome com data), evita um
+            // único arquivo monolítico crescendo pra sempre e facilita auditar por dia.
+            var fileName = $"runtime-capture-{DateTime.UtcNow:yyyy-MM-dd}.jsonl";
+            var path = Path.Combine(_trainingDataPath, fileName);
+
+            // Lock só de processo — várias capturas ~simultâneas no mesmo worker não podem
+            // intercalar linhas parciais no arquivo (fire-and-forget, sem fila a montante).
+            lock (WriteLock)
+            {
+                File.AppendAllText(path, line + Environment.NewLine);
+            }
+
+            _logger.LogInformation(
+                "Exemplo capturado pro dataset de treino incremental em {Path} ({Context})",
+                Services.Logging.LogMessageSanitizer.Sanitize(path), logContext);
+
+            // F4.2 (issue #351): só conta depois que a linha foi de fato escrita.
+            _retrainingCoordinator?.RegisterCapturedExample();
+        }
+
+        /// <summary>Monta a linha JSONL de uma correção humana revisada. <c>internal</c> pra teste sem I/O.</summary>
+        internal static string BuildHumanCorrectionJsonlLine(
+            FieldCorrectionContext context,
+            FieldCorrectionReportSummary report,
+            DateTime capturedAtUtc)
+        {
+            var mapperLabel = context.MapperName ?? context.MapperGuid ?? "mapeador não identificado";
+            var record = new TrainingExampleRecord
+            {
+                Instruction =
+                    $"No documento do layout '{context.LayoutName}' (mapeador '{mapperLabel}'), o campo " +
+                    $"'{report.FieldPath}' foi gerado como '{report.ObservedValue}', mas o valor correto — " +
+                    $"revisado e aprovado por um humano — é '{report.ExpectedValue}'. Ajuste a transformação " +
+                    "para produzir o valor correto nesse campo a partir do XML de entrada.",
+                Input = context.InputXml,
+                Output = report.ExpectedValue ?? string.Empty,
+                GroundTruthXml = context.GroundTruthXml ?? string.Empty,
+                MapperGuid = context.MapperGuid ?? string.Empty,
+                MapperName = context.MapperName,
+                LayoutName = context.LayoutName,
+                IterationsUsed = 0,
+                Source = "human-correction-reviewed",
+                CapturedAtUtc = capturedAtUtc.ToString("o"),
+            };
+
+            return JsonSerializer.Serialize(record, JsonOptions);
         }
 
         /// <summary>Monta a linha JSONL. <c>internal</c> pra ser testável isoladamente sem I/O.</summary>

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerEndToEndAiCandidateTests.cs
@@ -143,7 +143,8 @@ namespace LayoutParserApi.Tests.Controllers
                 scopeFactory: scopeProvider.GetRequiredService<IServiceScopeFactory>(),
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
                     NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
-                fieldCorrectionStore: null!);
+                fieldCorrectionStore: null!,
+                trainingDataCapture: null!);
 
             var request = new TransformationRequest
             {

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldCorrectionTests.cs
@@ -10,6 +10,7 @@ using LayoutParserApi.Services.Transformation.Ai;
 using LayoutParserApi.Services.Transformation.LowCode;
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -36,16 +37,19 @@ namespace LayoutParserApi.Tests.Controllers
             public Guid? UserId { get; set; } = Guid.NewGuid();
         }
 
-        /// <summary>Fake em memória — nunca toca em SQL real, cobre os 3 métodos de <see cref="IFieldCorrectionStore"/>.</summary>
+        /// <summary>Fake em memória — nunca toca em SQL real, cobre os 6 métodos de <see cref="IFieldCorrectionStore"/>.</summary>
         private sealed class FakeFieldCorrectionStore : IFieldCorrectionStore
         {
             public FieldCorrectionContext? SavedContext { get; private set; }
+            public int SaveContextCallCount { get; private set; }
             public bool ThrowOnGetContext { get; set; }
             public List<(FieldCorrectionReportInput Input, Guid ReportedByUserId)> CreatedReports { get; } = new();
+            public List<FieldCorrectionReportSummary> Reports { get; } = new();
 
             public Task SaveContextAsync(FieldCorrectionContext context, CancellationToken cancellationToken)
             {
                 SavedContext = context;
+                SaveContextCallCount++;
                 return Task.CompletedTask;
             }
 
@@ -59,15 +63,55 @@ namespace LayoutParserApi.Tests.Controllers
 
             public Task<Guid> CreateReportAsync(FieldCorrectionReportInput input, Guid reportedByUserId, CancellationToken cancellationToken)
             {
+                var id = Guid.NewGuid();
                 CreatedReports.Add((input, reportedByUserId));
-                return Task.FromResult(Guid.NewGuid());
+                Reports.Add(new FieldCorrectionReportSummary(
+                    id, input.DocumentId, input.CandidateId, input.FieldPath,
+                    input.ObservedValue, input.ExpectedValue, input.Justification,
+                    reportedByUserId, FieldCorrectionReportStatus.Pending, DateTimeOffset.UtcNow, null, null));
+                return Task.FromResult(id);
+            }
+
+            public Task<IReadOnlyList<FieldCorrectionReportSummary>> ListPendingReportsAsync(int limit, CancellationToken cancellationToken)
+            {
+                IReadOnlyList<FieldCorrectionReportSummary> pending = Reports
+                    .Where(r => r.Status == FieldCorrectionReportStatus.Pending)
+                    .OrderBy(r => r.CreatedAtUtc)
+                    .Take(limit)
+                    .ToList();
+                return Task.FromResult(pending);
+            }
+
+            public Task<FieldCorrectionReportSummary?> GetReportAsync(Guid reportId, CancellationToken cancellationToken)
+                => Task.FromResult(Reports.FirstOrDefault(r => r.ReportId == reportId));
+
+            public Task<bool> TransitionStatusAsync(Guid reportId, string newStatus, Guid reviewedByUserId, CancellationToken cancellationToken)
+            {
+                var idx = Reports.FindIndex(r => r.ReportId == reportId);
+                if (idx < 0 || Reports[idx].Status != FieldCorrectionReportStatus.Pending)
+                    return Task.FromResult(false);
+
+                Reports[idx] = Reports[idx] with
+                {
+                    Status = newStatus,
+                    ReviewedByUserId = reviewedByUserId,
+                    ReviewedAtUtc = DateTimeOffset.UtcNow
+                };
+                return Task.FromResult(true);
             }
         }
 
-        private static (TransformationExecutionController Controller, FakeFieldCorrectionStore Store, FakeCurrentUser User) BuildController()
+        private static (TransformationExecutionController Controller, FakeFieldCorrectionStore Store, FakeCurrentUser User, string TrainingDataPath) BuildController()
         {
             var store = new FakeFieldCorrectionStore();
             var user = new FakeCurrentUser();
+
+            var trainingDataPath = Path.Combine(Path.GetTempPath(), "lp-tests-training-" + Guid.NewGuid().ToString("N"));
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["XslSynth:TrainingDataPath"] = trainingDataPath })
+                .Build();
+            var trainingCapture = new TrainingDataCaptureService(
+                NullLogger<TrainingDataCaptureService>.Instance, config);
 
             // scopeFactory real (necessário: TryPersistFieldCorrectionContext abre um IServiceScope
             // próprio dentro do Task.Run, mesmo padrão de TryEnqueueAiCandidate) resolvendo o MESMO
@@ -97,9 +141,10 @@ namespace LayoutParserApi.Tests.Controllers
                 scopeFactory: scopeFactory,
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
                     NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
-                fieldCorrectionStore: store);
+                fieldCorrectionStore: store,
+                trainingDataCapture: trainingCapture);
 
-            return (controller, store, user);
+            return (controller, store, user, trainingDataPath);
         }
 
         private sealed class NoopAiCandidateService : IAiTransformationCandidateService
@@ -130,7 +175,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task TryPersistFieldCorrectionContext_grava_gabarito_sysmiddle_quando_existe()
         {
-            var (controller, store, _) = BuildController();
+            var (controller, store, _, _) = BuildController();
 
             var request = new TransformationRequest { InputContent = "linha-txt", LayoutName = "LAYOUT_X" };
             var layoutGuid = Guid.NewGuid();
@@ -168,7 +213,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task TryPersistFieldCorrectionContext_sem_candidato_sysmiddle_grava_sem_gabarito()
         {
-            var (controller, store, _) = BuildController();
+            var (controller, store, _, _) = BuildController();
 
             var request = new TransformationRequest { InputContent = "<xml/>", LayoutName = "LAYOUT_Y" };
             var layoutGuid = Guid.NewGuid();
@@ -194,7 +239,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task ReportFieldCorrection_documento_valido_retorna_202_e_grava_pending()
         {
-            var (controller, store, user) = BuildController();
+            var (controller, store, user, _) = BuildController();
             var context = new FieldCorrectionContext(
                 "doc_abc123", "mapper-1", "MeuMapper", "layout-guid-1", "LAYOUT_X",
                 "<xml>entrada</xml>", "<xml>gabarito</xml>", DateTimeOffset.UtcNow);
@@ -224,7 +269,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task ReportFieldCorrection_documentId_sem_contexto_retorna_404()
         {
-            var (controller, _, _) = BuildController();
+            var (controller, _, _, _) = BuildController();
             var request = new FieldCorrectionRequest
             {
                 DocumentId = "doc_inexistente",
@@ -242,7 +287,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task ReportFieldCorrection_sem_identidade_resolvida_retorna_404_failclosed()
         {
-            var (controller, _, user) = BuildController();
+            var (controller, _, user, _) = BuildController();
             user.UserId = null; // identidade não resolvida (TrustedIdentityMiddleware não confiou na origem)
 
             var request = new FieldCorrectionRequest
@@ -268,7 +313,7 @@ namespace LayoutParserApi.Tests.Controllers
         public async Task ReportFieldCorrection_campo_obrigatorio_ausente_retorna_400(
             string documentId, string candidateId, string fieldPath, string observedValue, string expectedValue)
         {
-            var (controller, _, _) = BuildController();
+            var (controller, _, _, _) = BuildController();
             var request = new FieldCorrectionRequest
             {
                 DocumentId = documentId,
@@ -286,7 +331,7 @@ namespace LayoutParserApi.Tests.Controllers
         [Fact]
         public async Task ReportFieldCorrection_IdentityDatabase_indisponivel_degrada_para_404_sem_lancar()
         {
-            var (controller, store, _) = BuildController();
+            var (controller, store, _, _) = BuildController();
             store.ThrowOnGetContext = true;
 
             var request = new FieldCorrectionRequest
@@ -303,6 +348,160 @@ namespace LayoutParserApi.Tests.Controllers
             var result = await controller.ReportFieldCorrection(request, CancellationToken.None);
 
             Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        // --- Curadoria: GET field-correction/pending + POST field-correction/{id}/review (issue #346) ---
+
+        /// <summary>Cria um contexto + um reporte pending e devolve (store, reportId).</summary>
+        private static async Task<(FakeFieldCorrectionStore Store, Guid ReportId)> SeedPendingReportAsync(
+            TransformationExecutionController controller, FakeFieldCorrectionStore store,
+            string observed = "001", string expected = "1", string groundTruth = "<xml>gabarito</xml>")
+        {
+            var context = new FieldCorrectionContext(
+                "doc_cur", "mapper-1", "MeuMapper", "layout-guid-1", "LAYOUT_X",
+                "<xml>entrada</xml>", groundTruth, DateTimeOffset.UtcNow);
+            await store.SaveContextAsync(context, CancellationToken.None);
+
+            var report = new FieldCorrectionRequest
+            {
+                DocumentId = "doc_cur",
+                CandidateId = "tclxsl-1",
+                FieldPath = "/nfeProc/NFe/infNFe/ide/nNF",
+                ObservedValue = observed,
+                ExpectedValue = expected,
+                Justification = "zero à esquerda"
+            };
+            var created = await controller.ReportFieldCorrection(report, CancellationToken.None);
+            var accepted = Assert.IsType<AcceptedResult>(created);
+            var reportId = (Guid)accepted.Value!.GetType().GetProperty("reportId")!.GetValue(accepted.Value)!;
+            return (store, reportId);
+        }
+
+        private static string? ReadCapturedJsonl(string trainingDataPath)
+        {
+            if (!Directory.Exists(trainingDataPath)) return null;
+            var files = Directory.GetFiles(trainingDataPath, "runtime-capture-*.jsonl");
+            return files.Length == 0 ? null : string.Concat(files.Select(File.ReadAllText));
+        }
+
+        [Fact]
+        public async Task ListPendingFieldCorrections_retorna_somente_pendentes()
+        {
+            var (controller, store, _, _) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store);
+
+            var pendingBefore = Assert.IsType<OkObjectResult>(await controller.ListPendingFieldCorrections(100, CancellationToken.None));
+            Assert.Equal(1, (int)pendingBefore.Value!.GetType().GetProperty("count")!.GetValue(pendingBefore.Value)!);
+
+            await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "rejected" }, CancellationToken.None);
+
+            var pendingAfter = Assert.IsType<OkObjectResult>(await controller.ListPendingFieldCorrections(100, CancellationToken.None));
+            Assert.Equal(0, (int)pendingAfter.Value!.GetType().GetProperty("count")!.GetValue(pendingAfter.Value)!);
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_accepted_transiciona_e_gera_jsonl_com_source_correto()
+        {
+            var (controller, store, user, trainingPath) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store, observed: "001", expected: "1");
+
+            var result = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "Accepted" }, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+            var report = await store.GetReportAsync(reportId, CancellationToken.None);
+            Assert.Equal(FieldCorrectionReportStatus.ReviewedAccepted, report!.Status);
+            Assert.Equal(user.UserId, report.ReviewedByUserId);
+            Assert.NotNull(report.ReviewedAtUtc);
+
+            var jsonl = ReadCapturedJsonl(trainingPath);
+            Assert.NotNull(jsonl);
+            Assert.Contains("\"source\":\"human-correction-reviewed\"", jsonl);
+            Assert.Contains("\"output\":\"1\"", jsonl);
+
+            if (Directory.Exists(trainingPath)) Directory.Delete(trainingPath, true);
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_rejected_transiciona_e_NAO_gera_jsonl()
+        {
+            var (controller, store, _, trainingPath) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store);
+
+            var result = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "rejected" }, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+            var report = await store.GetReportAsync(reportId, CancellationToken.None);
+            Assert.Equal(FieldCorrectionReportStatus.ReviewedRejected, report!.Status);
+            Assert.Null(ReadCapturedJsonl(trainingPath));
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_segunda_chamada_retorna_409_idempotente()
+        {
+            var (controller, store, _, trainingPath) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store);
+
+            var first = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "accepted" }, CancellationToken.None);
+            Assert.IsType<OkObjectResult>(first);
+
+            var second = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "rejected" }, CancellationToken.None);
+            Assert.IsType<ConflictObjectResult>(second);
+
+            var report = await store.GetReportAsync(reportId, CancellationToken.None);
+            Assert.Equal(FieldCorrectionReportStatus.ReviewedAccepted, report!.Status);
+
+            if (Directory.Exists(trainingPath)) Directory.Delete(trainingPath, true);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("maybe")]
+        public async Task ReviewFieldCorrection_decision_invalida_retorna_400(string? decision)
+        {
+            var (controller, store, _, _) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store);
+
+            var result = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = decision }, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_sem_identidade_resolvida_retorna_404_failclosed()
+        {
+            var (controller, store, user, _) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store);
+            user.UserId = null;
+
+            var result = await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "accepted" }, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_reportId_inexistente_retorna_409()
+        {
+            var (controller, _, _, _) = BuildController();
+
+            var result = await controller.ReviewFieldCorrection(Guid.NewGuid(), new FieldCorrectionReviewRequest { Decision = "accepted" }, CancellationToken.None);
+
+            Assert.IsType<ConflictObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ReviewFieldCorrection_accepted_nao_sobrescreve_groundTruth_do_contexto()
+        {
+            var (controller, store, _, trainingPath) = BuildController();
+            var (_, reportId) = await SeedPendingReportAsync(controller, store, groundTruth: "<xml>GABARITO-ORIGINAL</xml>");
+            var saveCallsBefore = store.SaveContextCallCount;
+
+            await controller.ReviewFieldCorrection(reportId, new FieldCorrectionReviewRequest { Decision = "accepted" }, CancellationToken.None);
+
+            Assert.Equal("<xml>GABARITO-ORIGINAL</xml>", store.SavedContext!.GroundTruthXml);
+            Assert.Equal(saveCallsBefore, store.SaveContextCallCount);
+
+            if (Directory.Exists(trainingPath)) Directory.Delete(trainingPath, true);
         }
     }
 }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerFieldMappingsTests.cs
@@ -298,7 +298,8 @@ namespace LayoutParserApi.Tests.Controllers
                 scopeFactory: scopeFactory,
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
                     NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
-                fieldCorrectionStore: null!);
+                fieldCorrectionStore: null!,
+                trainingDataCapture: null!);
 
             return (controller, parserFake, runner);
         }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerPathwayDiagnosticsTests.cs
@@ -172,7 +172,8 @@ namespace LayoutParserApi.Tests.Controllers
                 scopeFactory: services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
                     NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
-                fieldCorrectionStore: null!);
+                fieldCorrectionStore: null!,
+                trainingDataCapture: null!);
 
             return (controller, aiSpy, tclDir);
         }

--- a/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/TransformationExecutionControllerUserIsolationTests.cs
@@ -117,7 +117,8 @@ namespace LayoutParserApi.Tests.Controllers
                 scopeFactory: null!,
                 canaryAlert: new LayoutParserApi.Services.Security.CanaryAlertService(
                     NullLogger<LayoutParserApi.Services.Security.CanaryAlertService>.Instance),
-                fieldCorrectionStore: null!);
+                fieldCorrectionStore: null!,
+                trainingDataCapture: null!);
 
             return (controller, spy, user);
         }


### PR DESCRIPTION
Promoção de `develop` para `master`.

## Conteúdo

- **#346** (PR #369) — curadoria de correção humana antes de virar dado de treino:
  - `GET /api/transformation/field-correction/pending` (fila de curadoria)
  - `POST /api/transformation/field-correction/{reportId}/review` (`accepted`/`rejected`, idempotente)
  - Só `reviewed_accepted` alimenta o JSONL incremental com `source="human-correction-reviewed"`; `rejected`/`pending` nunca.
  - `GroundTruthXml` do contexto nunca sobrescrito. `[Authorize(Roles="admin")]` (sem papel `fiscal` no projeto ainda — `TODO(#346)`).

## CI

`build` / `build-and-test` / `dependency-review` / `gitleaks` verdes na PR #369. 766 testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)