### PR TITLE
fix(mapper): normaliza prefixo LAY_ na busca de mapeador por layout guid (LayoutParserCypress#14)

### DIFF
--- a/Services/Database/MapperDatabaseService.cs
+++ b/Services/Database/MapperDatabaseService.cs
@@ -115,18 +115,28 @@ namespace LayoutParserApi.Services.Database
                 using var connection = new SqlConnection(_connectionString);
                 await connection.OpenAsync();
 
+                // ✅ Os GUIDs de layout em [tbMapper] são gravados COM o prefixo "LAY_"
+                // (ex.: LAY_ad4fb6f4-...), mas os chamadores costumam passar o GUID "cru"
+                // (layout.LayoutGuid.ToString()). Sem normalizar, a igualdade exata do WHERE
+                // devolve 0 linhas e o pathway de XSL reporta "Nenhum mapeador encontrado"
+                // mesmo existindo mapper (bug do Cypress #14 / FIAT ENVNFE). Mesma
+                // normalização já usada em GetMappersByLayoutGuidForPackagesAsync.
+                var layoutNoPrefix = NormalizeLayoutGuid(layoutGuid);
+                var layoutWithPrefix = $"LAY_{layoutNoPrefix}";
+
                 var query = @"
-                    SELECT 
+                    SELECT
                         [Id], [MapperGuid], [PackageGuid], [Name], [Description],
                         [IsXPathMapper], [InputLayoutGuid], [TargetLayoutGuid],
                         [ValueContent], [ProjectId], [LastUpdateDate]
                     FROM [ConnectUS_Macgyver].[dbo].[tbMapper]
-                    WHERE [InputLayoutGuid] = @LayoutGuid 
-                       OR [TargetLayoutGuid] = @LayoutGuid
+                    WHERE [InputLayoutGuid] IN (@LayoutNoPrefix, @LayoutWithPrefix)
+                       OR [TargetLayoutGuid] IN (@LayoutNoPrefix, @LayoutWithPrefix)
                     ORDER BY [LastUpdateDate] DESC";
 
                 using var command = new SqlCommand(query, connection);
-                command.Parameters.AddWithValue("@LayoutGuid", layoutGuid);
+                command.Parameters.AddWithValue("@LayoutNoPrefix", layoutNoPrefix);
+                command.Parameters.AddWithValue("@LayoutWithPrefix", layoutWithPrefix);
 
                 using var reader = await command.ExecuteReaderAsync();
 
@@ -135,19 +145,12 @@ namespace LayoutParserApi.Services.Database
                     var mapper = await MapReaderToMapperAsync(reader);
 
                     // Verificar se o layoutGuid corresponde ao InputLayoutGuid ou TargetLayoutGuid
-                    // Tanto das colunas quanto do XML descriptografado
-                    bool matches = false;
-
-                    // Verificar colunas do banco
-                    if (mapper.InputLayoutGuid == layoutGuid || mapper.TargetLayoutGuid == layoutGuid)
-                        matches = true;
-
-                    // Verificar XML descriptografado (mais confiável)
-                    if (!string.IsNullOrEmpty(mapper.InputLayoutGuidFromXml) && mapper.InputLayoutGuidFromXml == layoutGuid)
-                        matches = true;
-
-                    if (!string.IsNullOrEmpty(mapper.TargetLayoutGuidFromXml) && mapper.TargetLayoutGuidFromXml == layoutGuid)
-                        matches = true;
+                    // Tanto das colunas quanto do XML descriptografado (comparação sem prefixo LAY_)
+                    bool matches = layoutNoPrefix.Length > 0 && (
+                        NormalizeLayoutGuid(mapper.InputLayoutGuid) == layoutNoPrefix ||
+                        NormalizeLayoutGuid(mapper.TargetLayoutGuid) == layoutNoPrefix ||
+                        NormalizeLayoutGuid(mapper.InputLayoutGuidFromXml) == layoutNoPrefix ||
+                        NormalizeLayoutGuid(mapper.TargetLayoutGuidFromXml) == layoutNoPrefix);
 
                     if (matches)
                         mappers.Add(mapper);
@@ -168,7 +171,10 @@ namespace LayoutParserApi.Services.Database
         public async Task<Mapper> GetMapperByInputLayoutGuidAsync(string inputLayoutGuid)
         {
             var mappers = await GetMappersByLayoutGuidAsync(inputLayoutGuid);
-            return mappers.FirstOrDefault(m => m.InputLayoutGuid == inputLayoutGuid || m.InputLayoutGuidFromXml == inputLayoutGuid);
+            var wanted = NormalizeLayoutGuid(inputLayoutGuid);
+            return mappers.FirstOrDefault(m =>
+                NormalizeLayoutGuid(m.InputLayoutGuid) == wanted ||
+                NormalizeLayoutGuid(m.InputLayoutGuidFromXml) == wanted);
         }
 
         /// <summary>
@@ -177,7 +183,10 @@ namespace LayoutParserApi.Services.Database
         public async Task<Mapper> GetMapperByTargetLayoutGuidAsync(string targetLayoutGuid)
         {
             var mappers = await GetMappersByLayoutGuidAsync(targetLayoutGuid);
-            return mappers.FirstOrDefault(m => m.TargetLayoutGuid == targetLayoutGuid || m.TargetLayoutGuidFromXml == targetLayoutGuid);
+            var wanted = NormalizeLayoutGuid(targetLayoutGuid);
+            return mappers.FirstOrDefault(m =>
+                NormalizeLayoutGuid(m.TargetLayoutGuid) == wanted ||
+                NormalizeLayoutGuid(m.TargetLayoutGuidFromXml) == wanted);
         }
 
         /// <summary>
@@ -273,6 +282,20 @@ namespace LayoutParserApi.Services.Database
             }
 
             return ranked;
+        }
+
+        /// <summary>
+        /// Normaliza um GUID de layout removendo o prefixo "LAY_" e espaços, em minúsculas.
+        /// Os chamadores ora passam o GUID cru (layout.LayoutGuid), ora com o prefixo
+        /// "LAY_" (como gravado em [tbMapper]) — normalizar dos dois lados evita falso
+        /// "não encontrado". Retorna "" para entrada nula/vazia.
+        /// </summary>
+        private static string NormalizeLayoutGuid(string layoutGuid)
+        {
+            if (string.IsNullOrWhiteSpace(layoutGuid)) return "";
+            var g = layoutGuid.Trim();
+            if (g.StartsWith("LAY_", StringComparison.OrdinalIgnoreCase)) g = g.Substring(4);
+            return g.Trim().ToLowerInvariant();
         }
 
         private static string NormalizePackageGuid(string packageGuid)

--- a/tests/LayoutParserApi.Tests/Database/MapperDatabaseServiceRealMapperParserShadowTests.cs
+++ b/tests/LayoutParserApi.Tests/Database/MapperDatabaseServiceRealMapperParserShadowTests.cs
@@ -178,6 +178,44 @@ namespace LayoutParserApi.Tests.Database
             Assert.Equal("<xsl:stylesheet>valor-unico</xsl:stylesheet>", mapper.XslContent);
         }
 
+        // ----------------------------------------------------------------------------------
+        // Regressão do Cypress #14 / FIAT LAY_TXT_MQSERIES_ENVNFE_4.00_NFe: generate-for-layout
+        // gerava o .tcl mas nenhum .xsl, com warning "Nenhum mapeador encontrado". Causa: os
+        // GUIDs em [tbMapper] são gravados com prefixo "LAY_", mas o chamador passa o GUID cru
+        // (layout.LayoutGuid.ToString()) e a busca fazia igualdade exata. NormalizeLayoutGuid
+        // remove o prefixo dos dois lados antes de comparar.
+        // ----------------------------------------------------------------------------------
+
+        private static string InvocarNormalizeLayoutGuid(string entrada)
+        {
+            var metodo = typeof(MapperDatabaseService).GetMethod(
+                "NormalizeLayoutGuid",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(metodo);
+            return (string)metodo!.Invoke(null, new object?[] { entrada })!;
+        }
+
+        [Theory]
+        [InlineData("ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c", "ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c")]
+        [InlineData("LAY_ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c", "ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c")]
+        [InlineData("  lay_AD4FB6F4-9FF5-44FD-988B-3DA5ED56B22C  ", "ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c")]
+        [InlineData(null, "")]
+        [InlineData("   ", "")]
+        public void NormalizeLayoutGuid_RemovePrefixoLayEEspacos_ParaComparacaoConsistente(string? entrada, string esperado)
+        {
+            Assert.Equal(esperado, InvocarNormalizeLayoutGuid(entrada!));
+        }
+
+        [Fact]
+        public void NormalizeLayoutGuid_GuidCruEComPrefixo_ColidemAposNormalizacao()
+        {
+            // O cerne do bug: estes dois valores representam o MESMO layout e precisam bater.
+            Assert.Equal(
+                InvocarNormalizeLayoutGuid("ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c"),
+                InvocarNormalizeLayoutGuid("LAY_ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c"));
+        }
+
         [Fact]
         public void ExtractLayoutGuids_ComContentVazio_NaoExecutaNadaEMantemMapperInalterado()
         {


### PR DESCRIPTION
## Sintoma (LayoutParserCypress#14)

`POST /api/AutoTransformation/generate-for-layout` para o layout FIAT `LAY_TXT_MQSERIES_ENVNFE_4.00_NFe` (GUID `ad4fb6f4-9ff5-44fd-988b-3da5ed56b22c`) gera o `.tcl` mas **não gera nenhum `.xsl`**, com warning `Nenhum mapeador encontrado para o layout ...`. Sem XSL, o caminho `tcl-xsl` do gate FIAT não prossegue.

## Causa raiz — bug de código

O `.tcl` sai porque é gerado do próprio XML do layout (não precisa de mapper). O `.xsl` precisa do mapper: `AutoTransformationGeneratorService.GenerateXslForLayoutAsync` → `MapperDatabaseService.GetMapperByInputLayoutGuidAsync(layoutGuidStr)` com o **GUID cru** (`ad4fb6f4-...`, sem `LAY_`).

`GetMappersByLayoutGuidAsync` fazia `WHERE InputLayoutGuid = @LayoutGuid OR TargetLayoutGuid = @LayoutGuid` com igualdade **exata**. Mas em `[ConnectUS_Macgyver].[dbo].[tbMapper]` essas colunas são gravadas **com prefixo `LAY_`** → 0 linhas → `mapper == null` → sem XSL.

O método irmão `GetMappersByLayoutGuidForPackagesAsync` (mesmo arquivo) **já normaliza** o prefixo; `GetBestMapperForLayoutGuidAsync` tem `Normalize()` local. Só a família não-restrita por pacote — a que o `generate-for-layout` usa — ficou sem. É bug, não lacuna de dado.

## Fix (`MapperDatabaseService.cs`)

- Novo `NormalizeLayoutGuid(string)` (strip `LAY_` + trim + lower), espelhando `NormalizePackageGuid`.
- `GetMappersByLayoutGuidAsync`: SQL busca as duas formas (`IN (@LayoutNoPrefix, @LayoutWithPrefix)` para input e target); match em memória compara normalizado.
- `GetMapperByInputLayoutGuidAsync` / `GetMapperByTargetLayoutGuidAsync`: comparação normalizada.
- **Continua read-only** no banco compartilhado — nenhuma escrita/DDL (`.claude/rules/security.md`).

## Testes

`dotnet build` 0 erros. `dotnet test` **772/772 verdes**. 5 casos novos travando a normalização (GUID cru e `LAY_`-prefixado colidem; null/whitespace → `""`).

## Ressalva

Sem acesso SQL neste ambiente para confirmar 100% que existe um registro em `tbMapper` para esse layout. Evidência forte de que existe: o endpoint roda e gera o `.tcl`, e o package FIAT tem os mappers SEND_ENV NFe (memória `multi-client-mappers`). Se pós-deploy o warning persistir, aí é lacuna de catálogo — query de confirmação no corpo da issue #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)