### PR TITLE
docs: ADRs de perfil fiscal (#379) e versionamento de edição manual de artefato (#381)

### DIFF
--- a/docs/architecture/adr-edicao-manual-artefato-versionamento-2026-09-10.md
+++ b/docs/architecture/adr-edicao-manual-artefato-versionamento-2026-09-10.md
@@ -1,0 +1,281 @@
+# ADR — Versionamento da edição manual de artefato TCL/XSLT
+
+- **Data:** 2026-09-10
+- **Autor:** @lp-architect (Aria)
+- **Issue:** #381 sub-fase 5a · cross-check #226 (226.1 / 226.2) · interage com #229 do React
+- **Status:** proposto (aguarda validação do dono)
+- **Contexto compartilhado:** `docs/architecture/cross-check-contratos-226-198-react-2026-09-10.md`,
+  `docs/architecture/contrato-rbac-erro-diff-mapping-fiscal-2026-09-10.md`
+- **Banco:** `IdentityDatabase:*` — **nunca** `172.31.249.51`.
+
+---
+
+## 1. Problema
+
+O front (LayoutParserReact #226) quer um
+`PATCH /api/workspaces/{ws}/mapping-drafts/{draftId}/artifacts/{engine}` para editar o
+texto do TCL/XSLT (`engine: 'tcl'|'xslt'`, `baseArtifactHash`, `justification?`).
+
+Hoje o artefato **nasce da compilação determinística** (`MappingDraftRuleTranspiler`, via
+`POST .../compile`) a partir das **regras estruturadas** (`MappingDraftRule`), e a
+`MappingRelease` resultante é idempotente por `(DraftId, RulesSnapshotHash)`. Depois de
+`publish` o artefato é **imutável** (`MappingRelease.cs:25`). O invariante do sistema é:
+
+> **artefato = f(regras estruturadas aceitas)** — reproduzível, com provenance nó→regra
+> (`MappingTestRunDivergence.RuleId` via `lp:ruleId` embutido pelo transpilador).
+
+Editar o texto do artefato à mão **quebra esse invariante**: o artefato deixa de ser
+função das regras, e o diff por regra do Fiscal Test Lab deixa de fechar.
+
+---
+
+## 2. Decisão
+
+### 2.1 Unidade de versão — **nova `MappingRelease` derivada** (confirma a recomendação do cross-check)
+
+A edição manual **não** é revisão de draft (draft não versiona — sem `RevisionNumber`,
+sem `RowVersion`; ver `MappingDraft.cs`). É uma **nova `MappingRelease`** criada em
+`draft_compiled`, derivada da release-base, com estes campos novos:
+
+| Campo novo em `MappingRelease` | Tipo | Semântica |
+|---|---|---|
+| `DerivedFromReleaseId` | `Guid?` | Release-base sobre cuja cópia de artefato o humano editou. `null` para releases nascidas de compilação. |
+| `ArtifactSource` | `string` | `"compiled"` (default, todas as releases atuais) ou `"manual_edit"`. |
+| `ManualEditReason` | `string?` | `justification` do PATCH — obrigatória para `manual_edit`. |
+| `ManuallyEditedArtifactKinds` | `string[]` | Quais artefatos da lista `Artifacts` foram tocados à mão (`["xslt"]`, `["tcl","xslt"]`...). Os demais permanecem cópia fiel da base. |
+
+**Identidade da release — `RulesSnapshotHash` deixa de ser suficiente sozinho:**
+
+- Para `ArtifactSource == "compiled"`: identidade continua `(DraftId, RulesSnapshotHash)` —
+  idempotência preservada, comportamento atual intacto.
+- Para `ArtifactSource == "manual_edit"`: a release **herda** o `RulesSnapshotHash` da
+  base (as regras não mudaram!), então a identidade passa a ser
+  `(DraftId, RulesSnapshotHash, ArtifactContentHash)`, onde `ArtifactContentHash` é o hash
+  do conjunto de conteúdos de artefato pós-edição. Duas edições manuais que resultem no
+  **mesmo texto** convergem para a mesma release (idempotência mantida num eixo novo);
+  textos diferentes = releases diferentes, todas com o mesmo `RulesSnapshotHash`.
+- `PreviousPublishedReleaseId` continua com o significado atual (linhagem de publicação).
+  `DerivedFromReleaseId` é ortogonal: linhagem de **edição**, não de publicação.
+
+### 2.2 Vínculo artefato ↔ regras após a edição
+
+Depois de `manual_edit`, o artefato editado **não é mais derivável das regras**. O sistema
+marca e trata isso assim:
+
+1. **Marcação explícita:** `ArtifactSource == "manual_edit"` +
+   `ManuallyEditedArtifactKinds`. O GET da release expõe ambos — o front mostra um selo
+   "editado manualmente" e **desabilita o diff-por-regra** para os kinds editados
+   (o `lp:ruleId` pode ter sido removido/alterado pelo humano; a provenance nó→regra
+   deixa de ser confiável).
+2. **Regras ficam "dessincronizadas" e isso é visível:** a release derivada carrega
+   `RulesDesynced = true` (campo derivado, não persistido: `ArtifactSource == "manual_edit"`).
+   O Fiscal Test Lab ainda roda (XSD + diff canônico contra `expectedXml`) — isso continua
+   valendo, porque valida **resultado**, não estrutura interna. O que se perde é só o
+   detalhamento "qual regra causou a divergência".
+3. **Recompilar depois de uma edição manual — política: NÃO sobrescreve, cria ramo novo.**
+   `POST .../compile` sempre produz uma release `compiled` com identidade
+   `(DraftId, RulesSnapshotHash)`. Se essa identidade já existe (caso comum: nada mudou nas
+   regras), a compilação é no-op idempotente e **devolve a release compiled original** —
+   **nunca** toca a release `manual_edit` (identidade diferente por causa do
+   `ArtifactContentHash`). Resultado: as duas coexistem. O front escolhe qual promover na
+   governança. **Não há sobrescrita silenciosa e não há bloqueio** — só bifurcação
+   explícita, coerente com o modelo idempotente atual.
+4. Se o humano editou o TCL e **depois** mexe numa regra estruturada e recompila: sai uma
+   release `compiled` nova (novo `RulesSnapshotHash`), **sem** as edições manuais. A UI
+   deve avisar "esta compilação não inclui suas edições manuais da release X" — a edição
+   manual não se propaga para regras. Reaplicar é ação manual do usuário.
+
+### 2.3 Concorrência otimista — reusa o padrão do `PATCH .../rules/{ruleId}`
+
+Confirmado: dá para reusar o mecanismo já implementado em
+`MappingDraftsController.UpdateRule` (linhas 205-270).
+
+| Item | `PATCH .../rules/{ruleId}` (hoje) | `PATCH .../artifacts/{engine}` (novo) |
+|---|---|---|
+| Precondição | `If-Match` header obrigatório | idem — `If-Match: "<base64>"` |
+| Falta o header | `428` `{ error }` | idem |
+| Header não-base64 | `400` `{ error }` | idem |
+| Valor do ETag | base64 do `ROWVERSION` da regra | base64 do **`MappingReleaseArtifact.Hash`** da base para aquele `engine` (o `baseArtifactHash` que o front propôs) |
+| Divergência | `412` `{ error, current: <regra atual> }` | `412` `{ error, current: <artefato atual da release-base> }` |
+| Sucesso | `200` + corpo com `eTag` novo | `200` + corpo da **release derivada** com `eTag` = hash do artefato novo |
+
+Diferença conceitual importante: no PATCH de regra, o `200` **muta a regra in-place**
+(novo `ROWVERSION`). No PATCH de artefato, o `200` **cria uma release nova** — o recurso
+`{draftId}/artifacts/{engine}` é uma projeção "a edição corrente do artefato do engine no
+contexto do draft", e escrevê-lo materializa uma `MappingRelease` `manual_edit`. O
+`If-Match` casa contra o hash do artefato **da release que o front tinha em mãos**
+(normalmente a última `compiled` ou a última `manual_edit` daquele draft/engine).
+
+### 2.4 RBAC
+
+Hoje edição de regra checa **só membership** (sem `[RequireWorkspaceRole]`). O editor de
+artefato é operação de **maior impacto** (produz release candidata) e precisa de gate de
+papel:
+
+```csharp
+[RequireWorkspaceRole(WorkspaceRole.Mapper, WorkspaceRole.FiscalAdmin, WorkspaceRole.Owner)]
+[HttpPatch("mapping-drafts/{draftId:guid}/artifacts/{engine}")]
+```
+
+- **`mapper`** = autor, pode editar (suposição do front — razoável e coerente com a
+  convenção existente: approve=reviewer/fiscal_admin, publish=fiscal_admin/owner).
+- **`fiscal_admin` / `owner`** = override.
+- `reviewer` / `operator` / `viewer` → `403` (via `RequireWorkspaceRoleFilter`).
+- Sem membership → `404` fail-closed. Sem identidade → `404` (não `401` — identidade vem
+  do BFF; ver `.claude/rules/security.md` e cross-check 226.4).
+- **Recomendação adicional (fora do escopo de 5b, mas registrar):** aplicar o mesmo
+  `[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]` no `PATCH .../rules/{ruleId}` e no
+  `POST .../compile`, hoje só protegidos por membership. Decisão de produto — sinalizada
+  em §5.
+
+### 2.5 Interação com #229 do React e com a governança existente
+
+- **#229 ("edição manual = revisão candidata, não sobrescreve release publicada"):**
+  totalmente compatível. A release derivada **nasce em `draft_compiled`**, nunca em
+  `published`/`approved`. Não toca a release publicada corrente. Para entrar em produção
+  ela percorre o **mesmo fluxo de governança**: `compile`(implícito no PATCH) →
+  Fiscal Test Lab (`test-runs`) → `approve` → `publish`. `publish` da derivada deprecia a
+  publicada anterior via `PreviousPublishedReleaseId` (mecânica atual, inalterada).
+- **Re-aprovação:** sim, obrigatória. A derivada é uma release nova ⇒ precisa de
+  `test_passed` + `approve` (reviewer/fiscal_admin) + `publish` (fiscal_admin/owner).
+  Não há atalho "herda a aprovação da base" — o conteúdo do artefato mudou, a aprovação
+  anterior não cobre.
+- **Trilha:** cada transição da derivada gera `MappingTransition` normalmente. A criação
+  da derivada em si (`manual_edit`) registra uma transição sintética
+  `null → draft_compiled` com `Justification = ManualEditReason` e `ChecksSnapshot`
+  contendo `{ derivedFromReleaseId, manuallyEditedArtifactKinds, baseArtifactHash }`.
+
+### 2.6 Validação de sintaxe (sub-fase 5c) — só referência
+
+O PATCH deve rejeitar TCL/XSLT sintaticamente inválido com **`422`** (convenção do
+projeto: `400` só para JSON/base64 malformado; `422` para "entendi o corpo mas o conteúdo
+não é aceitável"). O **como** (parser XSLT via `XslCompiledTransform.Load` em sandbox;
+lint de TCL) é a sub-fase **5c**, dona `@lp-parser-llm`, e é **gate de 5b** (o endpoint
+não faz merge sem ela). Não desenhado aqui.
+
+---
+
+## 3. Ciclo de vida (diagrama)
+
+```
+                    POST .../compile
+  regras aceitas ─────────────────────────►  Release A  (ArtifactSource=compiled,
+  (RulesSnapshotHash = H1)                    id=RA, status=draft_compiled,
+                                              identidade=(Draft, H1))
+                                                   │
+                          front carrega artefato XSLT de RA
+                          (baseArtifactHash = RA.Artifacts["xslt"].Hash)
+                                                   │
+     PATCH .../mapping-drafts/{draftId}/artifacts/xslt
+       If-Match: "<base64 do baseArtifactHash>"
+       body: { content: "<xslt editado>", justification: "ajuste manual do template X" }
+                                                   │
+              ┌────────────────────────────────────┼───────────────────────────┐
+              │ If-Match diverge do hash atual     │  If-Match confere          │
+              ▼                                    ▼                            │
+        412 { error, current: <artefato          cria  Release B               │
+              atual da release-base> }           ArtifactSource = manual_edit  │
+                                                 DerivedFromReleaseId = RA     │
+                                                 RulesSnapshotHash   = H1  (herdado) │
+                                                 ManuallyEditedArtifactKinds = ["xslt"] │
+                                                 identidade = (Draft, H1, ArtifactContentHash) │
+                                                 status = draft_compiled       │
+                                                 + MappingTransition (null→draft_compiled) │
+                                                   │                            │
+                          POST .../test-runs  (Fiscal Test Lab: XSD + diff canônico) │
+                                                   │  (diff-por-regra desabilitado p/ xslt) │
+                                          test_passed / test_failed             │
+                                                   │                            │
+                                    approve  (reviewer | fiscal_admin)          │
+                                                   │                            │
+                                    publish  (fiscal_admin | owner)             │
+                                                   │                            │
+                            Release B = published  ──►  Release A vira deprecated
+                                                        (PreviousPublishedReleaseId = RA)
+
+  recompilar (POST .../compile) enquanto B existe e as regras não mudaram:
+    → identidade (Draft, H1) já existe → devolve Release A (no-op idempotente).
+      Release B (manual_edit) permanece intacta e coexiste.
+```
+
+---
+
+## 4. Contrato do `PATCH .../mapping-drafts/{draftId}/artifacts/{engine}`
+
+```
+PATCH /api/workspaces/{workspaceId}/mapping-drafts/{draftId}/artifacts/{engine}
+Headers: If-Match: "<base64 do baseArtifactHash>"      (obrigatório)
+Path:    engine ∈ { "tcl", "xslt" }   ("sysmiddle" → 422, via MappingEngineGuardFilter)
+Body:    { "content": "<texto completo do artefato>",
+           "justification": "motivo da edição manual" }   // obrigatória
+```
+
+| Código | Quando | Corpo |
+|---|---|---|
+| `200` | edição aplicada — release derivada criada (ou idempotência: mesmo texto → devolve a derivada existente) | release derivada completa + `eTag` = hash do artefato novo |
+| `400` | `If-Match` não é base64 · JSON malformado | `{ error }` PT-BR |
+| `403` | papel insuficiente (`reviewer`/`operator`/`viewer`) | `{ error }` |
+| `404` | sem identidade · sem membership · draft de outro workspace · draft/engine inexistente | — |
+| `412` | `If-Match` diverge do hash atual do artefato da release-base | `{ error, current: <artefato atual> }` |
+| `422` | `engine` inválido/`sysmiddle` · `content` vazio · `justification` ausente · **sintaxe TCL/XSLT inválida (5c)** | `{ error }` PT-BR |
+| `428` | falta `If-Match` | `{ error }` |
+| `503` | falha ao persistir | `{ error }` |
+
+**Sem `401` por design** (identidade vem do BFF — cross-check 226.4).
+
+Corpo do `200` (esboço):
+
+```jsonc
+{
+  "releaseId": "<RB>",
+  "draftId": "<draft>",
+  "engine": "xslt",
+  "status": "draft_compiled",
+  "artifactSource": "manual_edit",
+  "derivedFromReleaseId": "<RA>",
+  "rulesSnapshotHash": "<H1>",              // herdado da base
+  "manuallyEditedArtifactKinds": ["xslt"],
+  "manualEditReason": "ajuste manual do template X",
+  "rulesDesynced": true,
+  "artifacts": [
+    { "kind": "xslt", "content": "<...>", "hash": "<novo>", "generatedAt": "..." },
+    { "kind": "tcl",  "content": "<cópia fiel da base>", "hash": "<igual RA>", "generatedAt": "..." }
+  ],
+  "eTag": "<novo hash do xslt>"
+}
+```
+
+---
+
+## 5. O que fica para as sub-issues
+
+- **5b — endpoint + store + concorrência** (@lp-backend-dev):
+  - Campos novos em `MappingRelease` (`DerivedFromReleaseId`, `ArtifactSource`,
+    `ManualEditReason`, `ManuallyEditedArtifactKinds`) + colunas via `EnsureSchemaAsync`
+    idempotente no `IdentityDatabase` (`ADD COLUMN`, nada de `CREATE TABLE`, nada em
+    `172.31.249.51`).
+  - `IMappingReleaseStore.CreateManualEditReleaseAsync(draftId, engine, content, baseArtifactHash, reason, actor)` — valida `If-Match` contra o hash do artefato da
+    release-base, calcula `ArtifactContentHash`, aplica idempotência no eixo novo, grava
+    release + `MappingTransition` sintética.
+  - Controller: reusa o esqueleto de `UpdateRule` (428/400/412/200) + `[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]`.
+  - Guarda `MappingEngineGuardFilter` para barrar `sysmiddle`.
+- **5c — validação de sintaxe** (@lp-parser-llm): gate de 5b; `422` em TCL/XSLT inválido.
+- **Governança (já existe):** nenhum código novo — a release derivada usa
+  `approve`/`publish`/`rollback`/`deprecate`/`archive` como estão.
+- **Decisão de produto pendente (§5 perguntas):** aplicar `[RequireWorkspaceRole]` também
+  em `PATCH .../rules/{ruleId}` e `POST .../compile`.
+
+---
+
+## 6. Perguntas em aberto para o dono
+
+1. **Recompilar após edição manual:** o ADR opta por **coexistência** (compiled e
+   manual_edit lado a lado, sem sobrescrita nem bloqueio). Confirma? Alternativa seria
+   bloquear `compile` enquanto houver `manual_edit` não publicada no draft.
+2. **`mapper` pode editar artefato?** O front supõe que sim. Confirma, ou edição de
+   artefato (mais sensível que edição de regra) deve exigir `fiscal_admin`+?
+3. **Reforçar RBAC de regra/compile** (`[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]`
+   onde hoje só há membership) — fazer junto com #381 ou issue separada?
+4. **Editar os dois engines (`tcl` e `xslt`) numa release derivada:** dois PATCHes
+   sequenciais (cada um deriva do anterior) ou um PATCH com array de artefatos? O ADR
+   assume **um engine por PATCH**, encadeando.

--- a/docs/architecture/adr-perfil-fiscal-draft-release-2026-09-10.md
+++ b/docs/architecture/adr-perfil-fiscal-draft-release-2026-09-10.md
@@ -1,0 +1,298 @@
+# ADR — Perfil fiscal (`FiscalProfile`) em draft/release
+
+- **Data:** 2026-09-10
+- **Autor:** @lp-architect (Aria)
+- **Issue:** #379 · cross-check #198.3 · pré-requisito de #380/#198.5
+- **Status:** proposto (aguarda validação do dono)
+- **Contexto compartilhado:** `docs/architecture/cross-check-contratos-226-198-react-2026-09-10.md`
+- **Banco:** `IdentityDatabase:*` — **nunca** `172.31.249.51` (regra de segurança).
+
+---
+
+## 1. Problema
+
+O front (LayoutParserReact #198.3) precisa exibir e filtrar mappings fiscais por
+**`documentType`**, **`schemaVersion`**, **`operation`** e **`jurisdiction`**. Hoje nada
+disso existe na fundação fiscal:
+
+- `FiscalProject` só tem `Name` + `WorkspaceId` + `CreatedAt`.
+- `MappingDraft` / `MappingRelease` não têm nenhum dos 4 campos.
+- `MappingDraftRule.Operation` existe mas é a operação de *transformação da regra*
+  (`concat`, `lookup`), não `operation` fiscal (entrada/saída/devolução/etc.).
+- `documentType`/`schemaVersion` só aparecem no pipeline de parse/transformação **legado**
+  (`Models/TransformationRequest.cs`, `Models/XmlAnalysis/XsdValidationResult.cs`),
+  desacoplado da fundação fiscal.
+- `jurisdiction` não existe em lugar nenhum do repo.
+
+É **pré-requisito de #380/#198.5** ("cobertura de destinos obrigatórios do XSD"): para
+enumerar os elementos obrigatórios do schema de saída é preciso resolver **qual XSD é o
+alvo**, e isso vem do perfil (`documentType` + `schemaVersion` → entrada em
+`XsdValidation:DocumentTypes`).
+
+---
+
+## 2. Decisão
+
+### 2.1 Onde o `FiscalProfile` vive — **na `MappingRelease` (imutável), com origem no `MappingDraft`**
+
+Modelo em duas camadas:
+
+| Camada | Papel | Mutabilidade |
+|---|---|---|
+| `MappingDraft.FiscalProfile` | Perfil **de trabalho** — o alvo que o autor está mapeando. Editável enquanto o draft não compilou nada. | Mutável (com regra — ver §2.3) |
+| `MappingRelease.FiscalProfile` | **Snapshot congelado** copiado do draft no momento da compilação (`CreateOrGetCompiledReleaseAsync`), junto com `RulesSnapshotHash` e `SourceRuleIds`. | Imutável |
+
+**Por que não (a) no `FiscalProject`:** `FiscalProject` é deliberadamente mínimo ("CRUD
+completo fica fora de escopo", design-slice2). Um projeto fiscal real agrega **vários**
+alvos (NFe 4.00 saída, NFe devolução, CTe...) — amarrar um perfil único ao projeto força
+1 projeto por `documentType`+`operation`, o que não corresponde ao uso. Além disso o
+perfil no projeto não daria imutabilidade por release "de graça".
+
+**Por que não só (b) no `MappingDraft`:** o draft não versiona (`MappingDraft.cs` não tem
+`RevisionNumber` nem `RowVersion`; o que versiona são as regras e as releases). Se o
+perfil vivesse *só* no draft, uma release publicada meses atrás perderia a rastreabilidade
+de contra qual schema foi validada quando alguém editasse o draft. A #380 (cobertura de
+obrigatórios) precisa cruzar **regras aceitas × XSD do perfil** — esse cruzamento tem que
+ser reproduzível a partir da release, não do estado atual do draft.
+
+**Por que (c) na `MappingRelease` como snapshot:** casa exatamente com o modelo já
+existente — a release **já é** a unidade de versão idempotente por
+`(DraftId, RulesSnapshotHash)`, já carrega `SourceRuleIds` e `CompileDiagnostics` como
+snapshot. O perfil é mais um campo do mesmo snapshot. A #380 lê `release.FiscalProfile`,
+resolve o XSD, enumera obrigatórios, cruza com `release.SourceRuleIds` → 100% reproduzível
+e estável.
+
+O draft mantém uma cópia **de trabalho** (`MappingDraft.FiscalProfile`) só para: (1) a UI
+ter o que mostrar antes da primeira compilação; (2) a compilação ter de onde copiar.
+
+### 2.2 Imutabilidade
+
+- **`MappingRelease.FiscalProfile` é imutável desde a criação da release** (não só
+  pós-`publish`). Segue o mesmo princípio de `RulesSnapshotHash`/`SourceRuleIds`: uma
+  release é um snapshot fechado. Mudou o perfil ⇒ recompila ⇒ nova release.
+- **`MappingDraft.FiscalProfile` é mutável só enquanto não há release derivada do draft.**
+  Depois que existe ao menos uma `MappingRelease` para aquele `DraftId`, mudar o perfil do
+  draft é permitido mas **não retroage** às releases existentes (elas guardam o snapshot
+  delas). É a mesma semântica de editar uma regra depois de já ter compilado: gera
+  divergência que só aparece na *próxima* release.
+- Consequência para a #380: a métrica de cobertura é sempre calculada contra
+  `release.FiscalProfile`, nunca contra `draft.FiscalProfile`.
+
+### 2.3 Modelo de dados
+
+`FiscalProfile` é um **value object** (sem identidade própria; serializado inline).
+Persistência: uma coluna `FiscalProfileJson NVARCHAR(MAX) NULL` em `MappingDraft` e em
+`MappingRelease` (mesmo padrão de `ArtifactsJson`/`SourceRuleIdsJson` já usados nos stores
+fiscais). Nada de tabela nova — o VO não é consultado relacionalmente; os filtros do
+catálogo (#198.4) que precisarem de `documentType`/`operation` podem promover esses dois
+campos a colunas indexadas numa iteração futura se a listagem exigir (fora do escopo
+deste ADR — hoje a listagem só pagina).
+
+```csharp
+namespace LayoutParserApi.Models.Entities.Fiscal
+{
+    /// <summary>
+    /// Perfil fiscal do alvo de mapeamento (issue #379 / cross-check #198.3). Value object —
+    /// vive inline no MappingDraft (cópia de trabalho, mutável) e na MappingRelease
+    /// (snapshot congelado na compilação, imutável). documentType+schemaVersion resolvem o
+    /// XSD alvo via XsdValidation:DocumentTypes (pré-requisito da #380 / #198.5).
+    /// </summary>
+    public sealed record FiscalProfile(
+        string DocumentType,      // enum fechado — chave em XsdValidation:DocumentTypes
+        string SchemaVersion,     // string livre — deve casar com XsdVersion da entrada acima
+        string Operation,         // enum fechado — FiscalOperation.*
+        string Jurisdiction);     // enum semiaberto — FiscalJurisdiction.* (UF ou "BR")
+
+    /// <summary>documentType — fechado, espelha as chaves de XsdValidation:DocumentTypes.</summary>
+    public static class FiscalDocumentType
+    {
+        public const string Nfe = "NFe";
+        public const string Cte = "CTe";
+        public const string NfCom = "NFCom";
+        public const string Mdfe = "MDFe";
+        public static readonly IReadOnlyCollection<string> All = new[] { Nfe, Cte, NfCom, Mdfe };
+        public static bool IsValid(string? v) => v != null && All.Contains(v);
+    }
+
+    /// <summary>operation fiscal — fechado. NÃO confundir com MappingDraftRule.Operation.</summary>
+    public static class FiscalOperation
+    {
+        public const string Outbound = "outbound";        // emissão / saída
+        public const string Inbound = "inbound";          // recebimento / entrada
+        public const string Return = "return";            // devolução
+        public const string Cancellation = "cancellation";
+        public const string Complementary = "complementary";
+        public static readonly IReadOnlyCollection<string> All =
+            new[] { Outbound, Inbound, Return, Cancellation, Complementary };
+        public static bool IsValid(string? v) => v != null && All.Contains(v);
+    }
+
+    /// <summary>
+    /// jurisdiction — semiaberto: as 27 UFs + "BR" (federal / nacional). Validação por
+    /// lista fechada de UF, mas o conjunto é notório e estável (não é string livre).
+    /// </summary>
+    public static class FiscalJurisdiction
+    {
+        public const string Federal = "BR";
+        public static readonly IReadOnlyCollection<string> Ufs = new[]
+        { "AC","AL","AP","AM","BA","CE","DF","ES","GO","MA","MT","MS","MG","PA","PB",
+          "PR","PE","PI","RJ","RN","RS","RO","RR","SC","SP","SE","TO" };
+        public static bool IsValid(string? v) => v == Federal || (v != null && Ufs.Contains(v));
+    }
+}
+```
+
+**Enums fechados vs. string livre — decisão:**
+
+| Campo | Tipo | Racional |
+|---|---|---|
+| `documentType` | **enum fechado** | Tem que casar 1:1 com uma chave de `XsdValidation:DocumentTypes`. Valor fora da lista = não há XSD = a #380 não roda. Rejeitar na entrada (422). |
+| `schemaVersion` | **string livre**, mas **validada por cruzamento** | O valor deve ser igual ao `XsdVersion` da entrada de `documentType` correspondente (ou uma futura lista de versões suportadas por tipo). É livre no *tipo* mas fechado na *validação* — a camada de serviço rejeita (422) se `schemaVersion` não corresponde a um XSD instalado em `XsdValidation:BasePath`. Mantém-se string para acomodar novas NTs sem redeploy de enum. |
+| `operation` | **enum fechado** | Conjunto pequeno, estável, semântica fiscal bem definida. |
+| `jurisdiction` | **enum semiaberto** (27 UF + `BR`) | Conjunto notório e finito; validar por lista evita lixo, mas não é "enum de código" — é tabela de referência conhecida. |
+
+### 2.4 Cruzamento com `XsdValidation:DocumentTypes`
+
+Hoje `appsettings.json` → `XsdValidation:DocumentTypes` tem 4 entradas (`NFe`, `CTE`,
+`NFCom`, `MDFe`), cada uma com `XsdVersion` + `Namespace` + `RootElement`. Nota: a chave é
+`CTE` no appsettings mas o `RootElement` é `CTe` — **este ADR adota `CTe`** como valor
+canônico de `documentType` e recomenda a sub-issue de implementação **normalizar a chave
+do appsettings para `CTe`** (ou mapear no resolver), para o perfil e a config baterem
+exatamente.
+
+Regra de validação (camada de serviço, ao gravar o perfil):
+
+1. `FiscalDocumentType.IsValid(documentType)` → senão 422.
+2. Existe `XsdValidation:DocumentTypes[documentType]` → senão 422
+   ("tipo de documento sem XSD configurado no ambiente").
+3. `schemaVersion` == `DocumentTypes[documentType].XsdVersion`
+   **ou** o arquivo XSD correspondente existe sob `XsdValidation:BasePath` → senão 422
+   ("versão de schema não instalada neste ambiente"). *(A forma exata de resolver o
+   caminho do XSD por versão fica para a sub-issue da #380 — aqui basta o contrato: o
+   perfil só é aceito se o XSD alvo for resolvível.)*
+4. `FiscalOperation.IsValid` / `FiscalJurisdiction.IsValid` → senão 422.
+
+### 2.5 Migração — DDL lazy idempotente no `IdentityDatabase`
+
+Segue o padrão dos outros stores fiscais (`SqlMappingReleaseStore`,
+`SqlMappingDraftStore`): bloco `EnsureSchemaAsync` idempotente, disparado no primeiro uso
+do store, **só** contra a connection string `IdentityDatabase:*`.
+
+```sql
+-- Executado por SqlMappingDraftStore.EnsureSchemaAsync (idempotente)
+IF COL_LENGTH('dbo.MappingDrafts', 'FiscalProfileJson') IS NULL
+    ALTER TABLE dbo.MappingDrafts ADD FiscalProfileJson NVARCHAR(MAX) NULL;
+
+-- Executado por SqlMappingReleaseStore.EnsureSchemaAsync (idempotente)
+IF COL_LENGTH('dbo.MappingReleases', 'FiscalProfileJson') IS NULL
+    ALTER TABLE dbo.MappingReleases ADD FiscalProfileJson NVARCHAR(MAX) NULL;
+```
+
+- **NULL permitido** — drafts/releases legados não têm perfil. A API trata
+  `FiscalProfile == null` como "perfil não definido": o GET devolve `fiscalProfile: null`
+  e a #380 devolve cobertura `null`/"perfil ausente" em vez de calcular.
+- **Nenhum `CREATE TABLE`** — só `ADD COLUMN`. **Nada** toca `172.31.249.51` /
+  `Database:*` (regra `.claude/rules/security.md`).
+- Sem índice agora. Se #198.4 (filtros de listagem) precisar filtrar por
+  `documentType`/`operation`, promover esses dois a colunas computadas persistidas +
+  índice numa sub-issue própria.
+
+### 2.6 Contrato de API
+
+**Entrada — endpoint dedicado, `PUT` idempotente:**
+
+```
+PUT /api/workspaces/{workspaceId}/mapping-drafts/{draftId}/fiscal-profile
+Body: { "documentType": "NFe", "schemaVersion": "PL_010b_NT2025_002_v1.30",
+        "operation": "outbound", "jurisdiction": "SP" }
+```
+
+| Código | Quando |
+|---|---|
+| `200` + perfil salvo | ok (cria ou substitui — idempotente) |
+| `422` | qualquer regra de §2.4 violada (mensagem PT-BR específica) |
+| `409` | draft já tem release derivada **e** a política escolhida for "travar" (ver nota) |
+| `404` | sem identidade / sem membership / draft de outro workspace / draft inexistente |
+
+> **Nota sobre `409`:** §2.2 permite editar o perfil do draft mesmo com release existente
+> (não retroage). Portanto o comportamento default é **200** (grava, não retroage). O
+> `409` fica reservado caso o dono prefira travar — decisão de produto, sinalizada em §5.
+
+- **Não** embutir o perfil no `POST .../drafts` nem no `POST .../compile`: mantém o
+  endpoint de criação enxuto e permite a UI coletar o perfil num passo separado do wizard.
+  A compilação apenas **lê** `draft.FiscalProfile` e o copia para a release; se estiver
+  `null` no momento do `compile`, a compilação **prossegue** mas a release nasce sem
+  perfil e a #380 fica indisponível para ela (warning no `CompileDiagnostics`, não erro).
+- RBAC: `[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]` — mesmo conjunto proposto
+  para o editor de artefato (#381), coerente com "quem mapeia define o alvo".
+
+**Saída — em todo GET de draft e de release:**
+
+```jsonc
+// GET .../mapping-drafts/{draftId}
+{ "draftId": "...", "engine": "xslt", /* ... */,
+  "fiscalProfile": {
+    "documentType": "NFe", "schemaVersion": "PL_010b_NT2025_002_v1.30",
+    "operation": "outbound", "jurisdiction": "SP",
+    "resolvedXsd": { "xsdVersion": "PL_010b_NT2025_002_v1.30",
+                     "namespace": "http://www.portalfiscal.inf.br/nfe",
+                     "rootElement": "NFe" }   // eco de XsdValidation:DocumentTypes, read-only
+  } }
+
+// GET .../mapping-drafts/{draftId}/releases/{releaseId}  → mesmo shape,
+// mas fiscalProfile é o snapshot congelado da release (pode divergir do draft atual)
+```
+
+- `resolvedXsd` é derivado (não persistido no draft) — conveniência para o front não ter
+  que reimplementar o lookup. Na release, `resolvedXsd` é recalculado a partir do snapshot
+  (estável, porque `documentType`+`schemaVersion` estão congelados).
+- `fiscalProfile: null` quando não definido.
+
+---
+
+## 3. Trade-offs
+
+| Eixo | Escolha | Custo aceito |
+|---|---|---|
+| Granularidade | Perfil no draft (trabalho) + snapshot na release | 2 lugares para serializar; risco de o front confundir "perfil do draft" com "perfil da release" — mitigado deixando explícito no shape do GET |
+| Imutabilidade | Congela na criação da release, não no publish | Uma release em `draft_compiled` não pode ter o perfil "corrigido" sem recompilar — consistente com o resto do snapshot, mas menos flexível |
+| Persistência | Coluna JSON, sem tabela, sem índice | Filtro por `documentType` na listagem exige trabalho extra depois (#198.4) |
+| `schemaVersion` string livre | Acomoda novas NTs sem redeploy | Validação vira responsabilidade de runtime (arquivo XSD existe?) em vez de compilação |
+| Federal vs UF | `jurisdiction` aceita UF **e** `BR` | Front precisa saber que "BR" é federal; documentar |
+
+**Performance:** desprezível — 1 coluna `NVARCHAR(MAX)` lida junto com a linha que já é
+carregada; `resolvedXsd` é lookup em dicionário de config em memória. Nenhuma query nova.
+
+**Segurança:** nenhuma exposição de segredo. DDL só no `IdentityDatabase`. Perfil não
+contém dado de cliente (é metadado de schema). RBAC reusa filtro existente.
+
+---
+
+## 4. O que fica para as sub-issues de implementação
+
+1. **#379a — modelo + persistência** (@lp-backend-dev): `FiscalProfile` VO + enums;
+   coluna `FiscalProfileJson` em `MappingDrafts` e `MappingReleases` via `EnsureSchemaAsync`
+   idempotente; serialização nos stores; normalizar chave `CTE`→`CTe` no resolver de
+   `XsdValidation:DocumentTypes`.
+2. **#379b — endpoint `PUT .../fiscal-profile`** (@lp-backend-dev): validação §2.4 com
+   mensagens PT-BR; `[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]`; decisão
+   200-vs-409 conforme §5.
+3. **#379c — snapshot na compilação** (@lp-backend-dev): `CreateOrGetCompiledReleaseAsync`
+   copia `draft.FiscalProfile` para a release; warning em `CompileDiagnostics` se `null`.
+4. **#379d — saída nos GETs** (@lp-backend-dev + @lp-doc): campo `fiscalProfile` +
+   `resolvedXsd` derivado no GET de draft e de release; atualizar Swagger/contrato React.
+5. **#380 (já existente)** consome `release.FiscalProfile.resolvedXsd` como fonte do XSD
+   alvo — **desbloqueada** por este ADR.
+6. **(futuro, se #198.4 exigir)** promover `documentType`/`operation` a colunas indexadas.
+
+---
+
+## 5. Perguntas em aberto para o dono
+
+1. **Editar perfil do draft depois de já existir release derivada:** grava sem retroagir
+   (200, default deste ADR) ou trava (409, exige novo draft)?
+2. **`schemaVersion`:** validar só "arquivo XSD existe no ambiente" ou manter uma allowlist
+   explícita de versões suportadas por `documentType` no `appsettings.json`?
+3. **`jurisdiction` é obrigatório?** Para NFe/CTe a UF importa (regras estaduais); para
+   um mapeamento puramente estrutural talvez `BR` baste. Campo obrigatório com default
+   `BR`, ou nullable?


### PR DESCRIPTION
Dois ADRs derivados do cross-check #226/#198 (PR #375). Só documentação.

## ADR 1 — Perfil fiscal (`adr-perfil-fiscal-draft-release-2026-09-10.md`, issue #379 / React #198.3)

**Decisão:** `FiscalProfile` como value object em 2 camadas — `MappingDraft.FiscalProfile` (cópia de trabalho mutável) e `MappingRelease.FiscalProfile` (snapshot congelado na compilação, imutável desde a criação). Rejeitados perfil no `FiscalProject` e perfil só no draft.

- `record FiscalProfile(DocumentType, SchemaVersion, Operation, Jurisdiction)`
- `documentType` enum fechado espelhando `XsdValidation:DocumentTypes` (NFe/CTe/NFCom/MDFe); `schemaVersion` string validada por cruzamento com XSD instalado; `operation` enum fechado; `jurisdiction` 27 UFs + `BR`.
- Migração: `ADD COLUMN FiscalProfileJson NVARCHAR(MAX) NULL` em `MappingDrafts`/`MappingReleases` via `EnsureSchemaAsync` idempotente, só `IdentityDatabase`.
- Contrato: `PUT .../mapping-drafts/{draftId}/fiscal-profile` (RBAC Mapper/FiscalAdmin/Owner); saída `fiscalProfile` + `resolvedXsd` em todo GET de draft/release.
- **Desbloqueia #380.** Sub-issues 379a–379d.

## ADR 2 — Edição manual de artefato (`adr-edicao-manual-artefato-versionamento-2026-09-10.md`, issue #381 sub-fase 5a / React #226)

**Decisão:** edição manual = **nova `MappingRelease` derivada** em `draft_compiled` (não revisão de draft). Novos campos: `DerivedFromReleaseId`, `ArtifactSource` (`compiled`|`manual_edit`), `ManualEditReason`, `ManuallyEditedArtifactKinds`.

- Identidade da release `manual_edit`: `(DraftId, RulesSnapshotHash herdado, ArtifactContentHash)`.
- Recompilar após edição manual **não sobrescreve nem bloqueia** — bifurca; a `compiled` e a `manual_edit` coexistem.
- Concorrência otimista reusa o padrão do `PATCH .../rules/{ruleId}` (428/400/412/200+eTag), mas o `200` **cria release nova** em vez de mutar in-place.
- RBAC `[RequireWorkspaceRole(Mapper, FiscalAdmin, Owner)]`; sem identidade → 404 (não 401).
- Compatível com React #229 e a governança atual: derivada percorre `test-runs → approve → publish`, **re-aprovação obrigatória**, `publish` deprecia a anterior.
- Diagrama completo do ciclo no ADR. Sub-issues 5b (endpoint+store+colunas) e 5c (validação de sintaxe, `@lp-parser-llm`).

## Pendências para o dono (nos dois ADRs)

Perfil fiscal: editar draft com release existente (grava sem retroagir vs. 409); `schemaVersion` allowlist vs. "arquivo existe"; `jurisdiction` default `BR` vs. nullable.
Edição manual: recompilar coexiste (default) vs. bloqueia; `mapper` edita ou exige `fiscal_admin`+; reforçar RBAC de regra/compile junto ou à parte; um engine por PATCH vs. array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)