### PR TITLE
feat(governance): endpoints de deprecação/arquivamento manual de MappingRelease (issue #378)

### DIFF
--- a/Controllers/MappingGovernanceController.cs
+++ b/Controllers/MappingGovernanceController.cs
@@ -17,6 +17,12 @@ namespace LayoutParserApi.Controllers
         public string? Environment { get; set; }
     }
 
+    /// <summary>Corpo opcional das transições de ciclo de vida (deprecate/archive — issue #378).</summary>
+    public sealed class LifecycleTransitionRequest
+    {
+        public string? Justification { get; set; }
+    }
+
     /// <summary>
     /// Governança/publicação de <see cref="MappingRelease"/> — Slice 7 (issue #94, design
     /// <c>design-slice7-governanca-piloto-fiat-2026-09-01.md</c>). Último slice da fundação: promove
@@ -192,6 +198,72 @@ namespace LayoutParserApi.Controllers
             catch (InvalidOperationException ex)
             {
                 _logger.LogWarning(ex, "Rollback recusado para release {ReleaseId}.", releaseId);
+                return UnprocessableEntity(new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// <c>published → deprecated</c> — deprecação manual (issue #378). A release deixa de ser a
+        /// publicação corrente mas continua consultável/auditável. Corpo opcional <c>justification</c>.
+        /// </summary>
+        /// <remarks>
+        /// RBAC: exige papel <c>fiscal_admin</c> ou <c>owner</c> no workspace da rota. Sem membership → 404;
+        /// papel insuficiente → 403. Transição inválida (status de origem ≠ <c>published</c>) → 422 com
+        /// mensagem PT-BR. Idempotente: re-deprecar uma release já <c>deprecated</c> é no-op (200).
+        /// </remarks>
+        [HttpPost("deprecate")]
+        [RequireWorkspaceRole(WorkspaceRole.FiscalAdmin, WorkspaceRole.Owner)]
+        public async Task<IActionResult> Deprecate(Guid workspaceId, Guid releaseId, [FromBody] LifecycleTransitionRequest? request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound();
+
+            var release = await _releaseStore.GetReleaseIfMemberAsync(releaseId, userId, cancellationToken);
+            if (release == null || release.WorkspaceId != workspaceId)
+                return NotFound();
+
+            try
+            {
+                var deprecated = await _releaseStore.DeprecateAsync(releaseId, userId, request?.Justification, cancellationToken);
+                return Ok(ToReleaseResponse(deprecated));
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Deprecação recusada para release {ReleaseId}.", releaseId);
+                return UnprocessableEntity(new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// <c>deprecated → archived</c> (também aceita <c>test_failed</c>/<c>in_review</c> abandonados
+        /// como origem — issue #378). Estado terminal: a release fica só para histórico/auditoria.
+        /// Corpo opcional <c>justification</c>.
+        /// </summary>
+        /// <remarks>
+        /// RBAC: exige papel <c>fiscal_admin</c> ou <c>owner</c> no workspace da rota. Sem membership → 404;
+        /// papel insuficiente → 403. Transição inválida (origem fora de <c>deprecated</c>/<c>test_failed</c>/
+        /// <c>in_review</c> — ex.: uma <c>published</c>, que precisa ser deprecada antes) → 422 com mensagem
+        /// PT-BR. Idempotente: re-arquivar uma release já <c>archived</c> é no-op (200).
+        /// </remarks>
+        [HttpPost("archive")]
+        [RequireWorkspaceRole(WorkspaceRole.FiscalAdmin, WorkspaceRole.Owner)]
+        public async Task<IActionResult> Archive(Guid workspaceId, Guid releaseId, [FromBody] LifecycleTransitionRequest? request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId is not Guid userId)
+                return NotFound();
+
+            var release = await _releaseStore.GetReleaseIfMemberAsync(releaseId, userId, cancellationToken);
+            if (release == null || release.WorkspaceId != workspaceId)
+                return NotFound();
+
+            try
+            {
+                var archived = await _releaseStore.ArchiveAsync(releaseId, userId, request?.Justification, cancellationToken);
+                return Ok(ToReleaseResponse(archived));
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Arquivamento recusado para release {ReleaseId}.", releaseId);
                 return UnprocessableEntity(new { error = ex.Message });
             }
         }

--- a/Services/Database/SqlMappingReleaseStore.cs
+++ b/Services/Database/SqlMappingReleaseStore.cs
@@ -516,6 +516,103 @@ CREATE INDEX IX_tbMappingTransition_ReleaseId ON dbo.tbMappingTransition(Release
                 ?? throw new InvalidOperationException("Falha ao reler a release após rollback.");
         }
 
+        public async Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var tx = connection.BeginTransaction();
+            try
+            {
+                var current = await GetReleaseForUpdateAsync(connection, tx, releaseId, cancellationToken)
+                    ?? throw new InvalidOperationException($"Release {releaseId} não encontrada.");
+
+                // Idempotente (mesmo padrão do rollback): já deprecada — no-op, sem transição nova.
+                if (current.Status == MappingReleaseStatus.Deprecated)
+                {
+                    await tx.CommitAsync(cancellationToken);
+                    return await GetReleaseAsync(connection, releaseId, cancellationToken)
+                        ?? throw new InvalidOperationException("Falha ao reler a release na deprecação idempotente.");
+                }
+
+                if (current.Status != MappingReleaseStatus.Published)
+                    throw new InvalidOperationException($"Release {releaseId} está em \"{current.Status}\"; deprecação manual exige \"{MappingReleaseStatus.Published}\".");
+
+                await InsertTransitionAsync(connection, tx, releaseId, MappingReleaseStatus.Published, MappingReleaseStatus.Deprecated, actorUserId, justification ?? "Deprecação manual.", null, cancellationToken);
+                using (var update = new SqlCommand(
+                    "UPDATE dbo.tbMappingRelease SET Status = @Status WHERE ReleaseId = @ReleaseId;", connection, tx))
+                {
+                    update.Parameters.AddWithValue("@Status", MappingReleaseStatus.Deprecated);
+                    update.Parameters.AddWithValue("@ReleaseId", releaseId);
+                    await update.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                await tx.CommitAsync(cancellationToken);
+            }
+            catch
+            {
+                await tx.RollbackAsync(cancellationToken);
+                throw;
+            }
+
+            return await GetReleaseAsync(connection, releaseId, cancellationToken)
+                ?? throw new InvalidOperationException("Falha ao reler a release após deprecação.");
+        }
+
+        // Origens válidas para arquivamento manual (issue #378): deprecated é o caminho normal;
+        // test_failed/in_review cobrem releases abandonadas que nunca chegaram a publicar.
+        private static readonly string[] ArchivableFromStatuses =
+        {
+            MappingReleaseStatus.Deprecated,
+            MappingReleaseStatus.TestFailed,
+            MappingReleaseStatus.InReview,
+        };
+
+        public async Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
+
+            using var tx = connection.BeginTransaction();
+            try
+            {
+                var current = await GetReleaseForUpdateAsync(connection, tx, releaseId, cancellationToken)
+                    ?? throw new InvalidOperationException($"Release {releaseId} não encontrada.");
+
+                // Idempotente: já arquivada — no-op, sem transição nova.
+                if (current.Status == MappingReleaseStatus.Archived)
+                {
+                    await tx.CommitAsync(cancellationToken);
+                    return await GetReleaseAsync(connection, releaseId, cancellationToken)
+                        ?? throw new InvalidOperationException("Falha ao reler a release no arquivamento idempotente.");
+                }
+
+                if (Array.IndexOf(ArchivableFromStatuses, current.Status) < 0)
+                    throw new InvalidOperationException($"Release {releaseId} está em \"{current.Status}\"; arquivamento manual exige um destes: {string.Join(", ", ArchivableFromStatuses)}.");
+
+                await InsertTransitionAsync(connection, tx, releaseId, current.Status, MappingReleaseStatus.Archived, actorUserId, justification ?? "Arquivamento manual.", null, cancellationToken);
+                using (var update = new SqlCommand(
+                    "UPDATE dbo.tbMappingRelease SET Status = @Status WHERE ReleaseId = @ReleaseId;", connection, tx))
+                {
+                    update.Parameters.AddWithValue("@Status", MappingReleaseStatus.Archived);
+                    update.Parameters.AddWithValue("@ReleaseId", releaseId);
+                    await update.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                await tx.CommitAsync(cancellationToken);
+            }
+            catch
+            {
+                await tx.RollbackAsync(cancellationToken);
+                throw;
+            }
+
+            return await GetReleaseAsync(connection, releaseId, cancellationToken)
+                ?? throw new InvalidOperationException("Falha ao reler a release após arquivamento.");
+        }
+
         private static async Task InsertTransitionAsync(
             SqlConnection connection, SqlTransaction tx, Guid releaseId, string fromStatus, string toStatus,
             Guid actorUserId, string? justification, string? checksSnapshot, CancellationToken cancellationToken)

--- a/Services/Interfaces/IMappingReleaseStore.cs
+++ b/Services/Interfaces/IMappingReleaseStore.cs
@@ -102,5 +102,24 @@ namespace LayoutParserApi.Services.Interfaces
         /// no-op — devolve o estado atual sem gravar nova transição.
         /// </summary>
         Task<MappingReleaseDetail> RollbackAsync(Guid releaseId, Guid actorUserId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// <c>published → deprecated</c> (arquivamento/deprecação manual — issue #378, cross-check #198.1).
+        /// Espelha <see cref="ApproveAsync"/>/<see cref="PublishAsync"/>: valida o estado de origem,
+        /// faz o <c>UPDATE</c> de status e grava a transição em <c>MappingTransition</c> na mesma operação.
+        /// Idempotente (mesmo padrão do <see cref="RollbackAsync"/>): se a release já está
+        /// <c>deprecated</c>, é no-op — devolve o estado atual sem gravar nova transição. Qualquer
+        /// outro status de origem (não <c>published</c>) lança <see cref="InvalidOperationException"/>.
+        /// </summary>
+        Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// <c>deprecated → archived</c> (também aceita <c>test_failed</c> e <c>in_review</c> abandonados
+        /// como origem — issue #378). Congela a release em estado terminal. Grava a transição em
+        /// <c>MappingTransition</c>. Idempotente: se já está <c>archived</c>, é no-op. Origem fora de
+        /// <c>{deprecated, test_failed, in_review}</c> lança <see cref="InvalidOperationException"/>
+        /// (uma release <c>published</c> precisa ser deprecada antes de arquivada).
+        /// </summary>
+        Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken);
     }
 }

--- a/tests/LayoutParserApi.Tests/Controllers/MappingGovernanceControllerTests.cs
+++ b/tests/LayoutParserApi.Tests/Controllers/MappingGovernanceControllerTests.cs
@@ -156,6 +156,43 @@ namespace LayoutParserApi.Tests.Controllers
 
                 return Task.FromResult(ById[releaseId]);
             }
+
+            private static readonly string[] ArchivableFrom =
+            {
+                MappingReleaseStatus.Deprecated, MappingReleaseStatus.TestFailed, MappingReleaseStatus.InReview,
+            };
+
+            public Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+            {
+                var current = ById[releaseId];
+                // Idempotente: já deprecada — no-op.
+                if (current.Status == MappingReleaseStatus.Deprecated)
+                    return Task.FromResult(current);
+
+                if (current.Status != MappingReleaseStatus.Published)
+                    throw new InvalidOperationException($"Release {releaseId} está em \"{current.Status}\"; deprecação manual exige \"{MappingReleaseStatus.Published}\".");
+
+                Transitions.Add((releaseId, MappingReleaseStatus.Published, MappingReleaseStatus.Deprecated, actorUserId, justification ?? "Deprecação manual."));
+                var updated = current with { Status = MappingReleaseStatus.Deprecated };
+                ById[releaseId] = updated;
+                return Task.FromResult(updated);
+            }
+
+            public Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+            {
+                var current = ById[releaseId];
+                // Idempotente: já arquivada — no-op.
+                if (current.Status == MappingReleaseStatus.Archived)
+                    return Task.FromResult(current);
+
+                if (Array.IndexOf(ArchivableFrom, current.Status) < 0)
+                    throw new InvalidOperationException($"Release {releaseId} está em \"{current.Status}\"; arquivamento manual exige um destes: {string.Join(", ", ArchivableFrom)}.");
+
+                Transitions.Add((releaseId, current.Status, MappingReleaseStatus.Archived, actorUserId, justification ?? "Arquivamento manual."));
+                var updated = current with { Status = MappingReleaseStatus.Archived };
+                ById[releaseId] = updated;
+                return Task.FromResult(updated);
+            }
         }
 
         private static MappingReleaseDetail NewRelease(Guid workspaceId, Guid draftId, string status) => new(
@@ -283,6 +320,131 @@ namespace LayoutParserApi.Tests.Controllers
             Assert.Equal(MappingReleaseStatus.Deprecated, store.ById[releaseB.ReleaseId].Status);
             Assert.Equal(MappingReleaseStatus.Published, store.ById[releaseA.ReleaseId].Status);
             Assert.Equal(transitionCountAposPrimeiro, store.Transitions.Count); // no-op: nenhuma transição nova gravada.
+        }
+
+        // --- Deprecação/arquivamento manual (issue #378) ---
+
+        [Fact]
+        public async Task Deprecate_release_published_promove_para_deprecated()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var actor = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.Published);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, actor).Deprecate(workspaceId, release.ReleaseId, new LifecycleTransitionRequest { Justification = "fim de vida" }, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(MappingReleaseStatus.Deprecated, store.ById[release.ReleaseId].Status);
+            Assert.Contains(store.Transitions, t => t.ReleaseId == release.ReleaseId && t.From == MappingReleaseStatus.Published && t.To == MappingReleaseStatus.Deprecated && t.Actor == actor && t.Justification == "fim de vida");
+        }
+
+        [Fact]
+        public async Task Deprecate_release_nao_published_retorna_422()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.TestPassed);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, Guid.NewGuid()).Deprecate(workspaceId, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal(MappingReleaseStatus.TestPassed, store.ById[release.ReleaseId].Status);
+        }
+
+        [Fact]
+        public async Task Deprecate_duas_vezes_e_idempotente_no_op()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var actor = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.Published);
+            store.ById[release.ReleaseId] = release;
+
+            await controllerFor(store, actor).Deprecate(workspaceId, release.ReleaseId, null, CancellationToken.None);
+            var transitionsApos1 = store.Transitions.Count;
+            var segundo = await controllerFor(store, actor).Deprecate(workspaceId, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(segundo);
+            Assert.Equal(MappingReleaseStatus.Deprecated, store.ById[release.ReleaseId].Status);
+            Assert.Equal(transitionsApos1, store.Transitions.Count);
+        }
+
+        [Fact]
+        public async Task Archive_release_deprecated_promove_para_archived()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var actor = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.Deprecated);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, actor).Archive(workspaceId, release.ReleaseId, new LifecycleTransitionRequest { Justification = "encerrada" }, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(MappingReleaseStatus.Archived, store.ById[release.ReleaseId].Status);
+            Assert.Contains(store.Transitions, t => t.ReleaseId == release.ReleaseId && t.From == MappingReleaseStatus.Deprecated && t.To == MappingReleaseStatus.Archived && t.Actor == actor);
+        }
+
+        [Fact]
+        public async Task Archive_release_test_failed_abandonada_promove_para_archived()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.TestFailed);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, Guid.NewGuid()).Archive(workspaceId, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(MappingReleaseStatus.Archived, store.ById[release.ReleaseId].Status);
+        }
+
+        [Fact]
+        public async Task Archive_release_published_retorna_422()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.Published);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, Guid.NewGuid()).Archive(workspaceId, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal(MappingReleaseStatus.Published, store.ById[release.ReleaseId].Status);
+        }
+
+        [Fact]
+        public async Task Archive_duas_vezes_e_idempotente_no_op()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceId = Guid.NewGuid();
+            var actor = Guid.NewGuid();
+            var release = NewRelease(workspaceId, Guid.NewGuid(), MappingReleaseStatus.Deprecated);
+            store.ById[release.ReleaseId] = release;
+
+            await controllerFor(store, actor).Archive(workspaceId, release.ReleaseId, null, CancellationToken.None);
+            var transitionsApos1 = store.Transitions.Count;
+            var segundo = await controllerFor(store, actor).Archive(workspaceId, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(segundo);
+            Assert.Equal(MappingReleaseStatus.Archived, store.ById[release.ReleaseId].Status);
+            Assert.Equal(transitionsApos1, store.Transitions.Count);
+        }
+
+        [Fact]
+        public async Task Deprecate_release_de_outro_workspace_retorna_404()
+        {
+            var store = new FakeReleaseStore();
+            var workspaceDoAtacante = Guid.NewGuid();
+            var release = NewRelease(Guid.NewGuid(), Guid.NewGuid(), MappingReleaseStatus.Published);
+            store.ById[release.ReleaseId] = release;
+
+            var result = await controllerFor(store, Guid.NewGuid()).Deprecate(workspaceDoAtacante, release.ReleaseId, null, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
         }
 
         // --- Isolamento cross-workspace (mesmo padrão dos slices anteriores) ---

--- a/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
+++ b/tests/LayoutParserApi.Tests/Integration/FiatPilotGateTests.cs
@@ -262,6 +262,10 @@ namespace LayoutParserApi.Tests.Integration
 
             public Task<MappingReleaseDetail> RollbackAsync(Guid releaseId, Guid actorUserId, CancellationToken cancellationToken)
                 => throw new NotSupportedException("Não exercitado neste gate — coberto em MappingGovernanceControllerTests.");
+            public Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException("Não exercitado neste gate — coberto em MappingGovernanceControllerTests.");
+            public Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException("Não exercitado neste gate — coberto em MappingGovernanceControllerTests.");
         }
 
         private static IServiceScopeFactory BuildScopeFactory(FakeDraftStore draftStore, FakeReleaseStore releaseStore)

--- a/tests/LayoutParserApi.Tests/Services/Fiscal/MappingCompileServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Fiscal/MappingCompileServiceTests.cs
@@ -85,6 +85,10 @@ namespace LayoutParserApi.Tests.Services.Fiscal
                 => throw new NotSupportedException();
             public Task<MappingReleaseDetail> RollbackAsync(Guid releaseId, Guid actorUserId, CancellationToken cancellationToken)
                 => throw new NotSupportedException();
+            public Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+            public Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
         }
 
         private static MappingDraftRuleDetail AcceptedCopyRule(string source, string target) => new(

--- a/tests/LayoutParserApi.Tests/Services/Fiscal/MappingTestRunServiceTests.cs
+++ b/tests/LayoutParserApi.Tests/Services/Fiscal/MappingTestRunServiceTests.cs
@@ -53,6 +53,10 @@ namespace LayoutParserApi.Tests.Services.Fiscal
                 => throw new NotSupportedException();
             public Task<MappingReleaseDetail> RollbackAsync(Guid releaseId, Guid actorUserId, CancellationToken cancellationToken)
                 => throw new NotSupportedException();
+            public Task<MappingReleaseDetail> DeprecateAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+            public Task<MappingReleaseDetail> ArchiveAsync(Guid releaseId, Guid actorUserId, string? justification, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
         }
 
         private sealed class FakeDraftStore : IMappingDraftStore


### PR DESCRIPTION
Issue #378 (cross-check LayoutParserReact #198.1). Os status `deprecated`/`archived` existiam no enum mas sem endpoint que dispare a transição.

## Endpoints (`MappingGovernanceController`, mesmo padrão de approve/publish/rollback)

- `POST .../mapping-releases/{releaseId}/deprecate`
- `POST .../mapping-releases/{releaseId}/archive`

Body opcional `{ justification? }`. `[RequireWorkspaceRole(FiscalAdmin, Owner)]` (alinhado a publish/rollback). 404 sem membership / cross-workspace; 422 PT-BR em transição inválida.

## Regras de transição

- **deprecate**: `published → deprecated`. Idempotente no-op se já `deprecated`. Outra origem → 422.
- **archive**: origem em `{deprecated, test_failed, in_review}` → `archived` (`deprecated` é o caminho normal; `test_failed`/`in_review` cobrem releases abandonadas). Idempotente no-op se já `archived`. `published` sem deprecar antes → 422.
- Transição efetiva grava `MappingTransition` na mesma transação do `UPDATE` (no-op idempotente não grava).

## Store

`DeprecateAsync`/`ArchiveAsync` em `IMappingReleaseStore`/`SqlMappingReleaseStore`, espelhando `ApproveAsync`/`PublishAsync` — `GetReleaseForUpdateAsync` (UPDLOCK) + validação + `UPDATE` + trilha, tudo em `IdentityDatabase:*` (não toca `172.31.249.51`). Sem mudança de schema.

## Testes

`dotnet build` 0 erros. `dotnet test`: **790 passed, 0 failed** (+ XslSynth.Core 89). 8 testes novos: published→deprecated + trilha, deprecate de não-published → 422, idempotência 2x, deprecated→archived, test_failed→archived, archive de published → 422, cross-workspace → 404.

## Follow-up

Contrato novo → `@lp-doc` (Swagger/README), `@lp-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)